### PR TITLE
Fix Levenshtein fallback minimum calculation

### DIFF
--- a/lib/pythia/kernels_fallback.ex
+++ b/lib/pythia/kernels_fallback.ex
@@ -14,7 +14,7 @@ defmodule Pythia.KernelsFallback do
         insert = hd(acc) + 1
         delete = Enum.at(prev_row, j) + 1
         replace = Enum.at(prev_row, j - 1) + cost
-        [min(insert, delete, replace) | acc]
+        [Enum.min([insert, delete, replace]) | acc]
       end)
       |> Enum.reverse()
     end)


### PR DESCRIPTION
## Summary
- fix the pure Elixir Levenshtein fallback to compute the minimum edit cost safely with Enum.min

## Testing
- mix test *(fails: Hex installation blocked in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16b960010832da8eaf1132156bda6