### PR TITLE
Add fallback Mix compiler for Rustler

### DIFF
--- a/lib/pythia/kernels_fallback.ex
+++ b/lib/pythia/kernels_fallback.ex
@@ -14,7 +14,7 @@ defmodule Pythia.KernelsFallback do
         insert = hd(acc) + 1
         delete = Enum.at(prev_row, j) + 1
         replace = Enum.at(prev_row, j - 1) + cost
-        [min(insert, delete, replace) | acc]
+        [Enum.min([insert, delete, replace]) | acc]
       end)
       |> Enum.reverse()
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Pythia.MixProject do
       version: "0.1.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
-      compilers: [:rustler] ++ Mix.compilers(),
+      compilers: compilers(),
       deps: deps()
     ]
   end
@@ -21,5 +21,9 @@ defmodule Pythia.MixProject do
       {:rustler, "~> 0.33"},
       {:jason, "~> 1.4"}
     ]
+  end
+
+  defp compilers do
+    [:rustler_fallback | Mix.compilers()]
   end
 end

--- a/mix/tasks/compile.rustler_fallback.ex
+++ b/mix/tasks/compile.rustler_fallback.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.Compile.RustlerFallback do
+  @moduledoc "Compiler that delegates to Rustler when available and becomes a no-op otherwise."
+  use Mix.Task.Compiler
+
+  @impl Mix.Task.Compiler
+  def run(args) do
+    try do
+      Mix.Task.run("compile.rustler", args)
+    rescue
+      Mix.NoTaskError ->
+        Mix.shell().info("Rustler compiler not available, skipping.")
+        {:noop, []}
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a Mix compiler task that delegates to `compile.rustler` when available and becomes a no-op otherwise
- update the project compiler list to use the fallback task instead of hard-requiring the Rustler compiler

## Testing
- mix test *(fails: Hex installation is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16b960010832da8eaf1132156bda6