### PR TITLE
Agent Safety Showcase: deterministic propose→evaluate decision loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ return best
 
 PythiaLabs includes a deterministic showcase for controlled agent actions.
 
+The demo shows two core outcomes:
+- a safe action proceeds when the required permission is present
+- an unsafe action is rejected when authorization is missing
+
+It also includes an invalid action example to show strict shape validation.
+The goal is to demonstrate a core PythiaLabs principle: agent actions should produce observable traces and stable stop reasons, not just outputs.
+
 Run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ return best
 - Datomic (step log) + Neo4j (hypothesis graph)
 - Critic triggers (confidence‑based, rate‑limited) + cache
 - Multi‑domain executors (QA, graphs, puzzles)
+
+## Agent Safety Showcase
+
+PythiaLabs includes a deterministic showcase for controlled agent actions.
+
+Run:
+
+```bash
+mix run examples/agent_safety_showcase.exs
+```
+

--- a/docs/agent_safety_showcase.md
+++ b/docs/agent_safety_showcase.md
@@ -1,0 +1,57 @@
+# Agent Safety Showcase
+
+## Problem
+
+AI agents can produce actions that look valid at the surface level but are unsafe because the causal/authorization boundary is missing.
+
+Example:
+An agent proposes `delete_user_data`.
+The JSON shape may be valid.
+The action may be executable.
+But the required authorization is missing.
+
+Ordinary logs may show that an action happened.
+Pythia should show why the action was allowed, stopped, or rejected.
+
+## What the showcase demonstrates
+
+- deterministic action evaluation
+- explicit constraints
+- observable trace
+- stable stop_reason
+- safe action proceeds
+- unsafe action is rejected
+
+## How to run
+
+```bash
+mix run examples/agent_safety_showcase.exs
+```
+
+## Expected result
+
+Safe action:
+- accepted
+- constraints_satisfied
+
+Unsafe action:
+- rejected
+- missing_authorization
+
+Invalid action:
+- rejected
+- invalid_action
+
+## Relation to Liminal Stack
+
+PythiaLabs:
+- controlled reasoning/refinement loop
+
+CML:
+- causal validity / why a transition is allowed
+
+LTP:
+- trace transport / replayable transition history
+
+This showcase is not a full CML/LTP integration yet.
+It is the first deterministic bridge toward that architecture.

--- a/examples/agent_safety_showcase.exs
+++ b/examples/agent_safety_showcase.exs
@@ -20,6 +20,16 @@ unsafe_action = %{
   metadata: %{source: "showcase"}
 }
 
+invalid_action = %{
+  action_id: "act_003",
+  action_type: "",
+  actor: "agent_alpha",
+  target: "report_q1",
+  required_permission: "report.read",
+  granted_permissions: ["report.read"],
+  metadata: %{source: "showcase"}
+}
+
 print_result = fn title, result ->
   IO.puts("\nScenario: #{title}")
 
@@ -50,3 +60,7 @@ safe_action
 unsafe_action
 |> AgentSafetyDemo.run()
 |> print_result.("unsafe action")
+
+invalid_action
+|> AgentSafetyDemo.run()
+|> print_result.("invalid action")

--- a/examples/agent_safety_showcase.exs
+++ b/examples/agent_safety_showcase.exs
@@ -1,0 +1,52 @@
+alias Pythia.Showcase.AgentSafetyDemo
+
+safe_action = %{
+  action_id: "act_001",
+  action_type: "read_public_report",
+  actor: "agent_alpha",
+  target: "report_q1",
+  required_permission: "report.read",
+  granted_permissions: ["report.read"],
+  metadata: %{source: "showcase"}
+}
+
+unsafe_action = %{
+  action_id: "act_002",
+  action_type: "delete_user_data",
+  actor: "agent_alpha",
+  target: "user_123",
+  required_permission: "user_data.delete",
+  granted_permissions: [],
+  metadata: %{source: "showcase"}
+}
+
+print_result = fn title, result ->
+  IO.puts("\nScenario: #{title}")
+
+  case result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Final action: #{payload.action.action_type}")
+      IO.puts("Confidence: #{payload.confidence}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+      IO.puts("Trace:")
+      Enum.each(payload.trace, &IO.puts("- #{inspect(&1)}"))
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Rejected action: #{payload.rejected_action.action_type}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+      IO.puts("Trace:")
+      Enum.each(payload.trace, &IO.puts("- #{inspect(&1)}"))
+  end
+end
+
+IO.puts("Agent Safety Showcase")
+
+safe_action
+|> AgentSafetyDemo.run()
+|> print_result.("safe action")
+
+unsafe_action
+|> AgentSafetyDemo.run()
+|> print_result.("unsafe action")

--- a/lib/pythia/showcase/agent_action.ex
+++ b/lib/pythia/showcase/agent_action.ex
@@ -18,23 +18,32 @@ defmodule Pythia.Showcase.AgentAction do
   @spec build(map()) :: t()
   def build(attrs) when is_map(attrs) do
     %{
-      action_id: Map.get(attrs, :action_id, "act_default"),
-      action_type: Map.get(attrs, :action_type, ""),
-      actor: Map.get(attrs, :actor, ""),
-      target: Map.get(attrs, :target, ""),
-      required_permission: Map.get(attrs, :required_permission, ""),
-      granted_permissions: Map.get(attrs, :granted_permissions, []),
-      metadata: Map.get(attrs, :metadata, %{})
+      action_id: fetch(attrs, :action_id, "act_default"),
+      action_type: fetch(attrs, :action_type, ""),
+      actor: fetch(attrs, :actor, ""),
+      target: fetch(attrs, :target, ""),
+      required_permission: fetch(attrs, :required_permission, ""),
+      granted_permissions: fetch(attrs, :granted_permissions, []),
+      metadata: fetch(attrs, :metadata, %{})
     }
   end
 
   @spec validate(t()) :: :ok | {:error, atom()}
   def validate(action) when is_map(action) do
-    if Enum.all?(@required_fields, &present?(Map.get(action, &1))) do
+    permissions = Map.get(action, :granted_permissions)
+
+    valid_permissions =
+      is_list(permissions) and Enum.all?(permissions, fn permission -> is_binary(permission) end)
+
+    if Enum.all?(@required_fields, &present?(Map.get(action, &1))) and valid_permissions do
       :ok
     else
       {:error, :invalid_action}
     end
+  end
+
+  defp fetch(attrs, key, default) do
+    Map.get(attrs, key, Map.get(attrs, Atom.to_string(key), default))
   end
 
   defp present?(value) when is_binary(value), do: String.trim(value) != ""

--- a/lib/pythia/showcase/agent_action.ex
+++ b/lib/pythia/showcase/agent_action.ex
@@ -1,0 +1,42 @@
+defmodule Pythia.Showcase.AgentAction do
+  @moduledoc """
+  Data model and validation helpers for deterministic agent action evaluation.
+  """
+
+  @type t :: %{
+          action_id: String.t(),
+          action_type: String.t(),
+          actor: String.t(),
+          target: String.t(),
+          required_permission: String.t(),
+          granted_permissions: [String.t()],
+          metadata: map()
+        }
+
+  @required_fields [:action_type, :actor, :target, :required_permission]
+
+  @spec build(map()) :: t()
+  def build(attrs) when is_map(attrs) do
+    %{
+      action_id: Map.get(attrs, :action_id, "act_default"),
+      action_type: Map.get(attrs, :action_type, ""),
+      actor: Map.get(attrs, :actor, ""),
+      target: Map.get(attrs, :target, ""),
+      required_permission: Map.get(attrs, :required_permission, ""),
+      granted_permissions: Map.get(attrs, :granted_permissions, []),
+      metadata: Map.get(attrs, :metadata, %{})
+    }
+  end
+
+  @spec validate(t()) :: :ok | {:error, atom()}
+  def validate(action) when is_map(action) do
+    if Enum.all?(@required_fields, &present?(Map.get(action, &1))) do
+      :ok
+    else
+      {:error, :invalid_action}
+    end
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_), do: false
+end

--- a/lib/pythia/showcase/agent_safety_demo.ex
+++ b/lib/pythia/showcase/agent_safety_demo.ex
@@ -1,0 +1,31 @@
+defmodule Pythia.Showcase.AgentSafetyDemo do
+  @moduledoc """
+  Demonstrates the controlled loop: propose -> evaluate constraints -> stop with reason.
+  """
+
+  alias Pythia.Showcase.{AgentAction, SafetyGate}
+
+  @spec run(map()) :: {:ok, map()} | {:error, map()}
+  def run(action_attrs) when is_map(action_attrs) do
+    action = AgentAction.build(action_attrs)
+    result = SafetyGate.evaluate(action)
+
+    emit_telemetry(result)
+
+    result
+  end
+
+  defp emit_telemetry({status_tag, %{stop_reason: stop_reason} = result}) do
+    status =
+      case status_tag do
+        :ok -> :accepted
+        :error -> :rejected
+      end
+
+    :telemetry.execute(
+      [:pythia, :showcase, :decision],
+      %{count: 1},
+      %{status: status, stop_reason: stop_reason, trace_length: length(result.trace)}
+    )
+  end
+end

--- a/lib/pythia/showcase/safety_gate.ex
+++ b/lib/pythia/showcase/safety_gate.ex
@@ -1,0 +1,67 @@
+defmodule Pythia.Showcase.SafetyGate do
+  @moduledoc """
+  Deterministic constraint gate for agent actions.
+  """
+
+  alias Pythia.Showcase.AgentAction
+
+  @spec evaluate(AgentAction.t()) :: {:ok, map()} | {:error, map()}
+  def evaluate(action) do
+    with :ok <- AgentAction.validate(action),
+         :ok <- check_permission(action.required_permission, action.granted_permissions) do
+      trace = [
+        %{event: :proposed_action, action_type: action.action_type},
+        %{event: :constraint_check, constraint: :permission_present, result: :pass},
+        %{event: :decision, result: :proceed}
+      ]
+
+      {:ok,
+       %{
+         status: :accepted,
+         action: action,
+         confidence: 1.0,
+         stop_reason: :constraints_satisfied,
+         trace: trace
+       }}
+    else
+      {:error, :invalid_action} ->
+        {:error,
+         %{
+           status: :rejected,
+           rejected_action: action,
+           stop_reason: :invalid_action,
+           trace: invalid_trace(action)
+         }}
+
+      {:error, :missing_authorization} ->
+        {:error,
+         %{
+           status: :rejected,
+           rejected_action: action,
+           stop_reason: :missing_authorization,
+           trace: [
+             %{event: :proposed_action, action_type: action.action_type},
+             %{event: :constraint_check, constraint: :permission_present, result: :fail},
+             %{event: :decision, result: :reject}
+           ]
+         }}
+    end
+  end
+
+  defp check_permission(required, granted_permissions)
+       when is_binary(required) and is_list(granted_permissions) do
+    if Enum.member?(granted_permissions, required) do
+      :ok
+    else
+      {:error, :missing_authorization}
+    end
+  end
+
+  defp invalid_trace(action) do
+    [
+      %{event: :proposed_action, action_type: Map.get(action, :action_type, nil)},
+      %{event: :constraint_check, constraint: :action_shape, result: :fail},
+      %{event: :decision, result: :reject}
+    ]
+  end
+end

--- a/lib/pythia/showcase/safety_gate.ex
+++ b/lib/pythia/showcase/safety_gate.ex
@@ -57,6 +57,8 @@ defmodule Pythia.Showcase.SafetyGate do
     end
   end
 
+  defp check_permission(_required, _granted_permissions), do: {:error, :invalid_action}
+
   defp invalid_trace(action) do
     [
       %{event: :proposed_action, action_type: Map.get(action, :action_type, nil)},

--- a/test/agent_safety_showcase_test.exs
+++ b/test/agent_safety_showcase_test.exs
@@ -1,0 +1,102 @@
+defmodule Pythia.AgentSafetyShowcaseTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.AgentSafetyDemo
+
+  test "safe action proceeds" do
+    action = %{
+      action_id: "act_safe",
+      action_type: "read_public_report",
+      actor: "agent_alpha",
+      target: "report_q1",
+      required_permission: "report.read",
+      granted_permissions: ["report.read"]
+    }
+
+    assert {:ok, %{status: :accepted, stop_reason: :constraints_satisfied, trace: trace}} =
+             AgentSafetyDemo.run(action)
+
+    assert Enum.any?(trace, fn entry -> entry.event == :decision and entry.result == :proceed end)
+  end
+
+  test "unsafe action is rejected when permission is missing" do
+    action = %{
+      action_id: "act_unsafe",
+      action_type: "delete_user_data",
+      actor: "agent_alpha",
+      target: "user_123",
+      required_permission: "user_data.delete",
+      granted_permissions: []
+    }
+
+    assert {:error, %{status: :rejected, stop_reason: :missing_authorization, trace: trace}} =
+             AgentSafetyDemo.run(action)
+
+    assert Enum.any?(trace, fn entry ->
+             entry.event == :constraint_check and entry.constraint == :permission_present and
+               entry.result == :fail
+           end)
+  end
+
+  test "invalid action shape is rejected" do
+    invalid_actions = [
+      %{
+        action_id: "act_invalid_1",
+        action_type: "read_public_report",
+        actor: "",
+        target: "report_q1",
+        required_permission: "report.read",
+        granted_permissions: ["report.read"]
+      },
+      %{
+        action_id: "act_invalid_2",
+        action_type: "",
+        actor: "agent_alpha",
+        target: "report_q1",
+        required_permission: "report.read",
+        granted_permissions: ["report.read"]
+      },
+      %{
+        action_id: "act_invalid_3",
+        action_type: "read_public_report",
+        actor: "agent_alpha",
+        target: "",
+        required_permission: "report.read",
+        granted_permissions: ["report.read"]
+      },
+      %{
+        action_id: "act_invalid_4",
+        action_type: "read_public_report",
+        actor: "agent_alpha",
+        target: "report_q1",
+        required_permission: "",
+        granted_permissions: ["report.read"]
+      }
+    ]
+
+    Enum.each(invalid_actions, fn action ->
+      assert {:error, %{status: :rejected, stop_reason: :invalid_action}} =
+               AgentSafetyDemo.run(action)
+    end)
+  end
+
+  test "output is deterministic for same input" do
+    action = %{
+      action_id: "act_deterministic",
+      action_type: "transfer_funds",
+      actor: "agent_alpha",
+      target: "acct_42",
+      required_permission: "funds.transfer",
+      granted_permissions: []
+    }
+
+    first = AgentSafetyDemo.run(action)
+    second = AgentSafetyDemo.run(action)
+
+    assert first == second
+
+    assert {:error, %{stop_reason: stop_reason_1}} = first
+    assert {:error, %{stop_reason: stop_reason_2}} = second
+    assert stop_reason_1 == stop_reason_2
+  end
+end

--- a/test/agent_safety_showcase_test.exs
+++ b/test/agent_safety_showcase_test.exs
@@ -38,6 +38,21 @@ defmodule Pythia.AgentSafetyShowcaseTest do
            end)
   end
 
+  test "string-key input is accepted" do
+    action = %{
+      "action_id" => "act_string_keys",
+      "action_type" => "read_public_report",
+      "actor" => "agent_alpha",
+      "target" => "report_q1",
+      "required_permission" => "report.read",
+      "granted_permissions" => ["report.read"],
+      "metadata" => %{"source" => "json"}
+    }
+
+    assert {:ok, %{status: :accepted, stop_reason: :constraints_satisfied}} =
+             AgentSafetyDemo.run(action)
+  end
+
   test "invalid action shape is rejected" do
     invalid_actions = [
       %{
@@ -80,7 +95,41 @@ defmodule Pythia.AgentSafetyShowcaseTest do
     end)
   end
 
-  test "output is deterministic for same input" do
+  test "malformed granted_permissions is rejected as invalid_action" do
+    invalid_actions = [
+      %{
+        action_id: "act_bad_permissions_1",
+        action_type: "read_public_report",
+        actor: "agent_alpha",
+        target: "report_q1",
+        required_permission: "report.read",
+        granted_permissions: nil
+      },
+      %{
+        action_id: "act_bad_permissions_2",
+        action_type: "read_public_report",
+        actor: "agent_alpha",
+        target: "report_q1",
+        required_permission: "report.read",
+        granted_permissions: "report.read"
+      },
+      %{
+        action_id: "act_bad_permissions_3",
+        action_type: "read_public_report",
+        actor: "agent_alpha",
+        target: "report_q1",
+        required_permission: "report.read",
+        granted_permissions: ["report.read", 7]
+      }
+    ]
+
+    Enum.each(invalid_actions, fn action ->
+      assert {:error, %{status: :rejected, stop_reason: :invalid_action}} =
+               AgentSafetyDemo.run(action)
+    end)
+  end
+
+  test "output is deterministic for same unsafe input" do
     action = %{
       action_id: "act_deterministic",
       action_type: "transfer_funds",
@@ -98,5 +147,23 @@ defmodule Pythia.AgentSafetyShowcaseTest do
     assert {:error, %{stop_reason: stop_reason_1}} = first
     assert {:error, %{stop_reason: stop_reason_2}} = second
     assert stop_reason_1 == stop_reason_2
+  end
+
+  test "invalid action scenario is deterministic" do
+    action = %{
+      action_id: "act_invalid_deterministic",
+      action_type: "",
+      actor: "agent_alpha",
+      target: "report_q1",
+      required_permission: "report.read",
+      granted_permissions: ["report.read"]
+    }
+
+    first = AgentSafetyDemo.run(action)
+    second = AgentSafetyDemo.run(action)
+
+    assert first == second
+    assert {:error, %{status: :rejected, stop_reason: :invalid_action}} = first
+    assert {:error, %{status: :rejected, stop_reason: :invalid_action}} = second
   end
 end


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic showcase that demonstrates Pythia's controlled decision loop: propose → evaluate constraints → stop with a clear `stop_reason` and observable `trace`.
- Make the safety boundary explicit so safe actions can proceed while unsafe actions are deterministically rejected without any external LLM or network calls.
- Keep the change focused and reviewable by adding a lightweight, self-contained example, simple modules, tests, and docs that connect to Pythia's refinement philosophy.

### Description
- Add `Pythia.Showcase.AgentAction` (`lib/pythia/showcase/agent_action.ex`) which normalizes action input and validates required fields (`action_type`, `actor`, `target`, `required_permission`).
- Add `Pythia.Showcase.SafetyGate` (`lib/pythia/showcase/safety_gate.ex`) which deterministically evaluates constraints (permission presence and basic shape checks) and returns structured outcomes containing `status`, `stop_reason`, `trace`, and optional `confidence`.
- Add `Pythia.Showcase.AgentSafetyDemo` (`lib/pythia/showcase/agent_safety_demo.ex`) as the demonstration entrypoint that builds the action, calls the `SafetyGate`, and emits a telemetry event `[:pythia, :showcase, :decision]` with the result.
- Add a runnable example `examples/agent_safety_showcase.exs` that demonstrates two scenarios: a safe action (`read_public_report`) accepted and an unsafe action (`delete_user_data`) rejected, and prints `status`, `stop_reason`, `trace`, and `confidence`/action details.
- Add tests `test/agent_safety_showcase_test.exs` that verify: safe action accepted, missing authorization rejected, invalid action shape rejected, and deterministic outcomes for repeated identical inputs.
- Add documentation `docs/agent_safety_showcase.md` and a short `README.md` section with the run command `mix run examples/agent_safety_showcase.exs` and expected outcomes.

### Testing
- Added unit tests in `test/agent_safety_showcase_test.exs` that cover the four required cases (`safe action`, `missing authorization`, `invalid action shape`, and `deterministic output`) but automated execution could not complete in this environment due to dependency bootstrap failure. 
- An attempt to run `mix test test/agent_safety_showcase_test.exs` and `mix run examples/agent_safety_showcase.exs` was blocked because `mix` could not fetch Hex metadata (HTTP 403 while contacting `builds.hex.pm`), so tests were not executed here. 
- The code was lint/formatted locally (`mix format` attempted) and the test suite is included so CI in a normal environment with network access and Hex available should run the new tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdab15524832dbd7506fa34cf4f02)