### PR TITLE
Clarify MVP status and persistent reasoning memory roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ It is part of the architectural roadmap.
 
 Future versions may add persistent reasoning memory with two complementary layers:
 
-1. **Datomic-style append-only step log**
+1. **Datomic-style append-only step log**  
    Stores every reasoning step as an immutable event for replay, audit, debugging, and version comparison.
 
-2. **Neo4j-style hypothesis graph**
+2. **Neo4j-style hypothesis graph**  
    Connects actions, constraints, proposals, failures, stop reasons, and successful paths.
 
 This would allow PythiaLabs to support replay, audit, recurring failure analysis, and cross-run reasoning patterns.

--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ PythiaLabs is currently an MVP focused on:
 - Rust NIF / Rust Port worker integration
 - deterministic Agent Safety Showcase
 
-The Datomic + Neo4j layer is not implemented yet.
+The Datomic/Neo4j-style persistent memory layer is not implemented yet.
 It is part of the architectural roadmap.
 
 ## Roadmap: persistent reasoning memory
 
 Future versions may add persistent reasoning memory with two complementary layers:
 
-1. Append-only step log
-   Stores every reasoning step as an immutable event.
+1. **Datomic-style append-only step log**
+   Stores every reasoning step as an immutable event for replay, audit, debugging, and version comparison.
 
-2. Hypothesis graph
+2. **Neo4j-style hypothesis graph**
    Connects actions, constraints, proposals, failures, stop reasons, and successful paths.
 
 This would allow PythiaLabs to support replay, audit, recurring failure analysis, and cross-run reasoning patterns.
@@ -84,8 +84,7 @@ This layer is not implemented in the current MVP.
 
 For details, see `docs/persistent_reasoning_memory.md`.
 
-- Datomic-style append-only step log for immutable reasoning history
-- Neo4j-style hypothesis graph for relationships between actions, constraints, failures, and decisions
+Additional roadmap items:
 - critic triggers based on confidence, repeated failure classes, and trace patterns
 - multi-domain executors for QA, graph problems, puzzles, and agent actions
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,40 @@ repeat up to max_steps:
 return best
 ```
 
-## Next steps (beyond MVP)
-- Datomic (step log) + Neo4j (hypothesis graph)
-- Critic triggers (confidence‑based, rate‑limited) + cache
-- Multi‑domain executors (QA, graphs, puzzles)
+## Current MVP status
+
+PythiaLabs is currently an MVP focused on:
+
+- deterministic refinement loops
+- observable traces
+- stable stop reasons
+- Elixir/BEAM orchestration
+- Rust NIF / Rust Port worker integration
+- deterministic Agent Safety Showcase
+
+The Datomic + Neo4j layer is not implemented yet.
+It is part of the architectural roadmap.
+
+## Roadmap: persistent reasoning memory
+
+Future versions may add persistent reasoning memory with two complementary layers:
+
+1. Append-only step log
+   Stores every reasoning step as an immutable event.
+
+2. Hypothesis graph
+   Connects actions, constraints, proposals, failures, stop reasons, and successful paths.
+
+This would allow PythiaLabs to support replay, audit, recurring failure analysis, and cross-run reasoning patterns.
+
+This layer is not implemented in the current MVP.
+
+For details, see `docs/persistent_reasoning_memory.md`.
+
+- Datomic-style append-only step log for immutable reasoning history
+- Neo4j-style hypothesis graph for relationships between actions, constraints, failures, and decisions
+- critic triggers based on confidence, repeated failure classes, and trace patterns
+- multi-domain executors for QA, graph problems, puzzles, and agent actions
 
 ## Agent Safety Showcase
 
@@ -75,4 +105,3 @@ Run:
 ```bash
 mix run examples/agent_safety_showcase.exs
 ```
-

--- a/docs/persistent_reasoning_memory.md
+++ b/docs/persistent_reasoning_memory.md
@@ -4,6 +4,7 @@
 
 PythiaLabs currently returns traces directly from each run.
 The current MVP does not persist traces into Datomic, Neo4j, or any external database.
+The current MVP does not require persistent storage to run demos, tests, or the Agent Safety Showcase.
 
 ## Why persistence matters
 

--- a/docs/persistent_reasoning_memory.md
+++ b/docs/persistent_reasoning_memory.md
@@ -1,0 +1,98 @@
+# Persistent Reasoning Memory Roadmap
+
+## Current status
+
+PythiaLabs currently returns traces directly from each run.
+The current MVP does not persist traces into Datomic, Neo4j, or any external database.
+
+## Why persistence matters
+
+A single trace explains one run.
+Persistent reasoning memory would allow PythiaLabs to analyze many runs over time.
+
+This would help answer:
+
+- What happened?
+- In what order?
+- Which proposal was executed?
+- Which constraint failed?
+- Why did the loop stop?
+- Which `stop_reason` appears repeatedly?
+- Which actions or failure classes are connected?
+
+## Append-only step log
+
+A Datomic-style step log would store every reasoning step as an immutable event.
+
+It would capture:
+
+- run_id
+- step_id
+- timestamp
+- proposal
+- candidate
+- score or confidence
+- stop_reason
+- trace entry
+- version of rules or constraints
+
+This is useful for:
+
+- audit
+- replay
+- debugging
+- comparing behavior across versions
+- preserving decision history
+
+## Hypothesis graph
+
+A Neo4j-style hypothesis graph would connect entities such as:
+
+- actions
+- agents
+- constraints
+- proposals
+- failures
+- stop reasons
+- successful paths
+- rejected paths
+
+This is useful for:
+
+- discovering recurring failure patterns
+- understanding relationships between actions and constraints
+- finding which proposals often lead to rejection
+- supporting future critic logic
+- cross-run reasoning analysis
+
+## Future architecture
+
+Conceptual flow:
+
+```text
+Agent / Problem
+↓
+Planner loop
+↓
+Executor / SafetyGate
+↓
+Trace + stop_reason
+↓
+Append-only Step Log
+↓
+Hypothesis Graph
+↓
+Critic / Pattern Analysis / Replay
+```
+
+## Non-goals for current MVP
+
+The current MVP does not include:
+
+- Datomic adapter
+- Neo4j adapter
+- persistent database schema
+- docker-compose database setup
+- production storage layer
+
+This document is a roadmap, not an implementation claim.


### PR DESCRIPTION
### Motivation

- Make README and project docs explicitly distinguish implemented MVP capabilities from future architectural ideas so readers are not misled about persistence features. 
- Document a clear, high-level roadmap for persistent reasoning memory (Datomic-style append-only step log + Neo4j-style hypothesis graph) as a non-implemented architectural horizon. 

### Description

- Add a `Current MVP status` section to `README.md` that lists implemented items such as deterministic refinement loops, observable traces, stable stop reasons, Elixir/BEAM orchestration, Rust NIF/Port integration, and the Agent Safety Showcase. 
- Replace the prior “Next steps (beyond MVP)” heading with `Roadmap: persistent reasoning memory`, clarifying roadmap language and linking to the new document. 
- Add `docs/persistent_reasoning_memory.md` containing current status, rationale for persistence, append-only step log and hypothesis graph concepts, a simple conceptual flow, and explicit non-goals for the current MVP. 
- Keep this PR documentation-only with only small README wording/format adjustments and a link to the new doc. 

### Testing

- Ran `mix format`, which failed in this environment because the project lacks a usable `.formatter.exs` `:inputs`/patterns for plain `mix format`. 
- Attempted `mix local.hex --force`, which failed due to network/SSL restrictions in the environment (HTTP 403 to `builds.hex.pm`). 
- Attempted `mix compile` and `mix test`, which were blocked because dependencies could not be fetched (Hex/SCM issues, e.g., `:rustler` SCM not found). 
- Note: this is a docs-only change and no new tests were required or added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecad62500c832d8dde63b4b3e3b602)