### PR TITLE
Document Temporal-Causal Memory Stack roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ return best
 - Critic triggers (confidence‑based, rate‑limited) + cache
 - Multi‑domain executors (QA, graphs, puzzles)
 
+## Roadmap: persistent reasoning memory
+
+See docs/persistent_reasoning_memory.md.
+For the broader five-layer roadmap, see docs/temporal_causal_memory_stack.md.
+
+## Additional roadmap items
+
+- temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
+
 ## Agent Safety Showcase
 
 PythiaLabs includes a deterministic showcase for controlled agent actions.

--- a/README.md
+++ b/README.md
@@ -54,19 +54,31 @@ repeat up to max_steps:
 return best
 ```
 
-## Next steps (beyond MVP)
-- Datomic (step log) + Neo4j (hypothesis graph)
-- Critic triggers (confidence‑based, rate‑limited) + cache
-- Multi‑domain executors (QA, graphs, puzzles)
+## Current MVP status
+
+PythiaLabs is currently an MVP focused on:
+
+- deterministic refinement loops
+- observable traces
+- stable stop reasons
+- Elixir/BEAM orchestration
+- Rust NIF / Rust Port worker integration
+- deterministic Agent Safety Showcase
+
+The Datomic/Neo4j/XTDB/EventStoreDB/TimescaleDB-style memory layers are not implemented yet.
+They are part of the architectural roadmap.
 
 ## Roadmap: persistent reasoning memory
 
-See docs/persistent_reasoning_memory.md.
-For the broader five-layer roadmap, see docs/temporal_causal_memory_stack.md.
+See `docs/persistent_reasoning_memory.md`.
 
-## Additional roadmap items
+For the broader five-layer roadmap, see `docs/temporal_causal_memory_stack.md`.
+
+Additional roadmap items:
 
 - temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
+- critic triggers based on confidence, repeated failure classes, and trace patterns
+- multi-domain executors for QA, graph problems, puzzles, and agent actions
 
 ## Agent Safety Showcase
 

--- a/docs/persistent_reasoning_memory.md
+++ b/docs/persistent_reasoning_memory.md
@@ -1,0 +1,38 @@
+# Persistent Reasoning Memory Roadmap
+
+## Current status
+
+PythiaLabs currently returns trace data per run.
+The current MVP does not require external storage services to run demos, tests, or the Agent Safety Showcase.
+
+This document describes a roadmap for future versions. It is not an implementation claim.
+
+## Roadmap intent
+
+Future versions may add persistent reasoning memory to compare behavior across many runs and versions.
+
+A minimal first step is:
+
+- append-only step log for planner and executor traces
+- hypothesis graph for linking related steps, constraints, and outcomes
+
+## Why this roadmap exists
+
+Single-run traces are useful for local debugging and explainability.
+Persistent memory may later improve:
+
+- replay and auditability across runs
+- long-horizon failure analysis
+- critic inputs for recurring error patterns
+- evaluation across model or policy versions
+
+## Scope notes
+
+This roadmap is documentation-only for the current MVP.
+No storage adapter, schema, or runtime persistence behavior is implemented here.
+
+## Related roadmap
+
+For a broader future architecture that includes fact memory, graph memory, bitemporal temporal memory, event streams, and metrics timelines, see:
+
+docs/temporal_causal_memory_stack.md

--- a/docs/persistent_reasoning_memory.md
+++ b/docs/persistent_reasoning_memory.md
@@ -35,4 +35,4 @@ No storage adapter, schema, or runtime persistence behavior is implemented here.
 
 For a broader future architecture that includes fact memory, graph memory, bitemporal temporal memory, event streams, and metrics timelines, see:
 
-docs/temporal_causal_memory_stack.md
+`docs/temporal_causal_memory_stack.md`

--- a/docs/temporal_causal_memory_stack.md
+++ b/docs/temporal_causal_memory_stack.md
@@ -1,0 +1,212 @@
+# Temporal-Causal Memory Stack Roadmap
+
+## Current status
+
+PythiaLabs currently returns traces directly from each run.
+The current MVP does not persist traces into external databases.
+The current MVP does not require Datomic, Neo4j, XTDB, EventStoreDB, TimescaleDB, or any other storage service to run demos, tests, or the Agent Safety Showcase.
+
+This document is a roadmap, not an implementation claim.
+
+## Why another memory roadmap?
+
+A single trace explains one run.
+Persistent reasoning memory explains many runs over time.
+
+The Temporal-Causal Memory Stack separates five questions:
+
+- What was asserted?
+- How is it connected?
+- When was it valid?
+- What happened in sequence?
+- How did operational signals change over time?
+
+Together, these questions help explain not only one agent decision, but patterns across many decisions.
+
+## Layer 1: Fact memory — Datomic-style fact log
+
+Purpose:
+Stores immutable facts and assertions.
+
+Main question:
+What did the system assert or record?
+
+Examples:
+- agent_alpha proposed delete_user_data
+- required_permission was user_data.delete
+- stop_reason was missing_authorization
+- confidence was 1.0
+- trace entry was recorded
+
+Useful for:
+- audit
+- immutable reasoning history
+- replay
+- comparing behavior across versions
+- preserving decision records
+
+Status:
+Roadmap only. Not implemented in the current MVP.
+
+## Layer 2: Graph memory — Neo4j-style relationship graph
+
+Purpose:
+Stores relationships between entities.
+
+Main question:
+How are actions, agents, constraints, failures, and decisions connected?
+
+Examples:
+- agent_alpha -> proposed -> delete_user_data
+- delete_user_data -> requires -> user_data.delete
+- missing_authorization -> caused -> reject
+- action_type -> associated_with -> failure_class
+
+Useful for:
+- causal topology
+- relationship analysis
+- recurring failure discovery
+- critic support
+- explainability across related runs
+
+Status:
+Roadmap only. Not implemented in the current MVP.
+
+## Layer 3: Temporal memory — XTDB-style bitemporal timeline
+
+Purpose:
+Stores when facts are valid and when the system learned them.
+
+Main question:
+When was a fact true, and when did the system know it?
+
+Use two time axes:
+- valid_time: when a fact is true in the domain
+- transaction_time: when the system recorded or learned the fact
+
+Examples:
+- permission user_data.delete was valid from 10:00 to 10:30
+- the system learned about that permission at 11:00
+- a future grant becomes valid tomorrow at 09:00
+- an action was rejected because permission was not valid at the action time
+
+Useful for:
+- past / present / future reasoning
+- retroactive correction
+- proactive future validity
+- temporal audit
+- authorization windows
+- time-aware safety decisions
+
+Status:
+Roadmap only. Not implemented in the current MVP.
+
+## Layer 4: Event memory — EventStoreDB-style event stream
+
+Purpose:
+Stores event sequences in order.
+
+Main question:
+What happened, in what order?
+
+Examples:
+- run_started
+- proposal_created
+- candidate_executed
+- constraint_checked
+- decision_rejected
+- run_stopped
+
+Useful for:
+- event sourcing
+- replay
+- debugging
+- state reconstruction
+- deterministic sequence analysis
+
+Status:
+Roadmap only. Not implemented in the current MVP.
+
+## Layer 5: Metrics memory — TimescaleDB-style metrics timeline
+
+Purpose:
+Stores time-series operational signals.
+
+Main question:
+How did scores, confidence, latency, retries, failures, and drift change over time?
+
+Examples:
+- score per step
+- confidence per run
+- latency per executor
+- retry count per action type
+- failure rate per constraint
+- drift across versions
+
+Useful for:
+- observability
+- SLOs
+- regression detection
+- trend analysis
+- operational dashboards
+- critic trigger thresholds
+
+Status:
+Roadmap only. Not implemented in the current MVP.
+
+## Summary table
+
+| Layer | Style | Stores | Answers |
+|---|---|---|---|
+| Fact memory | Datomic-style | immutable facts/assertions | What was recorded? |
+| Graph memory | Neo4j-style | relationships | How is it connected? |
+| Temporal memory | XTDB-style | valid_time + transaction_time | When was it true / known? |
+| Event memory | EventStoreDB-style | ordered events | What happened next? |
+| Metrics memory | TimescaleDB-style | time-series signals | How did behavior change? |
+
+## Conceptual flow
+
+```text
+Agent / Problem
+↓
+Planner loop
+↓
+Executor / SafetyGate
+↓
+Trace + stop_reason
+↓
+Fact memory
+↓
+Graph memory
+↓
+Temporal memory
+↓
+Event memory
+↓
+Metrics memory
+↓
+Critic / Pattern Analysis / Replay / Dashboards
+```
+
+## Relation to existing docs
+
+docs/persistent_reasoning_memory.md describes the first roadmap step: append-only step log + hypothesis graph.
+
+This document expands that roadmap into a broader five-layer memory architecture.
+
+Both documents are roadmap docs, not implementation claims.
+
+## Non-goals for current MVP
+
+The current MVP does not include:
+
+- Datomic adapter
+- Neo4j adapter
+- XTDB adapter
+- EventStoreDB adapter
+- TimescaleDB adapter
+- persistent schema
+- docker-compose storage services
+- production storage layer
+
+Do not imply otherwise.

--- a/docs/temporal_causal_memory_stack.md
+++ b/docs/temporal_causal_memory_stack.md
@@ -25,72 +25,72 @@ Together, these questions help explain not only one agent decision, but patterns
 
 ## Layer 1: Fact memory — Datomic-style fact log
 
-Purpose:
+**Purpose:**
 Stores immutable facts and assertions.
 
-Main question:
+**Main question:**
 What did the system assert or record?
 
-Examples:
+**Examples:**
 - agent_alpha proposed delete_user_data
 - required_permission was user_data.delete
 - stop_reason was missing_authorization
 - confidence was 1.0
 - trace entry was recorded
 
-Useful for:
+**Useful for:**
 - audit
 - immutable reasoning history
 - replay
 - comparing behavior across versions
 - preserving decision records
 
-Status:
+**Status:**
 Roadmap only. Not implemented in the current MVP.
 
 ## Layer 2: Graph memory — Neo4j-style relationship graph
 
-Purpose:
+**Purpose:**
 Stores relationships between entities.
 
-Main question:
+**Main question:**
 How are actions, agents, constraints, failures, and decisions connected?
 
-Examples:
+**Examples:**
 - agent_alpha -> proposed -> delete_user_data
 - delete_user_data -> requires -> user_data.delete
 - missing_authorization -> caused -> reject
 - action_type -> associated_with -> failure_class
 
-Useful for:
+**Useful for:**
 - causal topology
 - relationship analysis
 - recurring failure discovery
 - critic support
 - explainability across related runs
 
-Status:
+**Status:**
 Roadmap only. Not implemented in the current MVP.
 
 ## Layer 3: Temporal memory — XTDB-style bitemporal timeline
 
-Purpose:
+**Purpose:**
 Stores when facts are valid and when the system learned them.
 
-Main question:
+**Main question:**
 When was a fact true, and when did the system know it?
 
-Use two time axes:
+**Use two time axes:**
 - valid_time: when a fact is true in the domain
 - transaction_time: when the system recorded or learned the fact
 
-Examples:
+**Examples:**
 - permission user_data.delete was valid from 10:00 to 10:30
 - the system learned about that permission at 11:00
 - a future grant becomes valid tomorrow at 09:00
 - an action was rejected because permission was not valid at the action time
 
-Useful for:
+**Useful for:**
 - past / present / future reasoning
 - retroactive correction
 - proactive future validity
@@ -98,18 +98,18 @@ Useful for:
 - authorization windows
 - time-aware safety decisions
 
-Status:
+**Status:**
 Roadmap only. Not implemented in the current MVP.
 
 ## Layer 4: Event memory — EventStoreDB-style event stream
 
-Purpose:
+**Purpose:**
 Stores event sequences in order.
 
-Main question:
+**Main question:**
 What happened, in what order?
 
-Examples:
+**Examples:**
 - run_started
 - proposal_created
 - candidate_executed
@@ -117,25 +117,25 @@ Examples:
 - decision_rejected
 - run_stopped
 
-Useful for:
+**Useful for:**
 - event sourcing
 - replay
 - debugging
 - state reconstruction
 - deterministic sequence analysis
 
-Status:
+**Status:**
 Roadmap only. Not implemented in the current MVP.
 
 ## Layer 5: Metrics memory — TimescaleDB-style metrics timeline
 
-Purpose:
+**Purpose:**
 Stores time-series operational signals.
 
-Main question:
+**Main question:**
 How did scores, confidence, latency, retries, failures, and drift change over time?
 
-Examples:
+**Examples:**
 - score per step
 - confidence per run
 - latency per executor
@@ -143,7 +143,7 @@ Examples:
 - failure rate per constraint
 - drift across versions
 
-Useful for:
+**Useful for:**
 - observability
 - SLOs
 - regression detection
@@ -151,7 +151,7 @@ Useful for:
 - operational dashboards
 - critic trigger thresholds
 
-Status:
+**Status:**
 Roadmap only. Not implemented in the current MVP.
 
 ## Summary table
@@ -190,7 +190,7 @@ Critic / Pattern Analysis / Replay / Dashboards
 
 ## Relation to existing docs
 
-docs/persistent_reasoning_memory.md describes the first roadmap step: append-only step log + hypothesis graph.
+`docs/persistent_reasoning_memory.md` describes the first roadmap step: append-only step log + hypothesis graph.
 
 This document expands that roadmap into a broader five-layer memory architecture.
 
@@ -209,4 +209,4 @@ The current MVP does not include:
 - docker-compose storage services
 - production storage layer
 
-Do not imply otherwise.
+This document should not be read as a claim that these storage layers are implemented.


### PR DESCRIPTION
### Motivation

- Expand the architecture roadmap to describe a future Temporal‑Causal Memory Stack that separates five complementary memory layers (fact, graph, bitemporal, event, metrics). 
- Keep the change documentation-only and explicitly avoid adding adapters, dependencies, schemas, runtime changes, or docker-compose for the current MVP.

### Description

- Add `docs/temporal_causal_memory_stack.md` containing the five-layer roadmap, examples, a summary table, conceptual flow, and explicit MVP non-goals. 
- Add `docs/persistent_reasoning_memory.md` with a short related‑roadmap note linking to the new five-layer document. 
- Update `README.md` to link to `docs/persistent_reasoning_memory.md`, add a sentence linking the broader five-layer roadmap, and add one short bullet under additional roadmap items. 
- Use clear, honest language (e.g., "roadmap", "future versions may", "not implemented") and do not change runtime behavior or add any implementation artifacts.

### Testing

- Ran `mix format` which failed due to no configured `.formatter.exs` inputs in this environment. 
- Ran `mix compile` which was blocked by missing Hex/dependency bootstrap in this container. 
- Ran `mix test` which was blocked by the same dependency/bootstrap issue; no new tests were added because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb0f2e650832dbaac71e8c0ca346f)