### PR TITLE
Add Bitemporal Authorization Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,21 @@ Run:
 ```bash
 mix run examples/agent_safety_showcase.exs
 ```
+
+## Bitemporal Authorization Showcase
+
+PythiaLabs includes a deterministic showcase for temporal authorization reasoning.
+
+Run:
+
+```bash
+mix run examples/bitemporal_authorization_showcase.exs
+```
+
+The demo shows how an agent action can be accepted or rejected based on:
+
+- whether the permission was valid at action_time
+- whether the system knew about the permission at decision_time
+- whether the permission was expired or scheduled for the future
+
+This demonstrates the Temporal-Causal Memory Stack idea without requiring XTDB or any external database.

--- a/docs/bitemporal_authorization_showcase.md
+++ b/docs/bitemporal_authorization_showcase.md
@@ -1,0 +1,35 @@
+# Bitemporal Authorization Showcase
+
+## Problem
+
+In agentic systems, a permission can be valid in the domain at one time, but the system may learn about it later.
+
+This creates an important safety question:
+
+Was the action authorized at the action time, and did the system know that authorization at the decision time?
+
+## Time axes
+
+- action_time: when the agent action was proposed or attempted
+- decision_time: when the system allowed or rejected the action
+- valid_time: when the permission is true in the domain
+- transaction_time / recorded_at: when the system learned or recorded the permission
+
+## What the showcase demonstrates
+
+- authorization valid and known
+- authorization valid but unknown at decision time
+- expired authorization
+- future authorization
+- deterministic stop_reason
+- trace explaining the temporal decision boundary
+
+## How to run
+
+mix run examples/bitemporal_authorization_showcase.exs
+
+## Relation to Temporal-Causal Memory Stack
+
+This showcase demonstrates the XTDB-style temporal memory layer without adding XTDB or any database dependency.
+
+It is an in-memory deterministic demo of valid_time and transaction_time reasoning.

--- a/docs/temporal_causal_memory_stack.md
+++ b/docs/temporal_causal_memory_stack.md
@@ -101,6 +101,8 @@ When was a fact true, and when did the system know it?
 **Status:**
 Roadmap only. Not implemented in the current MVP.
 
+For a deterministic in-memory demo of this idea, see: `docs/bitemporal_authorization_showcase.md`.
+
 ## Layer 4: Event memory — EventStoreDB-style event stream
 
 **Purpose:**

--- a/examples/bitemporal_authorization_showcase.exs
+++ b/examples/bitemporal_authorization_showcase.exs
@@ -1,0 +1,86 @@
+alias Pythia.Showcase.BitemporalAuthorization
+
+base_action = %{
+  action_id: "act_001",
+  action_type: "delete_user_data",
+  actor: "agent_alpha",
+  target: "user_123",
+  required_permission: "user_data.delete"
+}
+
+scenario_inputs = [
+  {
+    "valid and known",
+    Map.merge(base_action, %{
+      action_time: ~U[2026-04-25 10:15:00Z],
+      decision_time: ~U[2026-04-25 10:16:00Z]
+    }),
+    %{
+      permission: "user_data.delete",
+      valid_from: ~U[2026-04-25 10:00:00Z],
+      valid_to: ~U[2026-04-25 10:30:00Z],
+      recorded_at: ~U[2026-04-25 10:10:00Z]
+    }
+  },
+  {
+    "valid but unknown",
+    Map.merge(base_action, %{
+      action_time: ~U[2026-04-25 10:15:00Z],
+      decision_time: ~U[2026-04-25 10:16:00Z]
+    }),
+    %{
+      permission: "user_data.delete",
+      valid_from: ~U[2026-04-25 10:00:00Z],
+      valid_to: ~U[2026-04-25 10:30:00Z],
+      recorded_at: ~U[2026-04-25 10:20:00Z]
+    }
+  },
+  {
+    "expired",
+    Map.merge(base_action, %{
+      action_time: ~U[2026-04-25 10:35:00Z],
+      decision_time: ~U[2026-04-25 10:36:00Z]
+    }),
+    %{
+      permission: "user_data.delete",
+      valid_from: ~U[2026-04-25 10:00:00Z],
+      valid_to: ~U[2026-04-25 10:30:00Z],
+      recorded_at: ~U[2026-04-25 10:10:00Z]
+    }
+  },
+  {
+    "future permission",
+    Map.merge(base_action, %{
+      action_time: ~U[2026-04-25 09:55:00Z],
+      decision_time: ~U[2026-04-25 09:56:00Z]
+    }),
+    %{
+      permission: "user_data.delete",
+      valid_from: ~U[2026-04-25 10:00:00Z],
+      valid_to: ~U[2026-04-25 10:30:00Z],
+      recorded_at: ~U[2026-04-25 09:45:00Z]
+    }
+  }
+]
+
+print_result = fn scenario_name, result ->
+  IO.puts("\nScenario: #{scenario_name}")
+
+  case result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+  end
+end
+
+IO.puts("Bitemporal Authorization Showcase")
+
+Enum.each(scenario_inputs, fn {name, action, permission_record} ->
+  action
+  |> BitemporalAuthorization.evaluate(permission_record)
+  |> print_result.(name)
+end)

--- a/lib/pythia/showcase/bitemporal_authorization.ex
+++ b/lib/pythia/showcase/bitemporal_authorization.ex
@@ -27,153 +27,170 @@ defmodule Pythia.Showcase.BitemporalAuthorization do
 
     cond do
       not matching_permission?(required_permission, permission) ->
-        reject(:missing_permission_record, [
-          %{
-            event: :permission_match_check,
-            result: :fail,
-            required: required_permission,
-            record: permission
-          },
-          %{event: :decision, result: :reject}
-          | base_trace
-        ])
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :fail,
+                required: required_permission,
+                record: permission
+              },
+              %{event: :decision, result: :reject}
+            ]
+
+        reject(:missing_permission_record, trace)
 
       not temporal_data_valid?(action_time, decision_time, valid_from, valid_to, recorded_at) ->
-        reject(:invalid_temporal_record, [
-          %{
-            event: :permission_match_check,
-            result: :pass,
-            required: required_permission,
-            record: permission
-          },
-          %{
-            event: :valid_time_check,
-            result: :invalid,
-            valid_from: valid_from,
-            valid_to: valid_to,
-            action_time: action_time
-          },
-          %{
-            event: :transaction_time_check,
-            result: :invalid,
-            recorded_at: recorded_at,
-            decision_time: decision_time
-          },
-          %{event: :decision, result: :reject}
-          | base_trace
-        ])
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :pass,
+                required: required_permission,
+                record: permission
+              },
+              %{
+                event: :valid_time_check,
+                result: :invalid,
+                valid_from: valid_from,
+                valid_to: valid_to,
+                action_time: action_time
+              },
+              %{
+                event: :transaction_time_check,
+                result: :invalid,
+                recorded_at: recorded_at,
+                decision_time: decision_time
+              },
+              %{event: :decision, result: :reject}
+            ]
+
+        reject(:invalid_temporal_record, trace)
 
       DateTime.compare(action_time, valid_from) == :lt ->
-        reject(:authorization_not_yet_valid, [
-          %{
-            event: :permission_match_check,
-            result: :pass,
-            required: required_permission,
-            record: permission
-          },
-          %{
-            event: :valid_time_check,
-            result: :fail,
-            reason: :before_valid_from,
-            valid_from: valid_from,
-            valid_to: valid_to,
-            action_time: action_time
-          },
-          %{
-            event: :transaction_time_check,
-            result: :skipped,
-            reason: :valid_time_failed,
-            recorded_at: recorded_at,
-            decision_time: decision_time
-          },
-          %{event: :decision, result: :reject}
-          | base_trace
-        ])
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :pass,
+                required: required_permission,
+                record: permission
+              },
+              %{
+                event: :valid_time_check,
+                result: :fail,
+                reason: :before_valid_from,
+                valid_from: valid_from,
+                valid_to: valid_to,
+                action_time: action_time
+              },
+              %{
+                event: :transaction_time_check,
+                result: :skipped,
+                reason: :valid_time_failed,
+                recorded_at: recorded_at,
+                decision_time: decision_time
+              },
+              %{event: :decision, result: :reject}
+            ]
+
+        reject(:authorization_not_yet_valid, trace)
 
       DateTime.compare(action_time, valid_to) == :gt ->
-        reject(:authorization_expired, [
-          %{
-            event: :permission_match_check,
-            result: :pass,
-            required: required_permission,
-            record: permission
-          },
-          %{
-            event: :valid_time_check,
-            result: :fail,
-            reason: :after_valid_to,
-            valid_from: valid_from,
-            valid_to: valid_to,
-            action_time: action_time
-          },
-          %{
-            event: :transaction_time_check,
-            result: :skipped,
-            reason: :valid_time_failed,
-            recorded_at: recorded_at,
-            decision_time: decision_time
-          },
-          %{event: :decision, result: :reject}
-          | base_trace
-        ])
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :pass,
+                required: required_permission,
+                record: permission
+              },
+              %{
+                event: :valid_time_check,
+                result: :fail,
+                reason: :after_valid_to,
+                valid_from: valid_from,
+                valid_to: valid_to,
+                action_time: action_time
+              },
+              %{
+                event: :transaction_time_check,
+                result: :skipped,
+                reason: :valid_time_failed,
+                recorded_at: recorded_at,
+                decision_time: decision_time
+              },
+              %{event: :decision, result: :reject}
+            ]
+
+        reject(:authorization_expired, trace)
 
       DateTime.compare(recorded_at, decision_time) == :gt ->
-        reject(:authorization_valid_but_unknown_at_decision_time, [
-          %{
-            event: :permission_match_check,
-            result: :pass,
-            required: required_permission,
-            record: permission
-          },
-          %{
-            event: :valid_time_check,
-            result: :pass,
-            valid_from: valid_from,
-            valid_to: valid_to,
-            action_time: action_time
-          },
-          %{
-            event: :transaction_time_check,
-            result: :fail,
-            reason: :recorded_after_decision,
-            recorded_at: recorded_at,
-            decision_time: decision_time
-          },
-          %{event: :decision, result: :reject}
-          | base_trace
-        ])
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :pass,
+                required: required_permission,
+                record: permission
+              },
+              %{
+                event: :valid_time_check,
+                result: :pass,
+                valid_from: valid_from,
+                valid_to: valid_to,
+                action_time: action_time
+              },
+              %{
+                event: :transaction_time_check,
+                result: :fail,
+                reason: :recorded_after_decision,
+                recorded_at: recorded_at,
+                decision_time: decision_time
+              },
+              %{event: :decision, result: :reject}
+            ]
+
+        reject(:authorization_valid_but_unknown_at_decision_time, trace)
 
       true ->
+        trace =
+          base_trace ++
+            [
+              %{
+                event: :permission_match_check,
+                result: :pass,
+                required: required_permission,
+                record: permission
+              },
+              %{
+                event: :valid_time_check,
+                result: :pass,
+                valid_from: valid_from,
+                valid_to: valid_to,
+                action_time: action_time
+              },
+              %{
+                event: :transaction_time_check,
+                result: :pass,
+                recorded_at: recorded_at,
+                decision_time: decision_time
+              },
+              %{event: :decision, result: :accept}
+            ]
+
         {:ok,
          %{
            status: :accepted,
            stop_reason: :authorization_valid_and_known,
            action: action,
            permission_record: permission_record,
-           trace:
-             Enum.reverse([
-               %{event: :decision, result: :accept},
-               %{
-                 event: :transaction_time_check,
-                 result: :pass,
-                 recorded_at: recorded_at,
-                 decision_time: decision_time
-               },
-               %{
-                 event: :valid_time_check,
-                 result: :pass,
-                 valid_from: valid_from,
-                 valid_to: valid_to,
-                 action_time: action_time
-               },
-               %{
-                 event: :permission_match_check,
-                 result: :pass,
-                 required: required_permission,
-                 record: permission
-               }
-               | base_trace
-             ])
+           trace: trace
          }}
     end
   end
@@ -190,7 +207,7 @@ defmodule Pythia.Showcase.BitemporalAuthorization do
      %{
        status: :rejected,
        stop_reason: stop_reason,
-       trace: Enum.reverse(trace)
+       trace: trace
      }}
   end
 

--- a/lib/pythia/showcase/bitemporal_authorization.ex
+++ b/lib/pythia/showcase/bitemporal_authorization.ex
@@ -1,0 +1,211 @@
+defmodule Pythia.Showcase.BitemporalAuthorization do
+  @moduledoc """
+  Deterministic in-memory showcase for bitemporal authorization reasoning.
+  """
+
+  @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
+  def evaluate(action, permission_record) when is_map(action) and is_map(permission_record) do
+    required_permission = fetch(action, :required_permission)
+    permission = fetch(permission_record, :permission)
+    action_time = fetch(action, :action_time)
+    decision_time = fetch(action, :decision_time)
+    valid_from = fetch(permission_record, :valid_from)
+    valid_to = fetch(permission_record, :valid_to)
+    recorded_at = fetch(permission_record, :recorded_at)
+
+    base_trace = [
+      %{
+        event: :proposed_action,
+        action_id: fetch(action, :action_id),
+        action_type: fetch(action, :action_type),
+        required_permission: required_permission,
+        action_time: action_time,
+        decision_time: decision_time
+      },
+      %{event: :required_permission, value: required_permission}
+    ]
+
+    cond do
+      not matching_permission?(required_permission, permission) ->
+        reject(:missing_permission_record, [
+          %{
+            event: :permission_match_check,
+            result: :fail,
+            required: required_permission,
+            record: permission
+          },
+          %{event: :decision, result: :reject}
+          | base_trace
+        ])
+
+      not temporal_data_valid?(action_time, decision_time, valid_from, valid_to, recorded_at) ->
+        reject(:invalid_temporal_record, [
+          %{
+            event: :permission_match_check,
+            result: :pass,
+            required: required_permission,
+            record: permission
+          },
+          %{
+            event: :valid_time_check,
+            result: :invalid,
+            valid_from: valid_from,
+            valid_to: valid_to,
+            action_time: action_time
+          },
+          %{
+            event: :transaction_time_check,
+            result: :invalid,
+            recorded_at: recorded_at,
+            decision_time: decision_time
+          },
+          %{event: :decision, result: :reject}
+          | base_trace
+        ])
+
+      DateTime.compare(action_time, valid_from) == :lt ->
+        reject(:authorization_not_yet_valid, [
+          %{
+            event: :permission_match_check,
+            result: :pass,
+            required: required_permission,
+            record: permission
+          },
+          %{
+            event: :valid_time_check,
+            result: :fail,
+            reason: :before_valid_from,
+            valid_from: valid_from,
+            valid_to: valid_to,
+            action_time: action_time
+          },
+          %{
+            event: :transaction_time_check,
+            result: :skipped,
+            reason: :valid_time_failed,
+            recorded_at: recorded_at,
+            decision_time: decision_time
+          },
+          %{event: :decision, result: :reject}
+          | base_trace
+        ])
+
+      DateTime.compare(action_time, valid_to) == :gt ->
+        reject(:authorization_expired, [
+          %{
+            event: :permission_match_check,
+            result: :pass,
+            required: required_permission,
+            record: permission
+          },
+          %{
+            event: :valid_time_check,
+            result: :fail,
+            reason: :after_valid_to,
+            valid_from: valid_from,
+            valid_to: valid_to,
+            action_time: action_time
+          },
+          %{
+            event: :transaction_time_check,
+            result: :skipped,
+            reason: :valid_time_failed,
+            recorded_at: recorded_at,
+            decision_time: decision_time
+          },
+          %{event: :decision, result: :reject}
+          | base_trace
+        ])
+
+      DateTime.compare(recorded_at, decision_time) == :gt ->
+        reject(:authorization_valid_but_unknown_at_decision_time, [
+          %{
+            event: :permission_match_check,
+            result: :pass,
+            required: required_permission,
+            record: permission
+          },
+          %{
+            event: :valid_time_check,
+            result: :pass,
+            valid_from: valid_from,
+            valid_to: valid_to,
+            action_time: action_time
+          },
+          %{
+            event: :transaction_time_check,
+            result: :fail,
+            reason: :recorded_after_decision,
+            recorded_at: recorded_at,
+            decision_time: decision_time
+          },
+          %{event: :decision, result: :reject}
+          | base_trace
+        ])
+
+      true ->
+        {:ok,
+         %{
+           status: :accepted,
+           stop_reason: :authorization_valid_and_known,
+           action: action,
+           permission_record: permission_record,
+           trace:
+             Enum.reverse([
+               %{event: :decision, result: :accept},
+               %{
+                 event: :transaction_time_check,
+                 result: :pass,
+                 recorded_at: recorded_at,
+                 decision_time: decision_time
+               },
+               %{
+                 event: :valid_time_check,
+                 result: :pass,
+                 valid_from: valid_from,
+                 valid_to: valid_to,
+                 action_time: action_time
+               },
+               %{
+                 event: :permission_match_check,
+                 result: :pass,
+                 required: required_permission,
+                 record: permission
+               }
+               | base_trace
+             ])
+         }}
+    end
+  end
+
+  def evaluate(_action, _permission_record) do
+    reject(:invalid_temporal_record, [
+      %{event: :proposed_action, result: :invalid_input_shape},
+      %{event: :decision, result: :reject}
+    ])
+  end
+
+  defp reject(stop_reason, trace) do
+    {:error,
+     %{
+       status: :rejected,
+       stop_reason: stop_reason,
+       trace: Enum.reverse(trace)
+     }}
+  end
+
+  defp fetch(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp matching_permission?(required_permission, permission) do
+    is_binary(required_permission) and required_permission != "" and
+      required_permission == permission
+  end
+
+  defp temporal_data_valid?(action_time, decision_time, valid_from, valid_to, recorded_at) do
+    Enum.all?(
+      [action_time, decision_time, valid_from, valid_to, recorded_at],
+      &is_struct(&1, DateTime)
+    ) and
+      DateTime.compare(valid_from, valid_to) != :gt
+  end
+end

--- a/test/bitemporal_authorization_showcase_test.exs
+++ b/test/bitemporal_authorization_showcase_test.exs
@@ -25,23 +25,54 @@ defmodule Pythia.BitemporalAuthorizationShowcaseTest do
   end
 
   test "valid and known authorization is accepted", ctx do
-    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known}} =
+    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known, trace: trace}} =
              BitemporalAuthorization.evaluate(ctx.action, ctx.permission_record)
+
+    assert Enum.map(trace, & &1.event) == [
+             :proposed_action,
+             :required_permission,
+             :permission_match_check,
+             :valid_time_check,
+             :transaction_time_check,
+             :decision
+           ]
   end
 
   test "valid but unknown authorization is rejected", ctx do
     unknown_permission_record = %{ctx.permission_record | recorded_at: ~U[2026-04-25 10:20:00Z]}
 
     assert {:error,
-            %{status: :rejected, stop_reason: :authorization_valid_but_unknown_at_decision_time}} =
+            %{
+              status: :rejected,
+              stop_reason: :authorization_valid_but_unknown_at_decision_time,
+              trace: trace
+            }} =
              BitemporalAuthorization.evaluate(ctx.action, unknown_permission_record)
+
+    assert Enum.map(trace, & &1.event) == [
+             :proposed_action,
+             :required_permission,
+             :permission_match_check,
+             :valid_time_check,
+             :transaction_time_check,
+             :decision
+           ]
   end
 
   test "expired authorization is rejected", ctx do
     expired_action = %{ctx.action | action_time: ~U[2026-04-25 10:35:00Z]}
 
-    assert {:error, %{status: :rejected, stop_reason: :authorization_expired}} =
+    assert {:error, %{status: :rejected, stop_reason: :authorization_expired, trace: trace}} =
              BitemporalAuthorization.evaluate(expired_action, ctx.permission_record)
+
+    assert Enum.map(trace, & &1.event) == [
+             :proposed_action,
+             :required_permission,
+             :permission_match_check,
+             :valid_time_check,
+             :transaction_time_check,
+             :decision
+           ]
   end
 
   test "future authorization is rejected", ctx do
@@ -90,5 +121,29 @@ defmodule Pythia.BitemporalAuthorizationShowcaseTest do
     assert Enum.any?(trace, fn entry ->
              entry.event == :transaction_time_check and entry.result == :fail
            end)
+  end
+
+  test "action_time == valid_from is accepted", ctx do
+    action_at_valid_from = %{ctx.action | action_time: ctx.permission_record.valid_from}
+
+    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known}} =
+             BitemporalAuthorization.evaluate(action_at_valid_from, ctx.permission_record)
+  end
+
+  test "action_time == valid_to is accepted", ctx do
+    action_at_valid_to = %{ctx.action | action_time: ctx.permission_record.valid_to}
+
+    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known}} =
+             BitemporalAuthorization.evaluate(action_at_valid_to, ctx.permission_record)
+  end
+
+  test "recorded_at == decision_time is accepted", ctx do
+    permission_known_at_decision = %{
+      ctx.permission_record
+      | recorded_at: ctx.action.decision_time
+    }
+
+    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known}} =
+             BitemporalAuthorization.evaluate(ctx.action, permission_known_at_decision)
   end
 end

--- a/test/bitemporal_authorization_showcase_test.exs
+++ b/test/bitemporal_authorization_showcase_test.exs
@@ -1,0 +1,94 @@
+defmodule Pythia.BitemporalAuthorizationShowcaseTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.BitemporalAuthorization
+
+  setup do
+    action = %{
+      action_id: "act_001",
+      action_type: "delete_user_data",
+      actor: "agent_alpha",
+      target: "user_123",
+      required_permission: "user_data.delete",
+      action_time: ~U[2026-04-25 10:15:00Z],
+      decision_time: ~U[2026-04-25 10:16:00Z]
+    }
+
+    permission_record = %{
+      permission: "user_data.delete",
+      valid_from: ~U[2026-04-25 10:00:00Z],
+      valid_to: ~U[2026-04-25 10:30:00Z],
+      recorded_at: ~U[2026-04-25 10:10:00Z]
+    }
+
+    %{action: action, permission_record: permission_record}
+  end
+
+  test "valid and known authorization is accepted", ctx do
+    assert {:ok, %{status: :accepted, stop_reason: :authorization_valid_and_known}} =
+             BitemporalAuthorization.evaluate(ctx.action, ctx.permission_record)
+  end
+
+  test "valid but unknown authorization is rejected", ctx do
+    unknown_permission_record = %{ctx.permission_record | recorded_at: ~U[2026-04-25 10:20:00Z]}
+
+    assert {:error,
+            %{status: :rejected, stop_reason: :authorization_valid_but_unknown_at_decision_time}} =
+             BitemporalAuthorization.evaluate(ctx.action, unknown_permission_record)
+  end
+
+  test "expired authorization is rejected", ctx do
+    expired_action = %{ctx.action | action_time: ~U[2026-04-25 10:35:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_expired}} =
+             BitemporalAuthorization.evaluate(expired_action, ctx.permission_record)
+  end
+
+  test "future authorization is rejected", ctx do
+    future_action = %{ctx.action | action_time: ~U[2026-04-25 09:55:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_not_yet_valid}} =
+             BitemporalAuthorization.evaluate(future_action, ctx.permission_record)
+  end
+
+  test "missing permission record is rejected", ctx do
+    missing_permission_record = %{ctx.permission_record | permission: "billing.read"}
+
+    assert {:error, %{status: :rejected, stop_reason: :missing_permission_record}} =
+             BitemporalAuthorization.evaluate(ctx.action, missing_permission_record)
+  end
+
+  test "malformed temporal data is rejected", ctx do
+    malformed_permission_record = %{ctx.permission_record | valid_to: nil}
+
+    assert {:error, %{status: :rejected, stop_reason: :invalid_temporal_record}} =
+             BitemporalAuthorization.evaluate(ctx.action, malformed_permission_record)
+  end
+
+  test "repeated input returns deterministic output", ctx do
+    first = BitemporalAuthorization.evaluate(ctx.action, ctx.permission_record)
+    second = BitemporalAuthorization.evaluate(ctx.action, ctx.permission_record)
+
+    assert first == second
+  end
+
+  test "trace contains valid_time and transaction_time checks", ctx do
+    assert {:error,
+            %{
+              stop_reason: :authorization_valid_but_unknown_at_decision_time,
+              trace: trace
+            }} =
+             BitemporalAuthorization.evaluate(ctx.action, %{
+               ctx.permission_record
+               | recorded_at: ~U[2026-04-25 10:20:00Z]
+             })
+
+    assert Enum.any?(trace, fn entry ->
+             entry.event == :valid_time_check and entry.result == :pass
+           end)
+
+    assert Enum.any?(trace, fn entry ->
+             entry.event == :transaction_time_check and entry.result == :fail
+           end)
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide a small deterministic, in-memory demo of XTDB-style bitemporal reasoning so the Temporal‑Causal Memory Stack roadmap has a runnable example. 
- Demonstrate the difference between `valid_time` (permission window) and `transaction_time` / `recorded_at` (when the system learned the permission) when deciding an agent action. 
- Keep the demo self-contained with no databases, persistence, or external dependencies (in-memory only). 

### Description

- Adds `Pythia.Showcase.BitemporalAuthorization.evaluate/2` in `lib/pythia/showcase/bitemporal_authorization.ex` that implements the decision rules and produces a human-readable `trace` and deterministic `stop_reason` values. 
- Adds a runnable example `examples/bitemporal_authorization_showcase.exs` which prints four scenarios: `valid and known`, `valid but unknown`, `expired`, and `future permission`. 
- Adds comprehensive ExUnit tests in `test/bitemporal_authorization_showcase_test.exs` covering accepted, valid-but-unknown, expired, future, missing permission, malformed temporal data, determinism, and trace-content assertions for `valid_time_check` and `transaction_time_check`. 
- Adds docs `docs/bitemporal_authorization_showcase.md`, updates `README.md` with a short section and `docs/temporal_causal_memory_stack.md` with a link to the new showcase. 

### Testing

- Added ExUnit tests in `test/bitemporal_authorization_showcase_test.exs` which exercise all required decision rules and trace checks, but `mix test` could not be completed in this environment due to dependency fetch/network issues (Mix/Hex attempted to fetch deps and failed with an HTTP/GitHub 403). 
- Formatting and compilation commands attempted: `mix format`, `mix compile`, and `mix test`; all were blocked by the same dependency/Hex network error so automated run results are pending in CI where dependencies can be fetched. 
- The example run `mix run examples/bitemporal_authorization_showcase.exs` was also attempted but could not be executed for the same environment limitation; the example script is included and prints the four requested scenarios when run locally or in CI with network access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc766d738832da91f14d2b80f9537)