### PR TITLE
Add Web3 Treasury Action Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,24 @@ The demo shows how an agent action can be accepted or rejected based on:
 - whether the permission was expired or scheduled for the future
 
 This demonstrates the Temporal-Causal Memory Stack idea without requiring XTDB or any external database.
+
+## Web3 Treasury Action Showcase
+
+PythiaLabs includes a deterministic in-memory showcase for DAO treasury transfer reasoning.
+
+Run:
+
+```bash
+mix run examples/web3_treasury_action_showcase.exs
+```
+
+The demo shows how a proposed treasury transfer can be accepted or rejected based on:
+
+- proposal matching
+- quorum
+- voting window
+- timelock
+- temporal authorization
+- transfer expiration
+
+This demonstrates the Web3 Consensus Reason Layer roadmap without requiring smart contracts, wallets, RPC nodes, or chain adapters.

--- a/docs/design_principles.md
+++ b/docs/design_principles.md
@@ -24,6 +24,8 @@ High-stakes agentic systems also need to explain why an action was allowed, reje
 
 This is a future application direction, not part of the current MVP.
 
+The Web3 Treasury Action Showcase demonstrates this idea with deterministic in-memory DAO treasury transfer checks.
+
 ## Why this matters
 
 For high-stakes domains (finance, public sector, regulated operations, critical infrastructure),

--- a/docs/web3_consensus_reason_layer.md
+++ b/docs/web3_consensus_reason_layer.md
@@ -41,6 +41,8 @@ A Web3 agent action should proceed only when it is:
 
 ## Use case 1: DAO treasury transfer
 
+For a deterministic in-memory demo of this use case, see: `docs/web3_treasury_action_showcase.md`.
+
 Scenario:
 An AI agent proposes a treasury transfer.
 

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -1,0 +1,51 @@
+# Web3 Treasury Action Showcase
+
+## Problem
+
+DAO treasury transfers are high-stakes actions.
+A blockchain can prove that a transaction happened, but agentic governance systems also need to explain why a transfer was allowed or rejected before execution.
+
+## What the showcase demonstrates
+
+This deterministic in-memory showcase evaluates a proposed DAO treasury transfer using:
+
+- proposal existence
+- permission match
+- quorum
+- voting window
+- timelock
+- authorization valid_time
+- authorization transaction_time / known-at-decision-time
+- transfer expiration
+
+## Why this matters
+
+A treasury action should not proceed merely because it is executable.
+
+It should proceed only when it is:
+
+- structurally valid
+- causally permitted
+- temporally valid
+- known to the system at decision time
+- replayable through trace
+
+## How to run
+
+```bash
+mix run examples/web3_treasury_action_showcase.exs
+```
+
+## Relation to Web3 Consensus Reason Layer
+
+This showcase demonstrates the first in-memory Web3 application of the Web3 Consensus Reason Layer roadmap.
+
+It does not add smart contracts, wallets, RPC calls, indexers, or chain adapters.
+
+It shows how PythiaLabs could reason about DAO treasury safety before any on-chain execution.
+
+## Relation to existing showcases
+
+- Agent Safety Showcase: basic action permission gate
+- Bitemporal Authorization Showcase: temporal authorization reasoning
+- Web3 Treasury Action Showcase: governance + temporal authorization + replayable reason trace

--- a/examples/web3_treasury_action_showcase.exs
+++ b/examples/web3_treasury_action_showcase.exs
@@ -1,0 +1,72 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+scenario_inputs = [
+  {"accepted transfer", base_action, base_governance_record},
+  {"quorum not met", base_action, %{base_governance_record | quorum_met: false}},
+  {"voting still open", base_action,
+   %{base_governance_record | voting_closed_at: ~U[2026-04-25 12:30:00Z]}},
+  {"timelock not satisfied", base_action,
+   %{base_governance_record | timelock_until: ~U[2026-04-25 12:30:00Z]}},
+  {
+    "valid authorization but unknown",
+    base_action,
+    %{base_governance_record | authorization_recorded_at: ~U[2026-04-25 12:30:00Z]}
+  },
+  {
+    "transfer expired",
+    %{base_action | action_time: ~U[2026-04-25 12:40:00Z]},
+    %{
+      base_governance_record
+      | transfer_expires_at: ~U[2026-04-25 12:30:00Z],
+        authorization_valid_to: ~U[2026-04-25 13:30:00Z]
+    }
+  }
+]
+
+print_result = fn scenario_name, result ->
+  IO.puts("\nScenario: #{scenario_name}")
+
+  case result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Stop reason: #{payload.stop_reason}")
+  end
+end
+
+IO.puts("Web3 Treasury Action Showcase")
+
+Enum.each(scenario_inputs, fn {name, action, governance_record} ->
+  action
+  |> Web3TreasuryAction.evaluate(governance_record)
+  |> print_result.(name)
+end)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -63,7 +63,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   end
 
   defp validate_governance_record(governance_record) do
-    with true <- Enum.all?(@required_governance_fields, &Map.has_key?(governance_record, &1)),
+    with true <- Enum.all?(@required_governance_fields, &has_field?(governance_record, &1)),
          true <- is_binary(fetch(governance_record, :proposal_id)),
          true <- is_binary(fetch(governance_record, :permission)),
          true <- is_boolean(fetch(governance_record, :quorum_met)),
@@ -191,5 +191,17 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
      }}
   end
 
-  defp fetch(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp has_field?(map, key) do
+    Map.has_key?(map, key) or Map.has_key?(map, Atom.to_string(key))
+  end
+
+  defp fetch(map, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(map, key) -> Map.get(map, key)
+      Map.has_key?(map, string_key) -> Map.get(map, string_key)
+      true -> nil
+    end
+  end
 end

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -1,0 +1,195 @@
+defmodule Pythia.Showcase.Web3TreasuryAction do
+  @moduledoc """
+  Deterministic in-memory showcase for Web3 DAO treasury action reasoning.
+  """
+
+  @required_governance_fields [
+    :proposal_id,
+    :permission,
+    :quorum_met,
+    :voting_closed_at,
+    :timelock_until,
+    :authorization_valid_from,
+    :authorization_valid_to,
+    :authorization_recorded_at,
+    :transfer_expires_at
+  ]
+
+  @accepted_trace [
+    :proposed_action,
+    :proposal_match_check,
+    :permission_check,
+    :quorum_check,
+    :voting_window_check,
+    :timelock_check,
+    :authorization_valid_time_check,
+    :authorization_transaction_time_check,
+    :transfer_expiration_check,
+    :decision
+  ]
+
+  @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
+  def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
+    with :ok <- validate_governance_record(governance_record),
+         :ok <- validate_action_timestamps(action),
+         :ok <- proposal_match_check(action, governance_record),
+         :ok <- permission_check(action, governance_record),
+         :ok <- quorum_check(governance_record),
+         :ok <- voting_window_check(action, governance_record),
+         :ok <- timelock_check(action, governance_record),
+         :ok <- authorization_valid_time_check(action, governance_record),
+         :ok <- authorization_transaction_time_check(action, governance_record),
+         :ok <- transfer_expiration_check(action, governance_record) do
+      {:ok,
+       %{
+         status: :accepted,
+         stop_reason: :treasury_transfer_accepted,
+         trace: @accepted_trace
+       }}
+    else
+      {:error, reason, failed_check} ->
+        reject(reason, build_rejected_trace(failed_check))
+    end
+  end
+
+  def evaluate(_action, _governance_record) do
+    reject(:invalid_governance_record, [:proposed_action, :decision])
+  end
+
+  defp build_rejected_trace(failed_check) do
+    @accepted_trace
+    |> Enum.take_while(&(&1 != failed_check))
+    |> Kernel.++([failed_check, :decision])
+  end
+
+  defp validate_governance_record(governance_record) do
+    with true <- Enum.all?(@required_governance_fields, &Map.has_key?(governance_record, &1)),
+         true <- is_binary(fetch(governance_record, :proposal_id)),
+         true <- is_binary(fetch(governance_record, :permission)),
+         true <- is_boolean(fetch(governance_record, :quorum_met)),
+         voting_closed_at when is_struct(voting_closed_at, DateTime) <-
+           fetch(governance_record, :voting_closed_at),
+         timelock_until when is_struct(timelock_until, DateTime) <-
+           fetch(governance_record, :timelock_until),
+         authorization_valid_from when is_struct(authorization_valid_from, DateTime) <-
+           fetch(governance_record, :authorization_valid_from),
+         authorization_valid_to when is_struct(authorization_valid_to, DateTime) <-
+           fetch(governance_record, :authorization_valid_to),
+         authorization_recorded_at when is_struct(authorization_recorded_at, DateTime) <-
+           fetch(governance_record, :authorization_recorded_at),
+         transfer_expires_at when is_struct(transfer_expires_at, DateTime) <-
+           fetch(governance_record, :transfer_expires_at),
+         true <- DateTime.compare(authorization_valid_from, authorization_valid_to) != :gt,
+         true <- DateTime.compare(voting_closed_at, transfer_expires_at) != :gt,
+         true <- DateTime.compare(timelock_until, transfer_expires_at) != :gt do
+      :ok
+    else
+      _ -> {:error, :invalid_governance_record, :proposal_match_check}
+    end
+  end
+
+  defp validate_action_timestamps(action) do
+    action_time = fetch(action, :action_time)
+    decision_time = fetch(action, :decision_time)
+
+    if is_struct(action_time, DateTime) and is_struct(decision_time, DateTime) do
+      :ok
+    else
+      {:error, :invalid_governance_record, :voting_window_check}
+    end
+  end
+
+  defp proposal_match_check(action, governance_record) do
+    case fetch(action, :proposal_id) == fetch(governance_record, :proposal_id) do
+      true -> :ok
+      false -> {:error, :missing_proposal_record, :proposal_match_check}
+    end
+  end
+
+  defp permission_check(action, governance_record) do
+    case fetch(action, :required_permission) == fetch(governance_record, :permission) do
+      true -> :ok
+      false -> {:error, :permission_mismatch, :permission_check}
+    end
+  end
+
+  defp quorum_check(governance_record) do
+    case fetch(governance_record, :quorum_met) do
+      true -> :ok
+      false -> {:error, :quorum_not_met, :quorum_check}
+    end
+  end
+
+  defp voting_window_check(action, governance_record) do
+    action_time = fetch(action, :action_time)
+    voting_closed_at = fetch(governance_record, :voting_closed_at)
+
+    if DateTime.compare(action_time, voting_closed_at) == :lt do
+      {:error, :voting_window_still_open, :voting_window_check}
+    else
+      :ok
+    end
+  end
+
+  defp timelock_check(action, governance_record) do
+    action_time = fetch(action, :action_time)
+    timelock_until = fetch(governance_record, :timelock_until)
+
+    if DateTime.compare(action_time, timelock_until) == :lt do
+      {:error, :timelock_not_satisfied, :timelock_check}
+    else
+      :ok
+    end
+  end
+
+  defp authorization_valid_time_check(action, governance_record) do
+    action_time = fetch(action, :action_time)
+    authorization_valid_from = fetch(governance_record, :authorization_valid_from)
+    authorization_valid_to = fetch(governance_record, :authorization_valid_to)
+
+    cond do
+      DateTime.compare(action_time, authorization_valid_from) == :lt ->
+        {:error, :authorization_not_yet_valid, :authorization_valid_time_check}
+
+      DateTime.compare(action_time, authorization_valid_to) == :gt ->
+        {:error, :authorization_expired, :authorization_valid_time_check}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp authorization_transaction_time_check(action, governance_record) do
+    decision_time = fetch(action, :decision_time)
+    authorization_recorded_at = fetch(governance_record, :authorization_recorded_at)
+
+    if DateTime.compare(authorization_recorded_at, decision_time) == :gt do
+      {:error, :authorization_valid_but_unknown_at_decision_time,
+       :authorization_transaction_time_check}
+    else
+      :ok
+    end
+  end
+
+  defp transfer_expiration_check(action, governance_record) do
+    action_time = fetch(action, :action_time)
+    transfer_expires_at = fetch(governance_record, :transfer_expires_at)
+
+    if DateTime.compare(action_time, transfer_expires_at) == :gt do
+      {:error, :transfer_expired, :transfer_expiration_check}
+    else
+      :ok
+    end
+  end
+
+  defp reject(stop_reason, trace) do
+    {:error,
+     %{
+       status: :rejected,
+       stop_reason: stop_reason,
+       trace: trace
+     }}
+  end
+
+  defp fetch(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+end

--- a/test/web3_treasury_action_showcase_test.exs
+++ b/test/web3_treasury_action_showcase_test.exs
@@ -149,9 +149,16 @@ defmodule Pythia.Web3TreasuryActionShowcaseTest do
 
   test "action_time == voting_closed_at is accepted for voting window", ctx do
     action = %{ctx.action | action_time: ctx.governance_record.voting_closed_at}
+    voting_closed_at = ctx.governance_record.voting_closed_at
+
+    record = %{
+      ctx.governance_record
+      | timelock_until: voting_closed_at,
+        authorization_valid_from: voting_closed_at
+    }
 
     assert {:ok, %{status: :accepted}} =
-             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+             Web3TreasuryAction.evaluate(action, record)
   end
 
   test "action_time == timelock_until is accepted for timelock", ctx do
@@ -190,5 +197,45 @@ defmodule Pythia.Web3TreasuryActionShowcaseTest do
     }
 
     assert {:ok, %{status: :accepted}} = Web3TreasuryAction.evaluate(action, record)
+  end
+
+  test "string-key action and governance input works" do
+    action = %{
+      "action_id" => "dao_act_001",
+      "action_type" => "treasury_transfer",
+      "actor" => "agent_alpha",
+      "dao_id" => "dao_pythia",
+      "proposal_id" => "prop_001",
+      "amount" => 10_000,
+      "asset" => "USDC",
+      "recipient" => "0xRecipient",
+      "required_permission" => "treasury.transfer",
+      "action_time" => ~U[2026-04-25 12:00:00Z],
+      "decision_time" => ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      "proposal_id" => "prop_001",
+      "permission" => "treasury.transfer",
+      "quorum_met" => true,
+      "voting_closed_at" => ~U[2026-04-25 11:00:00Z],
+      "timelock_until" => ~U[2026-04-25 11:30:00Z],
+      "authorization_valid_from" => ~U[2026-04-25 11:30:00Z],
+      "authorization_valid_to" => ~U[2026-04-25 13:00:00Z],
+      "authorization_recorded_at" => ~U[2026-04-25 11:45:00Z],
+      "transfer_expires_at" => ~U[2026-04-25 13:00:00Z]
+    }
+
+    assert {:ok, %{status: :accepted, stop_reason: :treasury_transfer_accepted}} =
+             Web3TreasuryAction.evaluate(action, governance_record)
+  end
+
+  test "string-key quorum false preserves false value and rejects with quorum_not_met", ctx do
+    action = Map.new(ctx.action, fn {k, v} -> {Atom.to_string(k), v} end)
+    governance_record = Map.new(ctx.governance_record, fn {k, v} -> {Atom.to_string(k), v} end)
+    governance_record = Map.put(governance_record, "quorum_met", false)
+
+    assert {:error, %{status: :rejected, stop_reason: :quorum_not_met}} =
+             Web3TreasuryAction.evaluate(action, governance_record)
   end
 end

--- a/test/web3_treasury_action_showcase_test.exs
+++ b/test/web3_treasury_action_showcase_test.exs
@@ -1,0 +1,194 @@
+defmodule Pythia.Web3TreasuryActionShowcaseTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "accepted transfer returns treasury_transfer_accepted", ctx do
+    assert {:ok, %{status: :accepted, stop_reason: :treasury_transfer_accepted}} =
+             Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+  end
+
+  test "missing proposal returns missing_proposal_record", ctx do
+    action = %{ctx.action | proposal_id: "prop_missing"}
+
+    assert {:error, %{status: :rejected, stop_reason: :missing_proposal_record}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "permission mismatch returns permission_mismatch", ctx do
+    action = %{ctx.action | required_permission: "dao.upgrade"}
+
+    assert {:error, %{status: :rejected, stop_reason: :permission_mismatch}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "quorum not met returns quorum_not_met", ctx do
+    record = %{ctx.governance_record | quorum_met: false}
+
+    assert {:error, %{status: :rejected, stop_reason: :quorum_not_met}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "voting still open returns voting_window_still_open", ctx do
+    record = %{ctx.governance_record | voting_closed_at: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :voting_window_still_open}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "timelock not satisfied returns timelock_not_satisfied", ctx do
+    record = %{ctx.governance_record | timelock_until: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :timelock_not_satisfied}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "authorization not yet valid returns authorization_not_yet_valid", ctx do
+    record = %{ctx.governance_record | authorization_valid_from: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_not_yet_valid}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "authorization expired returns authorization_expired", ctx do
+    action = %{ctx.action | action_time: ~U[2026-04-25 13:30:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_expired}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "authorization valid but unknown returns authorization_valid_but_unknown_at_decision_time",
+       ctx do
+    record = %{ctx.governance_record | authorization_recorded_at: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error,
+            %{status: :rejected, stop_reason: :authorization_valid_but_unknown_at_decision_time}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "transfer expired returns transfer_expired", ctx do
+    action = %{ctx.action | action_time: ~U[2026-04-25 12:40:00Z]}
+
+    record = %{
+      ctx.governance_record
+      | transfer_expires_at: ~U[2026-04-25 12:30:00Z],
+        authorization_valid_to: ~U[2026-04-25 13:30:00Z]
+    }
+
+    assert {:error, %{status: :rejected, stop_reason: :transfer_expired}} =
+             Web3TreasuryAction.evaluate(action, record)
+  end
+
+  test "malformed governance record returns invalid_governance_record", ctx do
+    malformed = Map.delete(ctx.governance_record, :timelock_until)
+
+    assert {:error, %{status: :rejected, stop_reason: :invalid_governance_record}} =
+             Web3TreasuryAction.evaluate(ctx.action, malformed)
+  end
+
+  test "repeated input returns deterministic output", ctx do
+    first = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    second = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    assert first == second
+  end
+
+  test "accepted trace has exact chronological event order", ctx do
+    assert {:ok, %{trace: trace}} = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    assert trace == [
+             :proposed_action,
+             :proposal_match_check,
+             :permission_check,
+             :quorum_check,
+             :voting_window_check,
+             :timelock_check,
+             :authorization_valid_time_check,
+             :authorization_transaction_time_check,
+             :transfer_expiration_check,
+             :decision
+           ]
+  end
+
+  test "rejected trace ends with decision", ctx do
+    action = %{ctx.action | proposal_id: "missing"}
+
+    assert {:error, %{trace: trace}} = Web3TreasuryAction.evaluate(action, ctx.governance_record)
+    assert List.last(trace) == :decision
+  end
+
+  test "action_time == voting_closed_at is accepted for voting window", ctx do
+    action = %{ctx.action | action_time: ctx.governance_record.voting_closed_at}
+
+    assert {:ok, %{status: :accepted}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "action_time == timelock_until is accepted for timelock", ctx do
+    action = %{ctx.action | action_time: ctx.governance_record.timelock_until}
+
+    assert {:ok, %{status: :accepted}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "action_time == authorization_valid_from is accepted", ctx do
+    action = %{ctx.action | action_time: ctx.governance_record.authorization_valid_from}
+
+    assert {:ok, %{status: :accepted}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "action_time == authorization_valid_to is accepted", ctx do
+    action = %{ctx.action | action_time: ctx.governance_record.authorization_valid_to}
+
+    assert {:ok, %{status: :accepted}} =
+             Web3TreasuryAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "authorization_recorded_at == decision_time is accepted", ctx do
+    record = %{ctx.governance_record | authorization_recorded_at: ctx.action.decision_time}
+
+    assert {:ok, %{status: :accepted}} = Web3TreasuryAction.evaluate(ctx.action, record)
+  end
+
+  test "action_time == transfer_expires_at is accepted", ctx do
+    action = %{ctx.action | action_time: ctx.governance_record.transfer_expires_at}
+
+    record = %{
+      ctx.governance_record
+      | authorization_valid_to: ctx.governance_record.transfer_expires_at
+    }
+
+    assert {:ok, %{status: :accepted}} = Web3TreasuryAction.evaluate(action, record)
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide a deterministic, dependency-free in-memory showcase that evaluates a DAO treasury transfer proposal against explicit governance and temporal constraints without any blockchain, wallet, RPC, or persistence dependencies.
- Demonstrate replayable chronological reason traces for agent-proposed treasury transfers as the first runnable artifact of the Web3 Consensus Reason Layer roadmap.

### Description

- Adds `Pythia.Showcase.Web3TreasuryAction` in `lib/pythia/showcase/web3_treasury_action.ex` with a public `evaluate(action, governance_record)` function that implements the required checks and returns `{:ok, %{status: :accepted, stop_reason: :treasury_transfer_accepted, trace: [...]}}` or `{:error, %{status: :rejected, stop_reason: ..., trace: [...]}}` for rejection paths.
- Adds a runnable example `examples/web3_treasury_action_showcase.exs` that prints the six required scenarios (accepted, quorum fail, voting-open fail, timelock fail, authorization-known-at-decision fail, transfer-expired fail).
- Adds comprehensive tests in `test/web3_treasury_action_showcase_test.exs` covering all accept/reject reasons, boundary conditions, determinism, and exact accepted-trace ordering.
- Adds documentation `docs/web3_treasury_action_showcase.md`, updates `README.md` with a new section and run instructions, and links the showcase from `docs/web3_consensus_reason_layer.md` and `docs/design_principles.md`.

### Testing

- Ran `mix format lib/pythia/showcase/web3_treasury_action.ex examples/web3_treasury_action_showcase.exs test/web3_treasury_action_showcase_test.exs`, which completed successfully.
- Attempted `mix compile`, but compilation was blocked because Mix could not fetch Hex dependencies in this environment (network/SSL/403) and the `:rustler` dependency could not be resolved.
- Attempted `mix test` and `mix run examples/web3_treasury_action_showcase.exs`, but both were blocked for the same reason (missing Hex/dependency fetch failure), so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecedefa84c832db2602719e68d43f8)