### PR TITLE
Add structured Web3 treasury decision trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ The demo shows how a proposed treasury transfer can be accepted or rejected base
 - transfer expiration
 
 This demonstrates the Web3 Consensus Reason Layer roadmap without requiring smart contracts, wallets, RPC nodes, or chain adapters.
+
+The result includes a structured chronological trace explaining which governance check passed or failed.

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -30,6 +30,29 @@ It should proceed only when it is:
 - known to the system at decision time
 - replayable through trace
 
+
+## Structured decision trace
+
+The showcase returns a chronological trace where each entry includes:
+
+- `event`
+- `result`
+- optional `reason`
+- relevant `expected` / `actual` values when useful
+- a final decision entry with `stop_reason`
+
+Example:
+
+```elixir
+%{
+  event: :quorum_check,
+  result: :fail,
+  reason: :quorum_not_met
+}
+```
+
+This makes the showcase useful not only as a demo, but as an audit-oriented explanation of why a treasury transfer was accepted or rejected.
+
 ## How to run
 
 ```bash

--- a/examples/web3_treasury_action_showcase.exs
+++ b/examples/web3_treasury_action_showcase.exs
@@ -52,15 +52,19 @@ scenario_inputs = [
 print_result = fn scenario_name, result ->
   IO.puts("\nScenario: #{scenario_name}")
 
-  case result do
-    {:ok, payload} ->
-      IO.puts("Status: #{payload.status}")
-      IO.puts("Stop reason: #{payload.stop_reason}")
+  payload =
+    case result do
+      {:ok, payload} -> payload
+      {:error, payload} -> payload
+    end
 
-    {:error, payload} ->
-      IO.puts("Status: #{payload.status}")
-      IO.puts("Stop reason: #{payload.stop_reason}")
-  end
+  IO.puts("Status: #{payload.status}")
+  IO.puts("Stop reason: #{payload.stop_reason}")
+  IO.puts("Trace:")
+
+  Enum.each(payload.trace, fn entry ->
+    IO.puts("- #{entry.event}: #{entry.result}")
+  end)
 end
 
 IO.puts("Web3 Treasury Action Showcase")

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -42,7 +42,10 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
          trace: trace ++ [decision_trace(:accept, :treasury_transfer_accepted)]
        }}
     else
-      {:error, stop_reason, failed_check} ->
+      {:error, stop_reason, trace} when is_list(trace) ->
+        reject(stop_reason, trace ++ [decision_trace(:reject, stop_reason)])
+
+      {:error, stop_reason, failed_check} when is_atom(failed_check) ->
         trace =
           proposed_trace ++
             [
@@ -53,9 +56,6 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
             ]
 
         reject(stop_reason, trace)
-
-      {:error, stop_reason, trace} ->
-        reject(stop_reason, trace ++ [decision_trace(:reject, stop_reason)])
     end
   end
 

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -15,8 +15,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     :transfer_expires_at
   ]
 
-  @accepted_trace [
-    :proposed_action,
+  @check_order [
     :proposal_match_check,
     :permission_check,
     :quorum_check,
@@ -24,42 +23,193 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     :timelock_check,
     :authorization_valid_time_check,
     :authorization_transaction_time_check,
-    :transfer_expiration_check,
-    :decision
+    :transfer_expiration_check
   ]
+
+  @accepted_events [:proposed_action | @check_order] ++ [:decision]
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
+    proposed_trace = [proposed_action_trace(action)]
+
     with :ok <- validate_governance_record(governance_record),
          :ok <- validate_action_timestamps(action),
-         :ok <- proposal_match_check(action, governance_record),
-         :ok <- permission_check(action, governance_record),
-         :ok <- quorum_check(governance_record),
-         :ok <- voting_window_check(action, governance_record),
-         :ok <- timelock_check(action, governance_record),
-         :ok <- authorization_valid_time_check(action, governance_record),
-         :ok <- authorization_transaction_time_check(action, governance_record),
-         :ok <- transfer_expiration_check(action, governance_record) do
+         {:ok, trace} <- run_checks(action, governance_record, proposed_trace) do
       {:ok,
        %{
          status: :accepted,
          stop_reason: :treasury_transfer_accepted,
-         trace: @accepted_trace
+         trace: trace ++ [decision_trace(:accept, :treasury_transfer_accepted)]
        }}
     else
-      {:error, reason, failed_check} ->
-        reject(reason, build_rejected_trace(failed_check))
+      {:error, stop_reason, failed_check} ->
+        trace =
+          proposed_trace ++
+            [
+              check_trace(failed_check, :fail, %{
+                reason: failure_reason(stop_reason)
+              }),
+              decision_trace(:reject, stop_reason)
+            ]
+
+        reject(stop_reason, trace)
+
+      {:error, stop_reason, trace} ->
+        reject(stop_reason, trace ++ [decision_trace(:reject, stop_reason)])
     end
   end
 
   def evaluate(_action, _governance_record) do
-    reject(:invalid_governance_record, [:proposed_action, :decision])
+    trace = [proposed_action_trace(%{}), decision_trace(:reject, :invalid_governance_record)]
+    reject(:invalid_governance_record, trace)
   end
 
-  defp build_rejected_trace(failed_check) do
-    @accepted_trace
-    |> Enum.take_while(&(&1 != failed_check))
-    |> Kernel.++([failed_check, :decision])
+  @spec trace_events([map()]) :: [atom()]
+  def trace_events(trace), do: Enum.map(trace, & &1.event)
+
+  defp run_checks(action, governance_record, trace) do
+    Enum.reduce_while(@check_order, {:ok, trace}, fn check, {:ok, acc_trace} ->
+      case run_check(check, action, governance_record) do
+        {:ok, details} ->
+          {:cont, {:ok, acc_trace ++ [check_trace(check, :pass, details)]}}
+
+        {:error, stop_reason, details} ->
+          fail_trace = acc_trace ++ [check_trace(check, :fail, details)]
+          {:halt, {:error, stop_reason, fail_trace}}
+      end
+    end)
+  end
+
+  defp run_check(:proposal_match_check, action, governance_record) do
+    expected = fetch(governance_record, :proposal_id)
+    actual = fetch(action, :proposal_id)
+
+    if actual == expected do
+      {:ok, %{expected: expected, actual: actual}}
+    else
+      {:error, :missing_proposal_record,
+       %{expected: expected, actual: actual, reason: :missing_proposal_record}}
+    end
+  end
+
+  defp run_check(:permission_check, action, governance_record) do
+    expected = fetch(governance_record, :permission)
+    actual = fetch(action, :required_permission)
+
+    if actual == expected do
+      {:ok, %{expected: expected, actual: actual}}
+    else
+      {:error, :permission_mismatch,
+       %{expected: expected, actual: actual, reason: :permission_mismatch}}
+    end
+  end
+
+  defp run_check(:quorum_check, _action, governance_record) do
+    quorum_met = fetch(governance_record, :quorum_met)
+
+    if quorum_met do
+      {:ok, %{actual: quorum_met}}
+    else
+      {:error, :quorum_not_met, %{actual: quorum_met, reason: :quorum_not_met}}
+    end
+  end
+
+  defp run_check(:voting_window_check, action, governance_record) do
+    action_time = fetch(action, :action_time)
+    voting_closed_at = fetch(governance_record, :voting_closed_at)
+
+    if DateTime.compare(action_time, voting_closed_at) == :lt do
+      {:error, :voting_window_still_open,
+       %{
+         reason: :voting_window_still_open,
+         action_time: action_time,
+         voting_closed_at: voting_closed_at
+       }}
+    else
+      {:ok, %{action_time: action_time, voting_closed_at: voting_closed_at}}
+    end
+  end
+
+  defp run_check(:timelock_check, action, governance_record) do
+    action_time = fetch(action, :action_time)
+    timelock_until = fetch(governance_record, :timelock_until)
+
+    if DateTime.compare(action_time, timelock_until) == :lt do
+      {:error, :timelock_not_satisfied,
+       %{
+         reason: :timelock_not_satisfied,
+         action_time: action_time,
+         timelock_until: timelock_until
+       }}
+    else
+      {:ok, %{action_time: action_time, timelock_until: timelock_until}}
+    end
+  end
+
+  defp run_check(:authorization_valid_time_check, action, governance_record) do
+    action_time = fetch(action, :action_time)
+    authorization_valid_from = fetch(governance_record, :authorization_valid_from)
+    authorization_valid_to = fetch(governance_record, :authorization_valid_to)
+
+    cond do
+      DateTime.compare(action_time, authorization_valid_from) == :lt ->
+        {:error, :authorization_not_yet_valid,
+         %{
+           reason: :authorization_not_yet_valid,
+           action_time: action_time,
+           authorization_valid_from: authorization_valid_from,
+           authorization_valid_to: authorization_valid_to
+         }}
+
+      DateTime.compare(action_time, authorization_valid_to) == :gt ->
+        {:error, :authorization_expired,
+         %{
+           reason: :authorization_expired,
+           action_time: action_time,
+           authorization_valid_from: authorization_valid_from,
+           authorization_valid_to: authorization_valid_to
+         }}
+
+      true ->
+        {:ok,
+         %{
+           action_time: action_time,
+           authorization_valid_from: authorization_valid_from,
+           authorization_valid_to: authorization_valid_to
+         }}
+    end
+  end
+
+  defp run_check(:authorization_transaction_time_check, action, governance_record) do
+    decision_time = fetch(action, :decision_time)
+    authorization_recorded_at = fetch(governance_record, :authorization_recorded_at)
+
+    if DateTime.compare(authorization_recorded_at, decision_time) == :gt do
+      {:error, :authorization_valid_but_unknown_at_decision_time,
+       %{
+         reason: :recorded_after_decision,
+         decision_time: decision_time,
+         authorization_recorded_at: authorization_recorded_at
+       }}
+    else
+      {:ok, %{decision_time: decision_time, authorization_recorded_at: authorization_recorded_at}}
+    end
+  end
+
+  defp run_check(:transfer_expiration_check, action, governance_record) do
+    action_time = fetch(action, :action_time)
+    transfer_expires_at = fetch(governance_record, :transfer_expires_at)
+
+    if DateTime.compare(action_time, transfer_expires_at) == :gt do
+      {:error, :transfer_expired,
+       %{
+         reason: :transfer_expired,
+         action_time: action_time,
+         transfer_expires_at: transfer_expires_at
+       }}
+    else
+      {:ok, %{action_time: action_time, transfer_expires_at: transfer_expires_at}}
+    end
   end
 
   defp validate_governance_record(governance_record) do
@@ -99,88 +249,29 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     end
   end
 
-  defp proposal_match_check(action, governance_record) do
-    case fetch(action, :proposal_id) == fetch(governance_record, :proposal_id) do
-      true -> :ok
-      false -> {:error, :missing_proposal_record, :proposal_match_check}
-    end
+  defp proposed_action_trace(action) do
+    %{
+      event: :proposed_action,
+      result: :observed,
+      action_id: fetch(action, :action_id),
+      action_type: fetch(action, :action_type),
+      proposal_id: fetch(action, :proposal_id),
+      actor: fetch(action, :actor)
+    }
   end
 
-  defp permission_check(action, governance_record) do
-    case fetch(action, :required_permission) == fetch(governance_record, :permission) do
-      true -> :ok
-      false -> {:error, :permission_mismatch, :permission_check}
-    end
+  defp check_trace(event, result, details) do
+    Map.merge(%{event: event, result: result}, details)
   end
 
-  defp quorum_check(governance_record) do
-    case fetch(governance_record, :quorum_met) do
-      true -> :ok
-      false -> {:error, :quorum_not_met, :quorum_check}
-    end
+  defp decision_trace(result, stop_reason) do
+    %{event: :decision, result: result, stop_reason: stop_reason}
   end
 
-  defp voting_window_check(action, governance_record) do
-    action_time = fetch(action, :action_time)
-    voting_closed_at = fetch(governance_record, :voting_closed_at)
+  defp failure_reason(:authorization_valid_but_unknown_at_decision_time),
+    do: :recorded_after_decision
 
-    if DateTime.compare(action_time, voting_closed_at) == :lt do
-      {:error, :voting_window_still_open, :voting_window_check}
-    else
-      :ok
-    end
-  end
-
-  defp timelock_check(action, governance_record) do
-    action_time = fetch(action, :action_time)
-    timelock_until = fetch(governance_record, :timelock_until)
-
-    if DateTime.compare(action_time, timelock_until) == :lt do
-      {:error, :timelock_not_satisfied, :timelock_check}
-    else
-      :ok
-    end
-  end
-
-  defp authorization_valid_time_check(action, governance_record) do
-    action_time = fetch(action, :action_time)
-    authorization_valid_from = fetch(governance_record, :authorization_valid_from)
-    authorization_valid_to = fetch(governance_record, :authorization_valid_to)
-
-    cond do
-      DateTime.compare(action_time, authorization_valid_from) == :lt ->
-        {:error, :authorization_not_yet_valid, :authorization_valid_time_check}
-
-      DateTime.compare(action_time, authorization_valid_to) == :gt ->
-        {:error, :authorization_expired, :authorization_valid_time_check}
-
-      true ->
-        :ok
-    end
-  end
-
-  defp authorization_transaction_time_check(action, governance_record) do
-    decision_time = fetch(action, :decision_time)
-    authorization_recorded_at = fetch(governance_record, :authorization_recorded_at)
-
-    if DateTime.compare(authorization_recorded_at, decision_time) == :gt do
-      {:error, :authorization_valid_but_unknown_at_decision_time,
-       :authorization_transaction_time_check}
-    else
-      :ok
-    end
-  end
-
-  defp transfer_expiration_check(action, governance_record) do
-    action_time = fetch(action, :action_time)
-    transfer_expires_at = fetch(governance_record, :transfer_expires_at)
-
-    if DateTime.compare(action_time, transfer_expires_at) == :gt do
-      {:error, :transfer_expired, :transfer_expiration_check}
-    else
-      :ok
-    end
-  end
+  defp failure_reason(other), do: other
 
   defp reject(stop_reason, trace) do
     {:error,

--- a/test/web3_treasury_action_showcase_test.exs
+++ b/test/web3_treasury_action_showcase_test.exs
@@ -126,7 +126,7 @@ defmodule Pythia.Web3TreasuryActionShowcaseTest do
   test "accepted trace has exact chronological event order", ctx do
     assert {:ok, %{trace: trace}} = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
 
-    assert trace == [
+    assert Web3TreasuryAction.trace_events(trace) == [
              :proposed_action,
              :proposal_match_check,
              :permission_check,
@@ -140,11 +140,102 @@ defmodule Pythia.Web3TreasuryActionShowcaseTest do
            ]
   end
 
-  test "rejected trace ends with decision", ctx do
+  test "accepted trace has pass results for all checks and ends with accept decision", ctx do
+    assert {:ok, %{trace: trace}} = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    check_entries = Enum.slice(trace, 1, 8)
+    assert Enum.all?(check_entries, &(&1.result == :pass))
+
+    assert Enum.at(trace, 0) ==
+             %{
+               event: :proposed_action,
+               result: :observed,
+               action_id: "dao_act_001",
+               action_type: "treasury_transfer",
+               proposal_id: "prop_001",
+               actor: "agent_alpha"
+             }
+
+    assert List.last(trace) ==
+             %{event: :decision, result: :accept, stop_reason: :treasury_transfer_accepted}
+  end
+
+  test "quorum failure trace contains quorum fail map and decision reject", ctx do
+    record = %{ctx.governance_record | quorum_met: false}
+
+    assert {:error, %{trace: trace, stop_reason: :quorum_not_met}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+
+    assert Enum.at(trace, 3) ==
+             %{event: :quorum_check, result: :fail, actual: false, reason: :quorum_not_met}
+
+    assert List.last(trace) == %{event: :decision, result: :reject, stop_reason: :quorum_not_met}
+  end
+
+  test "voting window failure trace contains voting_window_check fail", ctx do
+    record = %{ctx.governance_record | voting_closed_at: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error, %{trace: trace, stop_reason: :voting_window_still_open}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+
+    assert Enum.at(trace, 4).event == :voting_window_check
+    assert Enum.at(trace, 4).result == :fail
+    assert Enum.at(trace, 4).reason == :voting_window_still_open
+  end
+
+  test "timelock failure trace contains timelock_check fail", ctx do
+    record = %{ctx.governance_record | timelock_until: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error, %{trace: trace, stop_reason: :timelock_not_satisfied}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+
+    assert Enum.at(trace, 5).event == :timelock_check
+    assert Enum.at(trace, 5).result == :fail
+    assert Enum.at(trace, 5).reason == :timelock_not_satisfied
+  end
+
+  test "authorization valid but unknown trace includes recorded_after_decision reason", ctx do
+    record = %{ctx.governance_record | authorization_recorded_at: ~U[2026-04-25 12:30:00Z]}
+
+    assert {:error,
+            %{trace: trace, stop_reason: :authorization_valid_but_unknown_at_decision_time}} =
+             Web3TreasuryAction.evaluate(ctx.action, record)
+
+    assert Enum.at(trace, 7).event == :authorization_transaction_time_check
+    assert Enum.at(trace, 7).result == :fail
+    assert Enum.at(trace, 7).reason == :recorded_after_decision
+
+    assert List.last(trace) ==
+             %{
+               event: :decision,
+               result: :reject,
+               stop_reason: :authorization_valid_but_unknown_at_decision_time
+             }
+  end
+
+  test "transfer expired trace contains transfer_expiration_check fail", ctx do
+    action = %{ctx.action | action_time: ~U[2026-04-25 12:40:00Z]}
+
+    record = %{
+      ctx.governance_record
+      | transfer_expires_at: ~U[2026-04-25 12:30:00Z],
+        authorization_valid_to: ~U[2026-04-25 13:30:00Z]
+    }
+
+    assert {:error, %{trace: trace, stop_reason: :transfer_expired}} =
+             Web3TreasuryAction.evaluate(action, record)
+
+    assert Enum.at(trace, 8).event == :transfer_expiration_check
+    assert Enum.at(trace, 8).result == :fail
+    assert Enum.at(trace, 8).reason == :transfer_expired
+  end
+
+  test "rejected traces always end with decision reject", ctx do
     action = %{ctx.action | proposal_id: "missing"}
 
     assert {:error, %{trace: trace}} = Web3TreasuryAction.evaluate(action, ctx.governance_record)
-    assert List.last(trace) == :decision
+    assert List.last(trace).event == :decision
+    assert List.last(trace).result == :reject
   end
 
   test "action_time == voting_closed_at is accepted for voting window", ctx do

--- a/test/web3_treasury_action_showcase_test.exs
+++ b/test/web3_treasury_action_showcase_test.exs
@@ -238,6 +238,14 @@ defmodule Pythia.Web3TreasuryActionShowcaseTest do
     assert List.last(trace).result == :reject
   end
 
+  test "rejected trace entries always use atom events", ctx do
+    record = %{ctx.governance_record | quorum_met: false}
+
+    assert {:error, %{trace: trace}} = Web3TreasuryAction.evaluate(ctx.action, record)
+
+    assert Enum.all?(trace, fn entry -> is_atom(entry.event) end)
+  end
+
   test "action_time == voting_closed_at is accepted for voting window", ctx do
     action = %{ctx.action | action_time: ctx.governance_record.voting_closed_at}
     voting_closed_at = ctx.governance_record.voting_closed_at


### PR DESCRIPTION
### Motivation

- Replace the atom-only event trace with a replayable, audit-friendly decision trace that records what was checked, the observed values, pass/fail results, and why a decision stopped. 
- Make the Web3 Treasury Action Showcase suitable for grants, DAO governance, security review and future tooling that requires explainable, chronological reasoning.

### Description

- Replace the simple atom trace with chronological map entries (including `event`, `result`, optional `reason`, and relevant `expected`/`actual` or timestamps) in `Pythia.Showcase.Web3TreasuryAction` and preserve existing `stop_reason` values.  
- Add helper machinery: `run_checks/3`, `run_check/3` per check, `proposed_action_trace/1`, `check_trace/3`, `decision_trace/2`, `failure_reason/1`, and `trace_events/1` to extract event order.  
- Update tests in `test/web3_treasury_action_showcase_test.exs` to assert exact chronological event order, pass/fail semantics per check, specific failure reasons, deterministic output, and final decision map shapes.  
- Update example script `examples/web3_treasury_action_showcase.exs`, docs `docs/web3_treasury_action_showcase.md`, and README to show/describe the compact structured trace output.

### Testing

- `mix format lib/pythia/showcase/web3_treasury_action.ex examples/web3_treasury_action_showcase.exs test/web3_treasury_action_showcase_test.exs` completed successfully.  
- `mix compile` could not complete because the environment could not fetch Hex dependencies (SSL/HTTP 403 while attempting `mix deps.get`), so compilation was not performed.  
- `mix test` could not be executed for the same reason (missing dependencies / `rustler` SCM unresolved), so test run results are pending in an environment with network/Hex access.  
- Example runs (`mix run examples/...`) were attempted but failed for the same dependency/Hex fetch issue; unit tests and example outputs should pass when run in an environment that can fetch dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf6bc22ac832d8708645cc39aef64)