### PR TITLE
Add Web3 treasury trace export

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,8 @@ The demo shows how a proposed treasury transfer can be accepted or rejected base
 This demonstrates the Web3 Consensus Reason Layer roadmap without requiring smart contracts, wallets, RPC nodes, or chain adapters.
 
 The result includes a structured chronological trace explaining which governance check passed or failed.
+The structured trace can also be exported as a deterministic JSON-ready audit artifact.
+
+```bash
+mix run examples/web3_treasury_trace_export.exs
+```

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -53,6 +53,20 @@ Example:
 
 This makes the showcase useful not only as a demo, but as an audit-oriented explanation of why a treasury transfer was accepted or rejected.
 
+## JSON trace export
+
+The Web3 Treasury Action Showcase can export structured traces as deterministic maps suitable for JSON encoding.
+
+This makes traces easier to:
+
+- attach to audits
+- include in grant demos
+- share with DAO governance teams
+- inspect in external tools
+- compare across runs
+
+If JSON encoding is available, the showcase can also print JSON output.
+
 ## How to run
 
 ```bash

--- a/examples/web3_treasury_trace_export.exs
+++ b/examples/web3_treasury_trace_export.exs
@@ -1,0 +1,54 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+
+rejected_result =
+  Web3TreasuryAction.evaluate(base_action, %{base_governance_record | quorum_met: false})
+
+accepted_export = Web3TreasuryAction.export_result(accepted_result)
+rejected_export = Web3TreasuryAction.export_result(rejected_result)
+
+IO.puts("Web3 Treasury Trace Export\n")
+
+IO.puts("Accepted export:")
+IO.inspect(accepted_export, pretty: true)
+
+IO.puts("\nRejected export:")
+IO.inspect(rejected_export, pretty: true)
+
+if function_exported?(Web3TreasuryAction, :export_result_json, 1) do
+  {:ok, accepted_json} = Web3TreasuryAction.export_result_json(accepted_result)
+  {:ok, rejected_json} = Web3TreasuryAction.export_result_json(rejected_result)
+
+  IO.puts("\nAccepted JSON export:")
+  IO.puts(accepted_json)
+
+  IO.puts("\nRejected JSON export:")
+  IO.puts(rejected_json)
+end

--- a/examples/web3_treasury_trace_export.exs
+++ b/examples/web3_treasury_trace_export.exs
@@ -43,12 +43,17 @@ IO.puts("\nRejected export:")
 IO.inspect(rejected_export, pretty: true)
 
 if function_exported?(Web3TreasuryAction, :export_result_json, 1) do
-  {:ok, accepted_json} = Web3TreasuryAction.export_result_json(accepted_result)
-  {:ok, rejected_json} = Web3TreasuryAction.export_result_json(rejected_result)
+  case Web3TreasuryAction.export_result_json(accepted_result) do
+    {:ok, accepted_json} ->
+      {:ok, rejected_json} = Web3TreasuryAction.export_result_json(rejected_result)
 
-  IO.puts("\nAccepted JSON export:")
-  IO.puts(accepted_json)
+      IO.puts("\nAccepted JSON export:")
+      IO.puts(accepted_json)
 
-  IO.puts("\nRejected JSON export:")
-  IO.puts(rejected_json)
+      IO.puts("\nRejected JSON export:")
+      IO.puts(rejected_json)
+
+    {:error, :json_encoder_unavailable} ->
+      IO.puts("\nJSON export skipped: json_encoder_unavailable")
+  end
 end

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -74,10 +74,16 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     |> ensure_export_status()
   end
 
-  @spec export_result_json({:ok, map()} | {:error, map()}) :: {:ok, String.t()}
+  @spec export_result_json({:ok, map()} | {:error, map()}) ::
+          {:ok, String.t()} | {:error, :json_encoder_unavailable}
   def export_result_json(result) do
     export = export_result(result)
-    {:ok, Jason.encode!(export, pretty: true)}
+
+    if Code.ensure_loaded?(Jason) and function_exported?(Jason, :encode!, 2) do
+      {:ok, apply(Jason, :encode!, [export, [pretty: true]])}
+    else
+      {:error, :json_encoder_unavailable}
+    end
   end
 
   defp ensure_export_status(export) do
@@ -100,6 +106,12 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
 
+  defp normalize_value(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> normalize_value()
+  end
+
   defp normalize_value(value) when is_map(value) do
     value
     |> Enum.map(fn {key, item} -> {normalize_key(key), normalize_value(item)} end)
@@ -112,12 +124,6 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   defp normalize_value(value)
        when is_binary(value) or is_boolean(value) or is_number(value) or is_nil(value),
        do: value
-
-  defp normalize_value(%_{} = struct) do
-    struct
-    |> Map.from_struct()
-    |> normalize_value()
-  end
 
   defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
   defp normalize_key(key) when is_binary(key), do: key

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -26,8 +26,6 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     :transfer_expiration_check
   ]
 
-  @accepted_events [:proposed_action | @check_order] ++ [:decision]
-
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
     proposed_trace = [proposed_action_trace(action)]

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -101,6 +101,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     }
   end
 
+  defp normalize_value(value) when is_boolean(value) or is_nil(value), do: value
   defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
 
@@ -119,9 +120,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
 
   defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
 
-  defp normalize_value(value)
-       when is_binary(value) or is_boolean(value) or is_number(value) or is_nil(value),
-       do: value
+  defp normalize_value(value) when is_binary(value) or is_number(value), do: value
 
   defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
   defp normalize_key(key) when is_binary(key), do: key

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -67,6 +67,62 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   @spec trace_events([map()]) :: [atom()]
   def trace_events(trace), do: Enum.map(trace, & &1.event)
 
+  @spec export_result({:ok, map()} | {:error, map()}) :: map()
+  def export_result({status, payload}) when status in [:ok, :error] and is_map(payload) do
+    payload
+    |> normalize_value()
+    |> ensure_export_status()
+  end
+
+  @spec export_result_json({:ok, map()} | {:error, map()}) :: {:ok, String.t()}
+  def export_result_json(result) do
+    export = export_result(result)
+    {:ok, Jason.encode!(export, pretty: true)}
+  end
+
+  defp ensure_export_status(export) do
+    status =
+      case Map.get(export, "status") do
+        "accepted" -> "accepted"
+        _ -> "rejected"
+      end
+
+    stop_reason = Map.get(export, "stop_reason")
+    trace = Map.get(export, "trace", [])
+
+    %{
+      "status" => status,
+      "stop_reason" => stop_reason,
+      "trace" => trace
+    }
+  end
+
+  defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+
+  defp normalize_value(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, item} -> {normalize_key(key), normalize_value(item)} end)
+    |> Enum.sort_by(fn {key, _item} -> key end)
+    |> Map.new()
+  end
+
+  defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
+
+  defp normalize_value(value)
+       when is_binary(value) or is_boolean(value) or is_number(value) or is_nil(value),
+       do: value
+
+  defp normalize_value(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> normalize_value()
+  end
+
+  defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_key(key) when is_binary(key), do: key
+  defp normalize_key(key), do: to_string(key)
+
   defp run_checks(action, governance_record, trace) do
     Enum.reduce_while(@check_order, {:ok, trace}, fn check, {:ok, acc_trace} ->
       case run_check(check, action, governance_record) do

--- a/test/web3_treasury_trace_export_test.exs
+++ b/test/web3_treasury_trace_export_test.exs
@@ -82,12 +82,17 @@ defmodule Pythia.Web3TreasuryTraceExportTest do
     assert first == second
   end
 
-  test "export_result_json/1 returns {:ok, json} and includes key fields", ctx do
+  test "export_result_json/1 handles available and unavailable json encoder", ctx do
     accepted_result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    json_result = Web3TreasuryAction.export_result_json(accepted_result)
 
-    assert {:ok, json} = Web3TreasuryAction.export_result_json(accepted_result)
-    assert is_binary(json)
-    assert String.contains?(json, "treasury_transfer_accepted")
-    assert String.contains?(json, "proposed_action")
+    if Code.ensure_loaded?(Jason) and function_exported?(Jason, :encode!, 2) do
+      assert {:ok, json} = json_result
+      assert is_binary(json)
+      assert String.contains?(json, "treasury_transfer_accepted")
+      assert String.contains?(json, "proposed_action")
+    else
+      assert {:error, :json_encoder_unavailable} = json_result
+    end
   end
 end

--- a/test/web3_treasury_trace_export_test.exs
+++ b/test/web3_treasury_trace_export_test.exs
@@ -1,0 +1,93 @@
+defmodule Pythia.Web3TreasuryTraceExportTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "export_result/1 converts accepted result into string-key map", ctx do
+    accepted_result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    exported = Web3TreasuryAction.export_result(accepted_result)
+
+    assert exported["status"] == "accepted"
+    assert exported["stop_reason"] == "treasury_transfer_accepted"
+    assert is_list(exported["trace"])
+    assert hd(exported["trace"])["event"] == "proposed_action"
+    assert List.last(exported["trace"])["event"] == "decision"
+    assert List.last(exported["trace"])["stop_reason"] == "treasury_transfer_accepted"
+  end
+
+  test "export_result/1 converts rejected result into string-key map", ctx do
+    rejected_result =
+      Web3TreasuryAction.evaluate(ctx.action, %{ctx.governance_record | quorum_met: false})
+
+    exported = Web3TreasuryAction.export_result(rejected_result)
+
+    assert exported["status"] == "rejected"
+    assert exported["stop_reason"] == "quorum_not_met"
+
+    quorum_entry = Enum.find(exported["trace"], fn entry -> entry["event"] == "quorum_check" end)
+
+    assert quorum_entry["event"] == "quorum_check"
+    assert quorum_entry["result"] == "fail"
+    assert quorum_entry["reason"] == "quorum_not_met"
+    assert quorum_entry["actual"] == false
+  end
+
+  test "DateTime values are converted to ISO8601 strings", ctx do
+    accepted_result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    exported = Web3TreasuryAction.export_result(accepted_result)
+
+    voting_entry =
+      Enum.find(exported["trace"], fn entry -> entry["event"] == "voting_window_check" end)
+
+    assert is_binary(voting_entry["action_time"])
+    assert voting_entry["action_time"] == "2026-04-25T12:00:00Z"
+  end
+
+  test "output is deterministic", ctx do
+    accepted_result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    first = Web3TreasuryAction.export_result(accepted_result)
+    second = Web3TreasuryAction.export_result(accepted_result)
+
+    assert first == second
+  end
+
+  test "export_result_json/1 returns {:ok, json} and includes key fields", ctx do
+    accepted_result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    assert {:ok, json} = Web3TreasuryAction.export_result_json(accepted_result)
+    assert is_binary(json)
+    assert String.contains?(json, "treasury_transfer_accepted")
+    assert String.contains?(json, "proposed_action")
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide a deterministic, JSON-ready audit artifact for the Web3 Treasury Action Showcase so structured decision traces can be shared with auditors, grant reviewers, DAOs, and security teams.
- Keep the change dependency-free where possible and reuse the existing JSON library when available to avoid adding new external deps.

### Description
- Added `export_result/1` to `Pythia.Showcase.Web3TreasuryAction` which normalizes results into a deterministic string-key map and recursively converts atoms to strings and `DateTime` to ISO8601 strings.
- Added `export_result_json/1` which uses the existing `Jason` dependency (present in `mix.exs`) to return `{:ok, json_string}` for pretty JSON output.
- Implemented normalization helpers (`normalize_value/1`, `normalize_key/1`, `ensure_export_status/1`) and kept exports deterministic by sorting map keys.
- Added example `examples/web3_treasury_trace_export.exs`, test file `test/web3_treasury_trace_export_test.exs`, and documentation updates in `docs/web3_treasury_action_showcase.md` and `README.md` describing the JSON trace export and how to run the example.

### Testing
- Ran `mix format` on the modified files which completed successfully.
- Added automated tests in `test/web3_treasury_trace_export_test.exs` that validate accepted/rejected export shapes, `DateTime` → ISO8601 conversion, determinism, and the `export_result_json/1` helper.
- Attempted `mix compile`, `mix test`, and running the example via `mix run` but these were blocked by the environment's inability to fetch Hex dependencies (SSL/HTTP 403), so compilation and test execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0c443400832dad6907cf41960925)