### PR TITLE
Add Web3 treasury trace evidence digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,9 @@ The structured trace can also be exported as a deterministic JSON-ready audit ar
 ```bash
 mix run examples/web3_treasury_trace_export.exs
 ```
+
+The exported trace can also be wrapped into a SHA-256 evidence artifact:
+
+```bash
+mix run examples/web3_treasury_trace_evidence.exs
+```

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -67,6 +67,27 @@ This makes traces easier to:
 
 If JSON encoding is available, the showcase can also print JSON output.
 
+## Evidence digest
+
+The exported trace can be wrapped into an evidence artifact with a SHA-256 digest.
+
+This allows external reviewers to verify that a trace artifact has not changed.
+
+The digest is computed over a deterministic canonical representation of the exported trace.
+
+Example evidence shape:
+
+```elixir
+%{
+  "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
+  "algorithm" => "sha256",
+  "digest" => "...",
+  "payload" => %{...}
+}
+```
+
+This is not a digital signature yet. It is a deterministic fingerprint of the decision artifact.
+
 ## How to run
 
 ```bash
@@ -80,6 +101,18 @@ This showcase demonstrates the first in-memory Web3 application of the Web3 Cons
 It does not add smart contracts, wallets, RPC calls, indexers, or chain adapters.
 
 It shows how PythiaLabs could reason about DAO treasury safety before any on-chain execution.
+
+## Non-goals in this stage
+
+This PR does not add:
+
+- digital signatures
+- key management
+- blockchain anchoring
+- IPFS/Arweave upload
+- smart contracts
+- wallet integration
+- persistence
 
 ## Relation to existing showcases
 

--- a/examples/web3_treasury_trace_evidence.exs
+++ b/examples/web3_treasury_trace_evidence.exs
@@ -1,0 +1,50 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+
+rejected_result =
+  Web3TreasuryAction.evaluate(base_action, %{base_governance_record | quorum_met: false})
+
+accepted_evidence = Web3TreasuryAction.export_evidence(accepted_result)
+rejected_evidence = Web3TreasuryAction.export_evidence(rejected_result)
+
+print_evidence = fn label, evidence ->
+  payload = evidence["payload"]
+
+  IO.puts("\n#{label}:")
+  IO.puts("Artifact type: #{evidence["artifact_type"]}")
+  IO.puts("Algorithm: #{evidence["algorithm"]}")
+  IO.puts("Digest: #{evidence["digest"]}")
+  IO.puts("Status: #{payload["status"]}")
+  IO.puts("Stop reason: #{payload["stop_reason"]}")
+end
+
+IO.puts("Web3 Treasury Trace Evidence")
+print_evidence.("Accepted evidence", accepted_evidence)
+print_evidence.("Rejected evidence", rejected_evidence)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -84,6 +84,40 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     end
   end
 
+  @spec canonical_export_string({:ok, map()} | {:error, map()}) :: String.t()
+  def canonical_export_string(result) do
+    result
+    |> export_result()
+    |> canonical_encode()
+  end
+
+  @spec export_digest({:ok, map()} | {:error, map()}) :: map()
+  def export_digest(result) do
+    digest =
+      result
+      |> canonical_export_string()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    %{
+      "algorithm" => "sha256",
+      "digest" => digest
+    }
+  end
+
+  @spec export_evidence({:ok, map()} | {:error, map()}) :: map()
+  def export_evidence(result) do
+    payload = export_result(result)
+    digest = export_digest(result)
+
+    %{
+      "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
+      "algorithm" => digest["algorithm"],
+      "digest" => digest["digest"],
+      "payload" => payload
+    }
+  end
+
   defp ensure_export_status(export) do
     status =
       case Map.get(export, "status") do
@@ -125,6 +159,39 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
   defp normalize_key(key) when is_binary(key), do: key
   defp normalize_key(key), do: to_string(key)
+
+  defp canonical_encode(value) when is_map(value) do
+    body =
+      value
+      |> Enum.sort_by(fn {key, _value} -> key end)
+      |> Enum.map_join(",", fn {key, item} ->
+        canonical_encode(to_string(key)) <> ":" <> canonical_encode(item)
+      end)
+
+    "{" <> body <> "}"
+  end
+
+  defp canonical_encode(value) when is_list(value) do
+    "[" <> Enum.map_join(value, ",", &canonical_encode/1) <> "]"
+  end
+
+  defp canonical_encode(value) when is_binary(value) do
+    "\"" <> escape_string(value) <> "\""
+  end
+
+  defp canonical_encode(value) when is_number(value), do: to_string(value)
+  defp canonical_encode(true), do: "true"
+  defp canonical_encode(false), do: "false"
+  defp canonical_encode(nil), do: "null"
+
+  defp escape_string(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\"", "\\\"")
+    |> String.replace("\n", "\\n")
+    |> String.replace("\r", "\\r")
+    |> String.replace("\t", "\\t")
+  end
 
   defp run_checks(action, governance_record, trace) do
     Enum.reduce_while(@check_order, {:ok, trace}, fn check, {:ok, acc_trace} ->

--- a/test/web3_treasury_trace_evidence_test.exs
+++ b/test/web3_treasury_trace_evidence_test.exs
@@ -1,0 +1,118 @@
+defmodule Pythia.Web3TreasuryTraceEvidenceTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "export_digest/1 returns SHA-256 metadata", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    digest = Web3TreasuryAction.export_digest(result)
+
+    assert digest["algorithm"] == "sha256"
+    assert is_binary(digest["digest"])
+    assert String.length(digest["digest"]) == 64
+    assert digest["digest"] =~ ~r/\A[0-9a-f]{64}\z/
+  end
+
+  test "export_evidence/1 returns payload + digest", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    evidence = Web3TreasuryAction.export_evidence(result)
+
+    assert evidence["artifact_type"] == "pythia.web3_treasury_action.decision_trace.v1"
+    assert evidence["algorithm"] == "sha256"
+    assert is_binary(evidence["digest"])
+    assert evidence["payload"] == Web3TreasuryAction.export_result(result)
+  end
+
+  test "digest is deterministic for same accepted result", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    first = Web3TreasuryAction.export_digest(result)
+    second = Web3TreasuryAction.export_digest(result)
+
+    assert first == second
+  end
+
+  test "digest changes when decision changes", ctx do
+    accepted = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    rejected =
+      Web3TreasuryAction.evaluate(ctx.action, %{ctx.governance_record | quorum_met: false})
+
+    assert Web3TreasuryAction.export_digest(accepted)["digest"] !=
+             Web3TreasuryAction.export_digest(rejected)["digest"]
+  end
+
+  test "canonical map key order is stable" do
+    first =
+      {:ok,
+       %{
+         status: :accepted,
+         stop_reason: :treasury_transfer_accepted,
+         trace: [%{event: :decision, result: :accept, reason: "x"}],
+         metadata: %{"b" => 2, "a" => 1}
+       }}
+
+    second =
+      {:ok,
+       %{
+         metadata: %{"a" => 1, "b" => 2},
+         trace: [%{result: :accept, reason: "x", event: :decision}],
+         stop_reason: :treasury_transfer_accepted,
+         status: :accepted
+       }}
+
+    assert Web3TreasuryAction.canonical_export_string(first) ==
+             Web3TreasuryAction.canonical_export_string(second)
+  end
+
+  test "canonical encoder preserves booleans in rejected payload", ctx do
+    rejected =
+      Web3TreasuryAction.evaluate(ctx.action, %{ctx.governance_record | quorum_met: false})
+
+    payload = Web3TreasuryAction.export_evidence(rejected)["payload"]
+
+    quorum_entry = Enum.find(payload["trace"], fn entry -> entry["event"] == "quorum_check" end)
+
+    assert quorum_entry["actual"] == false
+  end
+
+  test "canonical_export_string/1 returns stable binary fields", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    canonical = Web3TreasuryAction.canonical_export_string(result)
+
+    assert is_binary(canonical)
+    assert String.contains?(canonical, "\"status\"")
+    assert String.contains?(canonical, "\"trace\"")
+    assert String.contains?(canonical, "\"stop_reason\"")
+  end
+end

--- a/test/web3_treasury_trace_evidence_test.exs
+++ b/test/web3_treasury_trace_evidence_test.exs
@@ -78,15 +78,27 @@ defmodule Pythia.Web3TreasuryTraceEvidenceTest do
        %{
          status: :accepted,
          stop_reason: :treasury_transfer_accepted,
-         trace: [%{event: :decision, result: :accept, reason: "x"}],
-         metadata: %{"b" => 2, "a" => 1}
+         trace: [
+           %{
+             event: :decision,
+             result: :accept,
+             reason: "x",
+             context: %{"z" => 3, "a" => 1, "m" => 2}
+           }
+         ]
        }}
 
     second =
       {:ok,
        %{
-         metadata: %{"a" => 1, "b" => 2},
-         trace: [%{result: :accept, reason: "x", event: :decision}],
+         trace: [
+           %{
+             result: :accept,
+             reason: "x",
+             event: :decision,
+             context: %{"m" => 2, "a" => 1, "z" => 3}
+           }
+         ],
          stop_reason: :treasury_transfer_accepted,
          status: :accepted
        }}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, verifiable fingerprint (SHA-256) for the JSON-ready Web3 Treasury Action decision trace export so reviewers can detect any artifact changes.
- Prepare a minimal evidence artifact shape that will later enable signing and anchoring, while avoiding any blockchain, key management, or external dependency changes in this step.

### Description

- Adds public APIs `canonical_export_string/1`, `export_digest/1`, and `export_evidence/1` to `lib/pythia/showcase/web3_treasury_action.ex` for canonical serialization, SHA-256 digest computation (using `:crypto.hash/2` and `Base.encode16(case: :lower)`), and evidence artifact wrapping.
- Implements a small deterministic canonical encoder (`canonical_encode/1`) for the export shape that supports maps with string keys (sorted), lists, strings (with basic escaping), numbers, booleans, and `nil` so the digest is stable across equivalent maps.
- Adds an example script at `examples/web3_treasury_trace_evidence.exs` that runs accepted and rejected scenarios and prints `artifact_type`, `algorithm`, `digest`, `status`, and `stop_reason` for both outputs.
- Adds test suite `test/web3_treasury_trace_evidence_test.exs` covering digest metadata shape, evidence payload contents, digest determinism, digest changes when decisions differ, canonical map key order stability, boolean preservation, and canonical string field presence, and updates `docs/web3_treasury_action_showcase.md` and `README.md` with an Evidence digest section and non-goals.

### Testing

- Ran `mix format` on the modified files and formatting completed successfully.
- `mix compile` and `mix test` were attempted but blocked in this environment due to Hex installation/network errors and dependency resolution for `:rustler`, so compilation and test execution could not complete here.
- `mix run examples/web3_treasury_trace_evidence.exs` and the existing example runs were attempted but also blocked for the same dependency/Hex network issue.
- Commit created with message `feat: add web3 treasury trace evidence digest` and changes include the modified `lib/pythia/showcase/web3_treasury_action.ex`, new `examples/web3_treasury_trace_evidence.exs`, new `test/web3_treasury_trace_evidence_test.exs`, and updated `docs/web3_treasury_action_showcase.md` and `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed13ead508832d9d7ba3c8066b2290)