### PR TITLE
Add Web3 treasury evidence verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,9 @@ The exported trace can also be wrapped into a SHA-256 evidence artifact:
 ```bash
 mix run examples/web3_treasury_trace_evidence.exs
 ```
+
+Evidence artifacts can also be verified locally:
+
+```bash
+mix run examples/web3_treasury_trace_verify.exs
+```

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -88,6 +88,23 @@ Example evidence shape:
 
 This is not a digital signature yet. It is a deterministic fingerprint of the decision artifact.
 
+## Evidence verification
+
+Evidence artifacts can be verified by recomputing the SHA-256 digest over the canonical payload.
+
+This allows external reviewers to detect whether the exported trace payload has changed.
+
+Verification can detect:
+
+- payload tampering
+- digest mismatch
+- unsupported artifact type
+- unsupported algorithm
+- malformed evidence shape
+
+This is still not a digital signature.
+It verifies artifact integrity, not authorship.
+
 ## How to run
 
 ```bash
@@ -108,6 +125,7 @@ This PR does not add:
 
 - digital signatures
 - key management
+- identity verification
 - blockchain anchoring
 - IPFS/Arweave upload
 - smart contracts

--- a/examples/web3_treasury_trace_verify.exs
+++ b/examples/web3_treasury_trace_verify.exs
@@ -1,0 +1,50 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+accepted_evidence = Web3TreasuryAction.export_evidence(accepted_result)
+
+tampered_evidence = put_in(accepted_evidence, ["payload", "stop_reason"], "tampered_stop_reason")
+
+print_result = fn label, verification_result ->
+  IO.puts("\n#{label}:")
+
+  case verification_result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Digest: #{payload.digest}")
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Reason: #{payload.reason}")
+  end
+end
+
+IO.puts("Web3 Treasury Trace Verification")
+print_result.("Valid evidence", Web3TreasuryAction.verify_evidence(accepted_evidence))
+print_result.("Tampered evidence", Web3TreasuryAction.verify_evidence(tampered_evidence))

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -108,7 +108,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   @spec export_evidence({:ok, map()} | {:error, map()}) :: map()
   def export_evidence(result) do
     payload = export_result(result)
-    digest = export_digest(result)
+    digest = digest_export_payload(payload)
 
     %{
       "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
@@ -117,6 +117,62 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       "payload" => payload
     }
   end
+
+  @spec digest_export_payload(map()) :: map()
+  def digest_export_payload(payload) when is_map(payload) do
+    digest =
+      payload
+      |> canonical_encode()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    %{
+      "algorithm" => "sha256",
+      "digest" => digest
+    }
+  end
+
+  @spec verify_evidence(map()) :: {:ok, map()} | {:error, map()}
+  def verify_evidence(evidence) when is_map(evidence) do
+    artifact_type = Map.get(evidence, "artifact_type")
+    algorithm = Map.get(evidence, "algorithm")
+    digest = Map.get(evidence, "digest")
+    payload = Map.get(evidence, "payload")
+
+    cond do
+      not valid_evidence_shape?(artifact_type, algorithm, digest, payload) ->
+        invalid_evidence_shape()
+
+      artifact_type != "pythia.web3_treasury_action.decision_trace.v1" ->
+        rejected(:unsupported_artifact_type)
+
+      algorithm != "sha256" ->
+        rejected(:unsupported_algorithm)
+
+      true ->
+        actual_digest = digest_export_payload(payload)["digest"]
+
+        if digest == actual_digest do
+          {:ok,
+           %{
+             status: :verified,
+             artifact_type: artifact_type,
+             algorithm: algorithm,
+             digest: digest
+           }}
+        else
+          {:error,
+           %{
+             status: :rejected,
+             reason: :digest_mismatch,
+             expected_digest: digest,
+             actual_digest: actual_digest
+           }}
+        end
+    end
+  end
+
+  def verify_evidence(_evidence), do: invalid_evidence_shape()
 
   defp ensure_export_status(export) do
     status =
@@ -134,6 +190,18 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       "trace" => trace
     }
   end
+
+  defp valid_evidence_shape?(artifact_type, algorithm, digest, payload) do
+    is_binary(artifact_type) and is_binary(algorithm) and is_map(payload) and
+      valid_digest?(digest)
+  end
+
+  defp valid_digest?(digest),
+    do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)
+
+  defp invalid_evidence_shape(), do: rejected(:invalid_evidence_shape)
+
+  defp rejected(reason), do: {:error, %{status: :rejected, reason: reason}}
 
   defp normalize_value(value) when is_boolean(value) or is_nil(value), do: value
   defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)

--- a/test/web3_treasury_trace_verification_test.exs
+++ b/test/web3_treasury_trace_verification_test.exs
@@ -1,0 +1,150 @@
+defmodule Pythia.Web3TreasuryTraceVerificationTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "valid evidence verifies successfully", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+
+    assert {:ok, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :verified
+    assert verification.artifact_type == "pythia.web3_treasury_action.decision_trace.v1"
+    assert verification.algorithm == "sha256"
+    assert verification.digest == evidence["digest"]
+  end
+
+  test "tampered payload returns digest_mismatch", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+
+    tampered = put_in(evidence, ["payload", "stop_reason"], "tampered_stop_reason")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(tampered)
+    assert verification.status == :rejected
+    assert verification.reason == :digest_mismatch
+    assert verification.expected_digest == tampered["digest"]
+    assert verification.actual_digest != tampered["digest"]
+  end
+
+  test "unsupported artifact type returns unsupported_artifact_type", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+      |> Map.put("artifact_type", "pythia.other_artifact.v1")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_artifact_type
+  end
+
+  test "unsupported algorithm returns unsupported_algorithm", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+      |> Map.put("algorithm", "sha512")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_algorithm
+  end
+
+  test "missing digest returns invalid_evidence_shape", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+      |> Map.delete("digest")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :rejected
+    assert verification.reason == :invalid_evidence_shape
+  end
+
+  test "missing payload returns invalid_evidence_shape", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+      |> Map.delete("payload")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :rejected
+    assert verification.reason == :invalid_evidence_shape
+  end
+
+  test "invalid digest format returns invalid_evidence_shape", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+      |> Map.put("digest", "INVALID_DIGEST")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence(evidence)
+    assert verification.status == :rejected
+    assert verification.reason == :invalid_evidence_shape
+  end
+
+  test "verification is deterministic", ctx do
+    evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence()
+
+    first = Web3TreasuryAction.verify_evidence(evidence)
+    second = Web3TreasuryAction.verify_evidence(evidence)
+
+    assert first == second
+  end
+
+  test "digest verification preserves booleans", ctx do
+    rejected_evidence =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(%{ctx.governance_record | quorum_met: false})
+      |> Web3TreasuryAction.export_evidence()
+
+    assert {:ok, _verification} = Web3TreasuryAction.verify_evidence(rejected_evidence)
+
+    quorum_entry =
+      rejected_evidence["payload"]["trace"]
+      |> Enum.find(fn entry -> entry["event"] == "quorum_check" end)
+
+    assert quorum_entry["actual"] == false
+  end
+end


### PR DESCRIPTION
### Motivation

- Make evidence digests produced by the Web3 Treasury Action useful by allowing reviewers to deterministically verify that an exported evidence payload has not been modified. 
- Provide an integrity-only verifier as a precursor to future steps (signatures, key management, anchoring) without adding any external dependencies or persistence.

### Description

- Adds `verify_evidence/1` to `Pythia.Showcase.Web3TreasuryAction` which validates evidence shape, artifact type, algorithm, digest format, and payload integrity and returns `{:ok, ...}` or `{:error, ...}` result maps. 
- Adds `digest_export_payload/1` which computes a SHA-256 digest over `canonical_encode(payload)` and is used by `export_evidence/1` so exported artifacts and verification use the same canonical digest method. 
- Adds an example `examples/web3_treasury_trace_verify.exs` that verifies a valid evidence artifact, tampers the payload, and shows the verification result for the tampered artifact. 
- Adds comprehensive tests in `test/web3_treasury_trace_verification_test.exs` covering valid evidence, tampering (`:digest_mismatch`), unsupported artifact type, unsupported algorithm, malformed evidence shape cases, deterministic verification, and boolean preservation; updates `docs/web3_treasury_action_showcase.md` and `README.md` to document verification and non-goals.

### Testing

- `mix format` was run against changed files (`lib/pythia/showcase/web3_treasury_action.ex`, `examples/web3_treasury_trace_verify.exs`, `test/web3_treasury_trace_verification_test.exs`) and succeeded. 
- `mix deps.get`, `mix compile`, and `mix test` could not be completed in this environment because `mix` cannot fetch Hex dependencies (SSL/HTTP 403 to Hex), so the new test suite was added but could not be executed here. 
- Example runs (`mix run examples/web3_treasury_trace_verify.exs`, `mix run examples/web3_treasury_trace_evidence.exs`, etc.) were not executed due to the same dependency fetching restriction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1a2a09e8832dba17ce409a7b72df)