### PR TITLE
Add signature-ready Web3 treasury evidence envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,9 @@ Evidence artifacts can also be verified locally:
 ```bash
 mix run examples/web3_treasury_trace_verify.exs
 ```
+
+Evidence can also be wrapped into a signature-ready envelope:
+
+```bash
+mix run examples/web3_treasury_evidence_envelope.exs
+```

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -138,7 +138,7 @@ It shows how PythiaLabs could reason about DAO treasury safety before any on-cha
 
 ## Non-goals in this stage
 
-This PR does not add:
+This stage does not add:
 
 - digital signatures
 - key management

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -105,6 +105,23 @@ Verification can detect:
 This is still not a digital signature.
 It verifies artifact integrity, not authorship.
 
+## Signature-ready evidence envelope
+
+Evidence can also be wrapped into a deterministic envelope with:
+
+- `schema`
+- `artifact_type`
+- `canonicalization` method
+- integrity digest metadata
+- `payload`
+- unsigned signature placeholder
+
+This prepares the artifact for future signed evidence without adding keys or signatures yet.
+
+The current signature status is always `unsigned`.
+
+This stage verifies integrity, not authorship.
+
 ## How to run
 
 ```bash
@@ -125,6 +142,7 @@ This PR does not add:
 
 - digital signatures
 - key management
+- public/private keys
 - identity verification
 - blockchain anchoring
 - IPFS/Arweave upload

--- a/examples/web3_treasury_evidence_envelope.exs
+++ b/examples/web3_treasury_evidence_envelope.exs
@@ -1,0 +1,65 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+envelope = Web3TreasuryAction.export_evidence_envelope(accepted_result)
+tampered_envelope = put_in(envelope, ["payload", "stop_reason"], "tampered_stop_reason")
+
+print_verification = fn label, verification_result ->
+  IO.puts("\n#{label}:")
+
+  case verification_result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Integrity: #{payload.integrity}")
+      IO.puts("Signature: #{payload.signature}")
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Reason: #{payload.reason}")
+  end
+end
+
+IO.puts("Web3 Treasury Evidence Envelope")
+IO.puts("\nEnvelope:")
+IO.puts("Schema: #{envelope["schema"]}")
+IO.puts("Artifact type: #{envelope["artifact_type"]}")
+IO.puts("Canonicalization: #{envelope["canonicalization"]}")
+IO.puts("Integrity algorithm: #{envelope["integrity"]["algorithm"]}")
+IO.puts("Digest: #{envelope["integrity"]["digest"]}")
+IO.puts("Signature status: #{envelope["signature"]["status"]}")
+
+print_verification.(
+  "Valid envelope verification",
+  Web3TreasuryAction.verify_evidence_envelope(envelope)
+)
+
+print_verification.(
+  "Tampered envelope verification",
+  Web3TreasuryAction.verify_evidence_envelope(tampered_envelope)
+)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -174,6 +174,92 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
 
   def verify_evidence(_evidence), do: invalid_evidence_shape()
 
+  @spec export_evidence_envelope({:ok, map()} | {:error, map()}) :: map()
+  def export_evidence_envelope(result) do
+    payload = export_result(result)
+    digest = digest_export_payload(payload)
+
+    %{
+      "schema" => "pythia.evidence.envelope.v1",
+      "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
+      "canonicalization" => "pythia.canonical_export.v1",
+      "integrity" => %{
+        "algorithm" => digest["algorithm"],
+        "digest" => digest["digest"]
+      },
+      "payload" => payload,
+      "signature" => %{
+        "status" => "unsigned",
+        "algorithm" => nil,
+        "public_key" => nil,
+        "signature" => nil
+      }
+    }
+  end
+
+  @spec verify_evidence_envelope(map()) :: {:ok, map()} | {:error, map()}
+  def verify_evidence_envelope(envelope) when is_map(envelope) do
+    schema = Map.get(envelope, "schema")
+    artifact_type = Map.get(envelope, "artifact_type")
+    canonicalization = Map.get(envelope, "canonicalization")
+    integrity = Map.get(envelope, "integrity")
+    payload = Map.get(envelope, "payload")
+    signature = Map.get(envelope, "signature")
+
+    cond do
+      not valid_envelope_shape?(
+        schema,
+        artifact_type,
+        canonicalization,
+        integrity,
+        payload,
+        signature
+      ) ->
+        rejected(:invalid_envelope_shape)
+
+      schema != "pythia.evidence.envelope.v1" ->
+        rejected(:unsupported_schema)
+
+      artifact_type != "pythia.web3_treasury_action.decision_trace.v1" ->
+        rejected(:unsupported_artifact_type)
+
+      canonicalization != "pythia.canonical_export.v1" ->
+        rejected(:unsupported_canonicalization)
+
+      integrity["algorithm"] != "sha256" ->
+        rejected(:unsupported_algorithm)
+
+      signature["status"] != "unsigned" ->
+        rejected(:unsupported_signature_status)
+
+      true ->
+        expected_digest = integrity["digest"]
+        actual_digest = digest_export_payload(payload)["digest"]
+
+        if expected_digest == actual_digest do
+          {:ok,
+           %{
+             status: :verified,
+             schema: schema,
+             artifact_type: artifact_type,
+             integrity: :verified,
+             signature: :unsigned,
+             digest: expected_digest
+           }}
+        else
+          {:error,
+           %{
+             status: :rejected,
+             reason: :digest_mismatch,
+             expected_digest: expected_digest,
+             actual_digest: actual_digest
+           }}
+        end
+    end
+  end
+
+  def verify_evidence_envelope(_envelope), do: rejected(:invalid_envelope_shape)
+
   defp ensure_export_status(export) do
     status =
       case Map.get(export, "status") do
@@ -194,6 +280,21 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   defp valid_evidence_shape?(artifact_type, algorithm, digest, payload) do
     is_binary(artifact_type) and is_binary(algorithm) and is_map(payload) and
       valid_digest?(digest)
+  end
+
+  defp valid_envelope_shape?(
+         schema,
+         artifact_type,
+         canonicalization,
+         integrity,
+         payload,
+         signature
+       ) do
+    is_binary(schema) and is_binary(artifact_type) and is_binary(canonicalization) and
+      is_map(payload) and
+      is_map(integrity) and is_binary(integrity["algorithm"]) and
+      valid_digest?(integrity["digest"]) and
+      is_map(signature) and is_binary(signature["status"])
   end
 
   defp valid_digest?(digest),

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -229,7 +229,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       integrity["algorithm"] != "sha256" ->
         rejected(:unsupported_algorithm)
 
-      signature["status"] != "unsigned" ->
+      not unsigned_signature_placeholder?(signature) ->
         rejected(:unsupported_signature_status)
 
       true ->
@@ -295,6 +295,11 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       is_map(integrity) and is_binary(integrity["algorithm"]) and
       valid_digest?(integrity["digest"]) and
       is_map(signature) and is_binary(signature["status"])
+  end
+
+  defp unsigned_signature_placeholder?(signature) do
+    signature["status"] == "unsigned" and is_nil(signature["algorithm"]) and
+      is_nil(signature["public_key"]) and is_nil(signature["signature"])
   end
 
   defp valid_digest?(digest),

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -1,0 +1,186 @@
+defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "export_evidence_envelope/1 returns expected envelope shape", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+    envelope = Web3TreasuryAction.export_evidence_envelope(result)
+
+    assert envelope["schema"] == "pythia.evidence.envelope.v1"
+    assert envelope["artifact_type"] == "pythia.web3_treasury_action.decision_trace.v1"
+    assert envelope["canonicalization"] == "pythia.canonical_export.v1"
+    assert envelope["integrity"]["algorithm"] == "sha256"
+    assert envelope["integrity"]["digest"] =~ ~r/\A[0-9a-f]{64}\z/
+    assert envelope["payload"] == Web3TreasuryAction.export_result(result)
+    assert envelope["signature"]["status"] == "unsigned"
+  end
+
+  test "envelope export is deterministic", ctx do
+    result = Web3TreasuryAction.evaluate(ctx.action, ctx.governance_record)
+
+    first = Web3TreasuryAction.export_evidence_envelope(result)
+    second = Web3TreasuryAction.export_evidence_envelope(result)
+
+    assert first == second
+  end
+
+  test "valid envelope verifies successfully", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+
+    assert {:ok, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :verified
+    assert verification.schema == "pythia.evidence.envelope.v1"
+    assert verification.artifact_type == "pythia.web3_treasury_action.decision_trace.v1"
+    assert verification.integrity == :verified
+    assert verification.signature == :unsigned
+    assert verification.digest == envelope["integrity"]["digest"]
+  end
+
+  test "tampered payload returns digest_mismatch", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+
+    tampered = put_in(envelope, ["payload", "stop_reason"], "tampered_stop_reason")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(tampered)
+    assert verification.status == :rejected
+    assert verification.reason == :digest_mismatch
+    assert verification.expected_digest == tampered["integrity"]["digest"]
+    assert verification.actual_digest != tampered["integrity"]["digest"]
+  end
+
+  test "unsupported schema returns unsupported_schema", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> Map.put("schema", "pythia.evidence.envelope.v2")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_schema
+  end
+
+  test "unsupported artifact type returns unsupported_artifact_type", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> Map.put("artifact_type", "pythia.other_artifact.v1")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_artifact_type
+  end
+
+  test "unsupported canonicalization returns unsupported_canonicalization", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> Map.put("canonicalization", "pythia.canonical_export.v2")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_canonicalization
+  end
+
+  test "unsupported algorithm returns unsupported_algorithm", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> put_in(["integrity", "algorithm"], "sha512")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_algorithm
+  end
+
+  test "missing integrity returns invalid_envelope_shape", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> Map.delete("integrity")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :invalid_envelope_shape
+  end
+
+  test "missing payload returns invalid_envelope_shape", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> Map.delete("payload")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :invalid_envelope_shape
+  end
+
+  test "unsupported signature status returns unsupported_signature_status", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> put_in(["signature", "status"], "signed")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_signature_status
+  end
+
+  test "boolean false is preserved inside rejected quorum envelope payload", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(%{ctx.governance_record | quorum_met: false})
+      |> Web3TreasuryAction.export_evidence_envelope()
+
+    assert {:ok, _verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+
+    quorum_entry =
+      envelope["payload"]["trace"]
+      |> Enum.find(fn entry -> entry["event"] == "quorum_check" end)
+
+    assert quorum_entry["actual"] == false
+  end
+end

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -169,6 +169,20 @@ defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
     assert verification.reason == :unsupported_signature_status
   end
 
+  test "unsigned signature placeholder requires nil signature fields", ctx do
+    envelope =
+      ctx.action
+      |> Web3TreasuryAction.evaluate(ctx.governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+      |> put_in(["signature", "algorithm"], "ed25519")
+      |> put_in(["signature", "public_key"], "fake_public_key")
+      |> put_in(["signature", "signature"], "fake_signature")
+
+    assert {:error, verification} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+    assert verification.status == :rejected
+    assert verification.reason == :unsupported_signature_status
+  end
+
   test "boolean false is preserved inside rejected quorum envelope payload", ctx do
     envelope =
       ctx.action


### PR DESCRIPTION
### Motivation

- Prepare a deterministic, forward-compatible envelope for Web3 Treasury Action evidence so signatures can be added later without changing the artifact format.
- Separate integrity (digest) from authorship (signature) by providing an explicit unsigned signature placeholder while preserving current integrity verification behavior.

### Description

- Adds `export_evidence_envelope/1` and `verify_evidence_envelope/1` to `lib/pythia/showcase/web3_treasury_action.ex` to produce and validate the deterministic envelope with the required shape and rejection reasons.
- Envelope shape follows the spec with `schema`, `artifact_type`, `canonicalization`, `integrity` (sha256 digest), `payload` (from `export_result/1`) and `signature` placeholder with `status: "unsigned"`.
- Reuses existing helpers (`export_result/1`, `digest_export_payload/1`, canonical encoder and digest validation) to compute and verify the integrity digest and to ensure determinism.
- Adds `examples/web3_treasury_evidence_envelope.exs`, `test/web3_treasury_evidence_envelope_test.exs`, updates `docs/web3_treasury_action_showcase.md`, and updates `README.md` to document and demonstrate the new envelope workflow.

### Testing

- Ran `mix format` on modified files successfully (`lib/pythia/showcase/web3_treasury_action.ex`, `examples/web3_treasury_evidence_envelope.exs`, `test/web3_treasury_evidence_envelope_test.exs`).
- Attempted `mix compile` and `mix test`, but dependency bootstrap failed in this environment due to Hex/SSL/network restrictions, so compilation and test execution could not complete here.
- Included comprehensive automated tests in `test/web3_treasury_evidence_envelope_test.exs` that cover envelope shape, determinism, successful verification, tampering (`:digest_mismatch`), unsupported schema/artifact/canonicalization/algorithm/signature status, missing fields, and boolean preservation; these tests are present and ready to run once dependencies can be fetched.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed20c3dbec832d947ccfacbccb2cf0)