### PR TITLE
Harden unsigned Web3 treasury evidence envelope validation

### DIFF
--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -105,6 +105,21 @@ Verification can detect:
 This is still not a digital signature.
 It verifies artifact integrity, not authorship.
 
+## Signature-ready evidence envelope
+
+For unsigned envelopes, the signature placeholder must remain empty:
+
+```elixir
+%{
+  "status" => "unsigned",
+  "algorithm" => nil,
+  "public_key" => nil,
+  "signature" => nil
+}
+```
+
+Any non-nil signature fields are rejected until real signature support is implemented.
+
 ## How to run
 
 ```bash

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -107,6 +107,33 @@ It verifies artifact integrity, not authorship.
 
 ## Signature-ready evidence envelope
 
+The envelope wraps an evidence artifact (not a raw payload directly):
+
+```elixir
+%{
+  "schema" => "pythia.evidence.envelope.v1",
+  "artifact" => %{
+    "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
+    "algorithm" => "sha256",
+    "digest" => "...",
+    "payload" => %{...}
+  },
+  "canonicalization" => "pythia.canonical_export.v1",
+  "integrity" => %{
+    "algorithm" => "sha256",
+    "digest" => "..."
+  },
+  "signature" => %{
+    "status" => "unsigned",
+    "algorithm" => nil,
+    "public_key" => nil,
+    "signature" => nil
+  }
+}
+```
+
+The top-level integrity digest must match the nested artifact digest.
+
 For unsigned envelopes, the signature placeholder must remain empty:
 
 ```elixir
@@ -119,6 +146,7 @@ For unsigned envelopes, the signature placeholder must remain empty:
 ```
 
 Any non-nil signature fields are rejected until real signature support is implemented.
+Signature status is currently unsigned-only.
 
 ## How to run
 

--- a/examples/web3_treasury_evidence_envelope.exs
+++ b/examples/web3_treasury_evidence_envelope.exs
@@ -1,0 +1,36 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+envelope = Web3TreasuryAction.export_evidence_envelope(result)
+
+IO.puts("Web3 Treasury Evidence Envelope")
+IO.inspect(envelope, pretty: true, limit: :infinity)
+
+IO.puts("\nVerification")
+IO.inspect(Web3TreasuryAction.verify_evidence_envelope(envelope), pretty: true)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -29,6 +29,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   @artifact_type "pythia.web3_treasury_action.decision_trace.v1"
   @canonicalization "pythia.canonical_export.v1"
   @integrity_algorithm "sha256"
+  @unsigned_signature_keys MapSet.new(["status", "algorithm", "public_key", "signature"])
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
@@ -273,13 +274,17 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     is_binary(integrity["algorithm"]) and valid_digest?(integrity["digest"])
   end
 
-  defp unsigned_signature_placeholder?(signature) do
-    is_map(signature) and
+  defp unsigned_signature_placeholder?(signature) when is_map(signature) do
+    signature_keys = signature |> Map.keys() |> MapSet.new()
+
+    signature_keys == @unsigned_signature_keys and
       signature["status"] == "unsigned" and
       is_nil(signature["algorithm"]) and
       is_nil(signature["public_key"]) and
       is_nil(signature["signature"])
   end
+
+  defp unsigned_signature_placeholder?(_signature), do: false
 
   defp valid_digest?(digest),
     do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -25,6 +25,10 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     :authorization_transaction_time_check,
     :transfer_expiration_check
   ]
+  @envelope_schema "pythia.evidence.envelope.v1"
+  @artifact_type "pythia.web3_treasury_action.decision_trace.v1"
+  @canonicalization "pythia.canonical_export.v1"
+  @integrity_algorithm "sha256"
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
@@ -100,7 +104,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       |> Base.encode16(case: :lower)
 
     %{
-      "algorithm" => "sha256",
+      "algorithm" => @integrity_algorithm,
       "digest" => digest
     }
   end
@@ -111,7 +115,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     digest = digest_export_payload(payload)
 
     %{
-      "artifact_type" => "pythia.web3_treasury_action.decision_trace.v1",
+      "artifact_type" => @artifact_type,
       "algorithm" => digest["algorithm"],
       "digest" => digest["digest"],
       "payload" => payload
@@ -127,7 +131,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       |> Base.encode16(case: :lower)
 
     %{
-      "algorithm" => "sha256",
+      "algorithm" => @integrity_algorithm,
       "digest" => digest
     }
   end
@@ -143,10 +147,10 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       not valid_evidence_shape?(artifact_type, algorithm, digest, payload) ->
         invalid_evidence_shape()
 
-      artifact_type != "pythia.web3_treasury_action.decision_trace.v1" ->
+      artifact_type != @artifact_type ->
         rejected(:unsupported_artifact_type)
 
-      algorithm != "sha256" ->
+      algorithm != @integrity_algorithm ->
         rejected(:unsupported_algorithm)
 
       true ->
@@ -174,6 +178,70 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
 
   def verify_evidence(_evidence), do: invalid_evidence_shape()
 
+  @spec export_evidence_envelope({:ok, map()} | {:error, map()}) :: map()
+  def export_evidence_envelope(result) do
+    artifact = export_evidence(result)
+
+    %{
+      "schema" => @envelope_schema,
+      "artifact" => artifact,
+      "canonicalization" => @canonicalization,
+      "integrity" => %{
+        "algorithm" => @integrity_algorithm,
+        "digest" => artifact["digest"]
+      },
+      "signature" => %{
+        "status" => "unsigned",
+        "algorithm" => nil,
+        "public_key" => nil,
+        "signature" => nil
+      }
+    }
+  end
+
+  @spec verify_evidence_envelope(map()) :: {:ok, map()} | {:error, map()}
+  def verify_evidence_envelope(envelope) when is_map(envelope) do
+    schema = Map.get(envelope, "schema")
+    artifact = Map.get(envelope, "artifact")
+    canonicalization = Map.get(envelope, "canonicalization")
+    integrity = Map.get(envelope, "integrity")
+    signature = Map.get(envelope, "signature")
+
+    cond do
+      not valid_evidence_envelope_shape?(schema, artifact, canonicalization, integrity, signature) ->
+        rejected(:invalid_envelope_shape)
+
+      schema != @envelope_schema ->
+        rejected(:unsupported_envelope_schema)
+
+      canonicalization != @canonicalization ->
+        rejected(:unsupported_canonicalization)
+
+      integrity["algorithm"] != @integrity_algorithm ->
+        rejected(:unsupported_algorithm)
+
+      integrity["digest"] != artifact["digest"] ->
+        rejected(:integrity_mismatch)
+
+      not unsigned_signature_placeholder?(signature) ->
+        rejected(:unsupported_signature_status)
+
+      true ->
+        with {:ok, verified_evidence} <- verify_evidence(artifact) do
+          {:ok,
+           %{
+             status: :verified,
+             schema: schema,
+             canonicalization: canonicalization,
+             digest: integrity["digest"],
+             evidence: verified_evidence
+           }}
+        end
+    end
+  end
+
+  def verify_evidence_envelope(_envelope), do: rejected(:invalid_envelope_shape)
+
   defp ensure_export_status(export) do
     status =
       case Map.get(export, "status") do
@@ -194,6 +262,23 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   defp valid_evidence_shape?(artifact_type, algorithm, digest, payload) do
     is_binary(artifact_type) and is_binary(algorithm) and is_map(payload) and
       valid_digest?(digest)
+  end
+
+  defp valid_evidence_envelope_shape?(schema, artifact, canonicalization, integrity, signature) do
+    is_binary(schema) and is_map(artifact) and is_binary(canonicalization) and is_map(integrity) and
+      valid_integrity_shape?(integrity) and is_map(signature)
+  end
+
+  defp valid_integrity_shape?(integrity) do
+    is_binary(integrity["algorithm"]) and valid_digest?(integrity["digest"])
+  end
+
+  defp unsigned_signature_placeholder?(signature) do
+    is_map(signature) and
+      signature["status"] == "unsigned" and
+      is_nil(signature["algorithm"]) and
+      is_nil(signature["public_key"]) and
+      is_nil(signature["signature"])
   end
 
   defp valid_digest?(digest),

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -134,6 +134,13 @@ defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
              Web3TreasuryAction.verify_evidence_envelope(tampered)
   end
 
+  test "unsigned signature map with unexpected key is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["signature", "sig_v2"], "fake")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
   test "missing signature map returns invalid_envelope_shape", %{envelope: envelope} do
     malformed = Map.delete(envelope, "signature")
 

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -1,0 +1,70 @@
+defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    result = Web3TreasuryAction.evaluate(action, governance_record)
+    envelope = Web3TreasuryAction.export_evidence_envelope(result)
+
+    %{envelope: envelope}
+  end
+
+  test "valid unsigned signature placeholder verifies successfully", %{envelope: envelope} do
+    assert {:ok, %{status: :verified}} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+  end
+
+  test "unsigned envelope with non-nil signature algorithm is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["signature", "algorithm"], "ed25519")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  test "unsigned envelope with non-nil public_key is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["signature", "public_key"], "fake-public-key")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  test "unsigned envelope with non-nil signature is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["signature", "signature"], "fake-signature")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  test "missing signature map returns invalid_envelope_shape", %{envelope: envelope} do
+    malformed = Map.delete(envelope, "signature")
+
+    assert {:error, %{status: :rejected, reason: :invalid_envelope_shape}} =
+             Web3TreasuryAction.verify_evidence_envelope(malformed)
+  end
+end

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -40,6 +40,35 @@ defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
     assert {:ok, %{status: :verified}} = Web3TreasuryAction.verify_evidence_envelope(envelope)
   end
 
+  test "envelope contains expected artifact and integrity shape", %{envelope: envelope} do
+    assert envelope["schema"] == "pythia.evidence.envelope.v1"
+
+    assert envelope["artifact"]["artifact_type"] ==
+             "pythia.web3_treasury_action.decision_trace.v1"
+
+    assert envelope["artifact"]["algorithm"] == "sha256"
+    assert envelope["artifact"]["digest"] =~ ~r/\A[0-9a-f]{64}\z/
+    assert is_map(envelope["artifact"]["payload"])
+    assert envelope["integrity"]["algorithm"] == "sha256"
+    assert envelope["integrity"]["digest"] == envelope["artifact"]["digest"]
+    assert envelope["canonicalization"] == "pythia.canonical_export.v1"
+    assert envelope["signature"]["status"] == "unsigned"
+  end
+
+  test "top-level integrity mismatch is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["integrity", "digest"], String.duplicate("0", 64))
+
+    assert {:error, %{status: :rejected, reason: :integrity_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  test "tampered artifact payload is rejected", %{envelope: envelope} do
+    tampered = put_in(envelope, ["artifact", "payload", "stop_reason"], "tampered_stop_reason")
+
+    assert {:error, %{status: :rejected, reason: :digest_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
   test "unsigned envelope with non-nil signature algorithm is rejected", %{envelope: envelope} do
     tampered = put_in(envelope, ["signature", "algorithm"], "ed25519")
 


### PR DESCRIPTION
### Motivation

- Ensure the unsigned "signature-ready" envelope is strict: an envelope claiming `status == "unsigned"` must not carry any non-nil signature metadata to avoid ambiguous or fake placeholder fields. 
- Harden verification before adding real signature support so the protocol remains unambiguous and safe for future signed prototypes. 
- Keep the change minimal and local: no signature generation, key management, or external integrations are added.

### Description

- Added module attributes (`@envelope_schema`, `@artifact_type`, `@canonicalization`, `@integrity_algorithm`) and used them in export/verify paths without changing existing evidence semantics. 
- Implemented `export_evidence_envelope/1` to produce a signature-ready envelope with the strict unsigned placeholder and `verify_evidence_envelope/1` to validate envelope shape, integrity, canonicalization, and the unsigned placeholder. 
- Added helper `unsigned_signature_placeholder?/1` and shape validators `valid_evidence_envelope_shape?/5` and `valid_integrity_shape?/1` to centralize checks. 
- Added tests `test/web3_treasury_evidence_envelope_test.exs`, updated docs `docs/web3_treasury_action_showcase.md`, and added example `examples/web3_treasury_evidence_envelope.exs` exercising the unsigned placeholder rules.

### Testing

- Ran `mix format lib/pythia/showcase/web3_treasury_action.ex test/web3_treasury_evidence_envelope_test.exs` which completed successfully. 
- Attempted `mix compile` and `mix test` but both failed due to missing Hex/dependency resolution (`Could not find an SCM for dependency :rustler`) in the execution environment. 
- Attempted `mix run` of the examples but these runs were blocked by the same dependency/Hex installation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed22f43380832d850079a3bb7eae40)