### PR TITLE
Add deterministic signed Web3 treasury evidence envelope demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,9 @@ Evidence can also be wrapped into a signature-ready envelope:
 ```bash
 mix run examples/web3_treasury_evidence_envelope.exs
 ```
+
+The project also includes a local deterministic demo signer to show how evidence envelopes may later support authorship verification.
+
+```bash
+mix run examples/web3_treasury_signed_envelope_demo.exs
+```

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -151,6 +151,20 @@ Signature status is currently unsigned-only.
 This prepares the artifact for future signed evidence without adding keys or signatures yet.
 This stage verifies integrity, not authorship.
 
+## Demo signed evidence envelope
+
+PythiaLabs includes a deterministic demo signer for local showcase purposes.
+
+This demonstrates the transition from:
+
+- unsigned integrity envelope
+- to signed demo envelope
+
+The demo signature is deterministic and based on SHA-256 over canonical envelope fields plus signer_id.
+
+This is not production cryptography.
+It does not include private keys, public keys, wallet signatures, identity verification, or blockchain anchoring.
+
 ## How to run
 
 ```bash

--- a/examples/web3_treasury_signed_envelope_demo.exs
+++ b/examples/web3_treasury_signed_envelope_demo.exs
@@ -1,0 +1,69 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+unsigned_envelope = Web3TreasuryAction.export_evidence_envelope(accepted_result)
+
+signed_envelope =
+  Web3TreasuryAction.sign_evidence_envelope_demo(unsigned_envelope, "demo_dao_reviewer")
+
+tampered_signed_envelope =
+  put_in(signed_envelope, ["artifact", "payload", "stop_reason"], "tampered_stop_reason")
+
+print_verification = fn label, verification_result ->
+  IO.puts("\n#{label}:")
+
+  case verification_result do
+    {:ok, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Signature: #{payload.signature}")
+      IO.puts("Signer: #{payload.signer_id}")
+
+    {:error, payload} ->
+      IO.puts("Status: #{payload.status}")
+      IO.puts("Reason: #{payload.reason}")
+  end
+end
+
+IO.puts("Web3 Treasury Signed Envelope Demo")
+
+IO.puts("\nSigned envelope:")
+IO.puts("Status: #{signed_envelope["signature"]["status"]}")
+IO.puts("Algorithm: #{signed_envelope["signature"]["algorithm"]}")
+IO.puts("Signer: #{signed_envelope["signature"]["signer_id"]}")
+IO.puts("Signature: #{signed_envelope["signature"]["signature"]}")
+
+print_verification.(
+  "Verification",
+  Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed_envelope)
+)
+
+print_verification.(
+  "Tampered verification",
+  Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered_signed_envelope)
+)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -29,6 +29,13 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   @artifact_type "pythia.web3_treasury_action.decision_trace.v1"
   @canonicalization "pythia.canonical_export.v1"
   @integrity_algorithm "sha256"
+  @evidence_envelope_keys MapSet.new([
+                            "schema",
+                            "artifact",
+                            "canonicalization",
+                            "integrity",
+                            "signature"
+                          ])
   @unsigned_signature_keys MapSet.new(["status", "algorithm", "public_key", "signature"])
   @signed_demo_signature_keys MapSet.new(["status", "algorithm", "signer_id", "signature"])
 
@@ -210,6 +217,9 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     signature = Map.get(envelope, "signature")
 
     cond do
+      not valid_evidence_envelope_key_set?(envelope) ->
+        rejected(:invalid_envelope_shape)
+
       not valid_evidence_envelope_shape?(schema, artifact, canonicalization, integrity, signature) ->
         rejected(:invalid_envelope_shape)
 
@@ -336,6 +346,9 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     signature = Map.get(envelope, "signature")
 
     cond do
+      not valid_evidence_envelope_key_set?(envelope) ->
+        rejected(:invalid_signed_envelope_shape)
+
       not valid_evidence_envelope_shape?(schema, artifact, canonicalization, integrity, signature) ->
         rejected(:invalid_signed_envelope_shape)
 
@@ -415,6 +428,19 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
 
   defp valid_digest?(digest),
     do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)
+
+  defp exact_key_set?(map, expected_keys) when is_map(map) do
+    map
+    |> Map.keys()
+    |> MapSet.new()
+    |> MapSet.equal?(expected_keys)
+  end
+
+  defp valid_evidence_envelope_key_set?(envelope) when is_map(envelope) do
+    exact_key_set?(envelope, @evidence_envelope_keys)
+  end
+
+  defp valid_evidence_envelope_key_set?(_), do: false
 
   defp invalid_evidence_shape(), do: rejected(:invalid_evidence_shape)
 

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -30,6 +30,7 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   @canonicalization "pythia.canonical_export.v1"
   @integrity_algorithm "sha256"
   @unsigned_signature_keys MapSet.new(["status", "algorithm", "public_key", "signature"])
+  @signed_demo_signature_keys MapSet.new(["status", "algorithm", "signer_id", "signature"])
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
@@ -243,6 +244,47 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
 
   def verify_evidence_envelope(_envelope), do: rejected(:invalid_envelope_shape)
 
+  @spec sign_evidence_envelope_demo(map(), String.t()) :: map()
+  def sign_evidence_envelope_demo(envelope, signer_id)
+      when is_map(envelope) and is_binary(signer_id) do
+    Map.put(envelope, "signature", %{
+      "status" => "signed_demo",
+      "algorithm" => "sha256-demo",
+      "signer_id" => signer_id,
+      "signature" => demo_signature(envelope, signer_id)
+    })
+  end
+
+  def sign_evidence_envelope_demo(envelope, signer_id) do
+    sign_evidence_envelope_demo(normalize_value(envelope), to_string(signer_id))
+  end
+
+  @spec verify_signed_evidence_envelope_demo(map()) :: {:ok, map()} | {:error, map()}
+  def verify_signed_evidence_envelope_demo(envelope) when is_map(envelope) do
+    signature = Map.get(envelope, "signature")
+
+    with {:ok, digest} <- verify_signed_envelope_integrity(envelope),
+         :ok <- verify_signed_signature_status(signature),
+         :ok <- verify_signed_signature_algorithm(signature),
+         :ok <- verify_signed_signer_id(signature),
+         :ok <- verify_signed_signature_digest(signature),
+         true <- signature["signature"] == demo_signature(envelope, signature["signer_id"]) do
+      {:ok,
+       %{
+         status: :verified,
+         signature: :verified_demo,
+         signer_id: signature["signer_id"],
+         digest: digest
+       }}
+    else
+      {:error, _payload} = error -> error
+      false -> rejected(:signature_mismatch)
+    end
+  end
+
+  def verify_signed_evidence_envelope_demo(_envelope),
+    do: rejected(:invalid_signed_envelope_shape)
+
   defp ensure_export_status(export) do
     status =
       case Map.get(export, "status") do
@@ -285,6 +327,91 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
   end
 
   defp unsigned_signature_placeholder?(_signature), do: false
+
+  defp verify_signed_envelope_integrity(envelope) do
+    schema = Map.get(envelope, "schema")
+    artifact = Map.get(envelope, "artifact")
+    canonicalization = Map.get(envelope, "canonicalization")
+    integrity = Map.get(envelope, "integrity")
+    signature = Map.get(envelope, "signature")
+
+    cond do
+      not valid_evidence_envelope_shape?(schema, artifact, canonicalization, integrity, signature) ->
+        rejected(:invalid_signed_envelope_shape)
+
+      schema != @envelope_schema ->
+        rejected(:invalid_signed_envelope_shape)
+
+      canonicalization != @canonicalization ->
+        rejected(:invalid_signed_envelope_shape)
+
+      integrity["algorithm"] != @integrity_algorithm ->
+        rejected(:invalid_signed_envelope_shape)
+
+      integrity["digest"] != artifact["digest"] ->
+        rejected(:digest_mismatch)
+
+      true ->
+        with {:ok, _verified_evidence} <- verify_evidence(artifact) do
+          {:ok, integrity["digest"]}
+        end
+    end
+  end
+
+  defp verify_signed_signature_status(signature) when is_map(signature) do
+    signature_keys = signature |> Map.keys() |> MapSet.new()
+
+    if signature_keys == @signed_demo_signature_keys and signature["status"] == "signed_demo" do
+      :ok
+    else
+      rejected(:unsupported_signature_status)
+    end
+  end
+
+  defp verify_signed_signature_status(_signature), do: rejected(:unsupported_signature_status)
+
+  defp verify_signed_signature_algorithm(signature) do
+    if signature["algorithm"] == "sha256-demo" do
+      :ok
+    else
+      rejected(:unsupported_signature_algorithm)
+    end
+  end
+
+  defp verify_signed_signer_id(signature) do
+    signer_id = signature["signer_id"]
+
+    if is_binary(signer_id) and String.trim(signer_id) != "" do
+      :ok
+    else
+      rejected(:invalid_signer_id)
+    end
+  end
+
+  defp verify_signed_signature_digest(signature) do
+    if valid_digest?(signature["signature"]) do
+      :ok
+    else
+      rejected(:signature_mismatch)
+    end
+  end
+
+  defp demo_signature_payload(envelope, signer_id) do
+    canonical_encode(%{
+      "schema" => envelope["schema"],
+      "artifact" => envelope["artifact"],
+      "canonicalization" => envelope["canonicalization"],
+      "integrity" => envelope["integrity"],
+      "signer_id" => signer_id
+    })
+  end
+
+  defp demo_signature(envelope, signer_id) do
+    envelope
+    |> demo_signature_payload(signer_id)
+    |> then(&:crypto.hash(:sha256, "demo-signature:" <> &1))
+    |> Base.encode16(case: :lower)
+  end
 
   defp valid_digest?(digest),
     do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)

--- a/test/web3_treasury_evidence_envelope_test.exs
+++ b/test/web3_treasury_evidence_envelope_test.exs
@@ -155,6 +155,13 @@ defmodule Pythia.Web3TreasuryEvidenceEnvelopeTest do
              Web3TreasuryAction.verify_evidence_envelope(malformed)
   end
 
+  test "unsigned envelope with unexpected top-level key is rejected", %{envelope: envelope} do
+    tampered = Map.put(envelope, "hidden_policy", "fake")
+
+    assert {:error, %{status: :rejected, reason: :invalid_envelope_shape}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
   test "boolean false is preserved inside rejected quorum envelope payload", ctx do
     envelope =
       ctx.action

--- a/test/web3_treasury_signed_envelope_demo_test.exs
+++ b/test/web3_treasury_signed_envelope_demo_test.exs
@@ -113,6 +113,16 @@ defmodule Pythia.Web3TreasurySignedEnvelopeDemoTest do
              Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
   end
 
+  test "signed demo signature map with unexpected key is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["signature", "sig_v2"], "fake")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
   test "blank signer_id is rejected", %{unsigned_envelope: envelope} do
     tampered =
       envelope
@@ -134,5 +144,15 @@ defmodule Pythia.Web3TreasurySignedEnvelopeDemoTest do
 
     assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
              Web3TreasuryAction.verify_evidence_envelope(signed)
+  end
+
+  test "signed envelope with unexpected top-level key is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> Map.put("hidden_policy", "fake")
+
+    assert {:error, %{status: :rejected, reason: :invalid_signed_envelope_shape}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
   end
 end

--- a/test/web3_treasury_signed_envelope_demo_test.exs
+++ b/test/web3_treasury_signed_envelope_demo_test.exs
@@ -1,0 +1,138 @@
+defmodule Pythia.Web3TreasurySignedEnvelopeDemoTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  setup do
+    action = %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+
+    governance_record = %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+
+    unsigned_envelope =
+      action
+      |> Web3TreasuryAction.evaluate(governance_record)
+      |> Web3TreasuryAction.export_evidence_envelope()
+
+    %{unsigned_envelope: unsigned_envelope}
+  end
+
+  test "sign_evidence_envelope_demo/2 returns signed_demo envelope", %{
+    unsigned_envelope: envelope
+  } do
+    signed = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+
+    assert signed["signature"]["status"] == "signed_demo"
+    assert signed["signature"]["algorithm"] == "sha256-demo"
+    assert signed["signature"]["signer_id"] == "demo_dao_reviewer"
+    assert signed["signature"]["signature"] =~ ~r/\A[0-9a-f]{64}\z/
+  end
+
+  test "signing is deterministic", %{unsigned_envelope: envelope} do
+    first = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+    second = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+
+    assert first["signature"]["signature"] == second["signature"]["signature"]
+  end
+
+  test "different signer_id changes signature", %{unsigned_envelope: envelope} do
+    first = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+    second = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_security_reviewer")
+
+    refute first["signature"]["signature"] == second["signature"]["signature"]
+  end
+
+  test "valid signed envelope verifies", %{unsigned_envelope: envelope} do
+    signed = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+
+    assert {:ok, verification} = Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed)
+    assert verification.status == :verified
+    assert verification.signature == :verified_demo
+    assert verification.signer_id == "demo_dao_reviewer"
+    assert verification.digest == envelope["integrity"]["digest"]
+  end
+
+  test "tampered artifact payload is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["artifact", "payload", "stop_reason"], "tampered_stop_reason")
+
+    assert {:error, %{status: :rejected, reason: :digest_mismatch}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
+  test "tampered signature is rejected with :signature_mismatch", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["signature", "signature"], String.duplicate("f", 64))
+
+    assert {:error, %{status: :rejected, reason: :signature_mismatch}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
+  test "unsupported signature algorithm is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["signature", "algorithm"], "sha512-demo")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_algorithm}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
+  test "unsupported signature status is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["signature", "status"], "signed")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
+  test "blank signer_id is rejected", %{unsigned_envelope: envelope} do
+    tampered =
+      envelope
+      |> Web3TreasuryAction.sign_evidence_envelope_demo("demo_dao_reviewer")
+      |> put_in(["signature", "signer_id"], "")
+
+    assert {:error, %{status: :rejected, reason: :invalid_signer_id}} =
+             Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered)
+  end
+
+  test "unsigned envelope is still verified by verify_evidence_envelope/1", %{
+    unsigned_envelope: envelope
+  } do
+    assert {:ok, %{status: :verified}} = Web3TreasuryAction.verify_evidence_envelope(envelope)
+  end
+
+  test "signed_demo envelope is rejected by unsigned verifier", %{unsigned_envelope: envelope} do
+    signed = Web3TreasuryAction.sign_evidence_envelope_demo(envelope, "demo_dao_reviewer")
+
+    assert {:error, %{status: :rejected, reason: :unsupported_signature_status}} =
+             Web3TreasuryAction.verify_evidence_envelope(signed)
+  end
+end


### PR DESCRIPTION
### Motivation

- Demonstrate a local, deterministic, non-production layer for evidence authorship that follows existing integrity checks without introducing real cryptography or key management. 

### Description

- Add deterministic demo signing API in `Pythia.Showcase.Web3TreasuryAction`: `sign_evidence_envelope_demo/2` and `verify_signed_evidence_envelope_demo/1` that compute a deterministic demo signature using `canonical_encode` and `:crypto.hash(:sha256, "demo-signature:" <> payload)` and encode it as lowercase hex. 
- Implement private helpers `demo_signature_payload/2` and `demo_signature/2` and strict signed-envelope shape checks that preserve existing unsigned verification behavior (`verify_evidence_envelope/1`).
- Add an example script `examples/web3_treasury_signed_envelope_demo.exs` that exports an unsigned envelope, signs it with `"demo_dao_reviewer"`, verifies it, tampers the artifact, and shows verification failure. 
- Add comprehensive tests in `test/web3_treasury_signed_envelope_demo_test.exs` covering deterministic signing, signer variance, valid verification, tampering, unsupported signature algorithm/status, blank signer rejection, and separation of unsigned vs signed verifiers; and update docs (`docs/web3_treasury_action_showcase.md`) and `README.md` to document the demo and its non-production scope.

### Testing

- Ran `mix format` on affected files successfully. 
- Attempted `mix compile` but it failed to fetch dependencies due to environment bootstrap issues (Hex download/SCM for `:rustler` could not be completed), so compilation could not be completed. 
- `mix test` and running the example with `mix run examples/web3_treasury_signed_envelope_demo.exs` were not executed because dependency installation/bootstrap was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed32c12b78832dab87371a40eadd8e)