### PR TITLE
PR #23: One Command Full Showcase for Web3 Treasury Reason Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,26 @@ This `signed_demo` flow is a deterministic local demo only and is not production
 ```bash
 mix run examples/web3_treasury_signed_envelope_demo.exs
 ```
+
+
+## Full Web3 Treasury Showcase
+
+Run:
+
+```bash
+mix run examples/web3_treasury_full_showcase.exs
+```
+
+This single deterministic demo shows:
+
+- accepted and rejected treasury actions
+- chronological decision traces
+- evidence export
+- SHA-256 digest generation
+- evidence verification
+- tamper rejection
+- unsigned evidence envelope verification
+- signed_demo envelope generation
+- signed_demo verification
+
+The `signed_demo` flow is deterministic local demo logic only and is not production cryptography.

--- a/docs/web3_treasury_action_showcase.md
+++ b/docs/web3_treasury_action_showcase.md
@@ -165,6 +165,19 @@ The demo signature is deterministic and based on SHA-256 over canonical envelope
 This is not production cryptography.
 It does not include private keys, public keys, wallet signatures, identity verification, or blockchain anchoring.
 
+
+## Full showcase
+
+For reviewer-friendly demos, PythiaLabs also includes a single deterministic command that combines the treasury action, evidence, envelope, and `signed_demo` flows end-to-end.
+
+```bash
+mix run examples/web3_treasury_full_showcase.exs
+```
+
+This is useful when you want to show the complete chain in one run:
+
+`decision → trace → evidence → digest → verify → tamper reject → envelope → signed_demo → signed verify`
+
 ## How to run
 
 ```bash

--- a/examples/web3_treasury_full_showcase.exs
+++ b/examples/web3_treasury_full_showcase.exs
@@ -1,0 +1,127 @@
+alias Pythia.Showcase.Web3TreasuryAction
+
+base_action = %{
+  action_id: "dao_act_001",
+  action_type: "treasury_transfer",
+  actor: "agent_alpha",
+  dao_id: "dao_pythia",
+  proposal_id: "prop_001",
+  amount: 10_000,
+  asset: "USDC",
+  recipient: "0xRecipient",
+  required_permission: "treasury.transfer",
+  action_time: ~U[2026-04-25 12:00:00Z],
+  decision_time: ~U[2026-04-25 12:01:00Z]
+}
+
+base_governance_record = %{
+  proposal_id: "prop_001",
+  permission: "treasury.transfer",
+  quorum_met: true,
+  voting_closed_at: ~U[2026-04-25 11:00:00Z],
+  timelock_until: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+  authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+  authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+  transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+}
+
+extract_payload = fn
+  {:ok, payload} -> payload
+  {:error, payload} -> payload
+end
+
+print_step = fn title ->
+  IO.puts("\n=== #{title} ===")
+end
+
+find_failed_check = fn trace ->
+  trace
+  |> Enum.find(fn entry -> entry[:result] == :fail end)
+  |> case do
+    nil -> "none"
+    failed -> to_string(failed[:event] || :unknown)
+  end
+end
+
+IO.puts("Web3 Treasury Full Showcase")
+
+print_step.("A. Accepted treasury action")
+accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
+accepted_payload = extract_payload.(accepted_result)
+
+IO.puts("status: #{accepted_payload.status}")
+IO.puts("stop_reason: #{accepted_payload.stop_reason}")
+IO.puts("trace_event_count: #{length(accepted_payload.trace)}")
+IO.puts("final_decision: #{List.last(accepted_payload.trace).result}")
+
+print_step.("B. Rejected treasury action: quorum_not_met")
+rejected_quorum_result =
+  Web3TreasuryAction.evaluate(base_action, %{base_governance_record | quorum_met: false})
+
+rejected_quorum_payload = extract_payload.(rejected_quorum_result)
+
+IO.puts("status: #{rejected_quorum_payload.status}")
+IO.puts("stop_reason: #{rejected_quorum_payload.stop_reason}")
+IO.puts("failed_check: #{find_failed_check.(rejected_quorum_payload.trace)}")
+
+print_step.("C. Rejected treasury action: authorization_valid_but_unknown_at_decision_time")
+rejected_unknown_result =
+  Web3TreasuryAction.evaluate(base_action, %{
+    base_governance_record
+    | authorization_recorded_at: ~U[2026-04-25 12:30:00Z]
+  })
+
+rejected_unknown_payload = extract_payload.(rejected_unknown_result)
+
+IO.puts("status: #{rejected_unknown_payload.status}")
+IO.puts("stop_reason: #{rejected_unknown_payload.stop_reason}")
+
+print_step.("D. Evidence export")
+exported_result = Web3TreasuryAction.export_result(accepted_result)
+IO.puts("export_status: #{exported_result["status"]}")
+IO.puts("export_stop_reason: #{exported_result["stop_reason"]}")
+IO.puts("trace_length: #{length(exported_result["trace"])}")
+
+print_step.("E. Evidence digest")
+digest = Web3TreasuryAction.export_digest(accepted_result)
+IO.puts("algorithm: #{digest["algorithm"]}")
+IO.puts("digest: #{digest["digest"]}")
+
+print_step.("F. Evidence verification")
+evidence = Web3TreasuryAction.export_evidence(accepted_result)
+verified_evidence = Web3TreasuryAction.verify_evidence(evidence)
+IO.inspect(verified_evidence, label: "verified_result")
+
+print_step.("G. Tampered evidence rejection")
+tampered_evidence = put_in(evidence, ["payload", "stop_reason"], "tampered_stop_reason")
+rejected_tampered_evidence = Web3TreasuryAction.verify_evidence(tampered_evidence)
+IO.inspect(rejected_tampered_evidence, label: "tamper_rejection")
+
+print_step.("H. Unsigned evidence envelope")
+unsigned_envelope = Web3TreasuryAction.export_evidence_envelope(accepted_result)
+verified_envelope = Web3TreasuryAction.verify_evidence_envelope(unsigned_envelope)
+IO.puts("schema: #{unsigned_envelope["schema"]}")
+IO.puts("digest: #{unsigned_envelope["integrity"]["digest"]}")
+IO.inspect(verified_envelope, label: "verification_status")
+
+print_step.("I. Signed demo envelope")
+{:ok, signed_envelope} =
+  Web3TreasuryAction.sign_evidence_envelope_demo(unsigned_envelope, "demo_dao_reviewer")
+
+IO.puts("signature_status: #{signed_envelope["signature"]["status"]}")
+IO.puts("algorithm: #{signed_envelope["signature"]["algorithm"]}")
+IO.puts("signer_id: #{signed_envelope["signature"]["signer_id"]}")
+
+print_step.("J. Signed demo verification")
+verified_signed_envelope = Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed_envelope)
+IO.inspect(verified_signed_envelope, label: "signed_verification")
+
+print_step.("K. Tampered signed demo envelope rejection")
+tampered_signed_envelope =
+  put_in(signed_envelope, ["artifact", "payload", "stop_reason"], "tampered_stop_reason")
+
+rejected_tampered_signed =
+  Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered_signed_envelope)
+
+IO.inspect(rejected_tampered_signed, label: "tampered_signed_rejection")

--- a/examples/web3_treasury_full_showcase.exs
+++ b/examples/web3_treasury_full_showcase.exs
@@ -36,9 +36,7 @@ print_step = fn title ->
 end
 
 find_failed_check = fn trace ->
-  trace
-  |> Enum.find(fn entry -> entry[:result] == :fail end)
-  |> case do
+  case Enum.find(trace, fn entry -> entry[:result] == :fail end) do
     nil -> "none"
     failed -> to_string(failed[:event] || :unknown)
   end

--- a/examples/web3_treasury_full_showcase.exs
+++ b/examples/web3_treasury_full_showcase.exs
@@ -44,7 +44,23 @@ find_failed_check = fn trace ->
   end
 end
 
+print_verification = fn verification_result ->
+  case verification_result do
+    {:ok, payload} ->
+      IO.puts("verification_status: #{payload.status}")
+
+      if Map.has_key?(payload, :algorithm), do: IO.puts("algorithm: #{payload.algorithm}")
+      if Map.has_key?(payload, :schema), do: IO.puts("schema: #{payload.schema}")
+      if Map.has_key?(payload, :signer_id), do: IO.puts("signer_id: #{payload.signer_id}")
+
+    {:error, payload} ->
+      IO.puts("verification_status: #{payload.status}")
+      IO.puts("reason: #{payload.reason}")
+  end
+end
+
 IO.puts("Web3 Treasury Full Showcase")
+IO.puts("Note: signed_demo is deterministic local demo logic only, not production cryptography.")
 
 print_step.("A. Accepted treasury action")
 accepted_result = Web3TreasuryAction.evaluate(base_action, base_governance_record)
@@ -91,19 +107,19 @@ IO.puts("digest: #{digest["digest"]}")
 print_step.("F. Evidence verification")
 evidence = Web3TreasuryAction.export_evidence(accepted_result)
 verified_evidence = Web3TreasuryAction.verify_evidence(evidence)
-IO.inspect(verified_evidence, label: "verified_result")
+print_verification.(verified_evidence)
 
 print_step.("G. Tampered evidence rejection")
 tampered_evidence = put_in(evidence, ["payload", "stop_reason"], "tampered_stop_reason")
 rejected_tampered_evidence = Web3TreasuryAction.verify_evidence(tampered_evidence)
-IO.inspect(rejected_tampered_evidence, label: "tamper_rejection")
+print_verification.(rejected_tampered_evidence)
 
 print_step.("H. Unsigned evidence envelope")
 unsigned_envelope = Web3TreasuryAction.export_evidence_envelope(accepted_result)
 verified_envelope = Web3TreasuryAction.verify_evidence_envelope(unsigned_envelope)
 IO.puts("schema: #{unsigned_envelope["schema"]}")
 IO.puts("digest: #{unsigned_envelope["integrity"]["digest"]}")
-IO.inspect(verified_envelope, label: "verification_status")
+print_verification.(verified_envelope)
 
 print_step.("I. Signed demo envelope")
 {:ok, signed_envelope} =
@@ -115,7 +131,7 @@ IO.puts("signer_id: #{signed_envelope["signature"]["signer_id"]}")
 
 print_step.("J. Signed demo verification")
 verified_signed_envelope = Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed_envelope)
-IO.inspect(verified_signed_envelope, label: "signed_verification")
+print_verification.(verified_signed_envelope)
 
 print_step.("K. Tampered signed demo envelope rejection")
 tampered_signed_envelope =
@@ -124,4 +140,6 @@ tampered_signed_envelope =
 rejected_tampered_signed =
   Web3TreasuryAction.verify_signed_evidence_envelope_demo(tampered_signed_envelope)
 
-IO.inspect(rejected_tampered_signed, label: "tampered_signed_rejection")
+print_verification.(rejected_tampered_signed)
+
+IO.puts("\nFull showcase completed.")


### PR DESCRIPTION
### Motivation

- Provide a single deterministic, reviewer-friendly command that demonstrates the complete PythiaLabs Web3 treasury reasoning flow end-to-end (decision → trace → evidence → digest → verify → tamper reject → envelope → signed_demo → signed verify).
- Make it easy to show accepted and rejected outcomes, exportable evidence, deterministic demo signing, and tamper detection without adding external integrations or production cryptography.

### Description

- Add `examples/web3_treasury_full_showcase.exs`, a deterministic script that runs the full flow and prints the requested A–K steps including `evaluate/2`, `export_result/1`, `export_digest/1`, `export_evidence/1`, `verify_evidence/1`, `export_evidence_envelope/1`, `sign_evidence_envelope_demo/2`, and `verify_signed_evidence_envelope_demo/1` outputs.
- Update `README.md` to include a `## Full Web3 Treasury Showcase` section with the `mix run examples/web3_treasury_full_showcase.exs` command and a clear note that `signed_demo` is local demo logic and not production cryptography.
- Update `docs/web3_treasury_action_showcase.md` with a `## Full showcase` section describing the unified one-command flow for reviewers.
- No new dependencies were added and no verifier behavior or production cryptography claims were changed.

### Testing

- Attempted `mix format` in the environment but it failed due to Mix formatter inputs / `.formatter.exs` expectations in this environment.
- Attempted `mix test` but test execution failed because Hex could not be installed in the current environment (network/SSL restriction prevented fetching dependencies).
- Attempted to run `mix run examples/web3_treasury_full_showcase.exs` but it could not execute for the same dependency/Hex installation restriction; the script is deterministic and should run in a normal dev environment after `mix deps.get`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc1e7378c832da4038a584ac638be)