### PR TITLE
PR #25: Polish README for reviewers and grant evaluators

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 PythiaLabs is a deterministic temporal-causal reasoning layer for agentic actions. It evaluates whether an action should proceed before execution, produces stable stop reasons, and exports replayable evidence traces for audit and review.
 
 ## Current focus
+
 - deterministic reasoning loops
 - agent action safety gates
 - bitemporal authorization reasoning
@@ -47,6 +48,7 @@ PythiaLabs currently does not claim:
 **Mission**: Minimal HRM-style reasoning loop for LIMINAL: `propose → run → measure → refine` with transparent step traces, fast kernels, and safe isolation.
 
 ## Stack
+
 - Elixir/BEAM for orchestration
 - Rust NIF (via rustler) for fast kernels
 - Rust Port worker for sandboxed solvers (BFS maze)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,49 @@
 # liminal-pythia — MVP
 
+PythiaLabs is a deterministic temporal-causal reasoning layer for agentic actions. It evaluates whether an action should proceed before execution, produces stable stop reasons, and exports replayable evidence traces for audit and review.
+
+## Current focus
+- deterministic reasoning loops
+- agent action safety gates
+- bitemporal authorization reasoning
+- Web3 DAO treasury action review
+- evidence export, verification, and tamper detection
+- local deterministic demos for grant and reviewer evaluation
+
+## Main demo for reviewers
+
+Run:
+
+```bash
+mix run examples/web3_treasury_full_showcase.exs
+```
+
+This demo shows:
+
+- accepted treasury action
+- rejected treasury action when quorum is not met
+- rejected treasury action when authorization was valid but unknown at decision time
+- evidence export
+- SHA-256 digest generation
+- evidence verification
+- tamper rejection
+- unsigned envelope verification
+- signed_demo envelope generation and verification
+
+Expected output guide: `docs/web3_treasury_full_showcase_expected_output.md`
+
+## What PythiaLabs is not yet
+
+PythiaLabs currently does not claim:
+
+- production cryptography
+- wallet integration
+- smart contract execution
+- RPC/indexer integration
+- on-chain enforcement
+- production identity verification
+- persistent external storage
+
 **Mission**: Minimal HRM-style reasoning loop for LIMINAL: `propose → run → measure → refine` with transparent step traces, fast kernels, and safe isolation.
 
 ## Stack
@@ -37,7 +81,7 @@ mix run examples/lev_demo.exs
 cd workers/solver_port && cargo build --release && cd ../../
 mix run examples/port_demo.exs
 
-# benchmark (NIF vs fallback)
+# benchmarks (NIF vs fallback)
 mix run benches/bench.exs
 ```
 


### PR DESCRIPTION
### Motivation
- Make the top of `README.md` immediately clear to grant reviewers, DAO operators, and technical evaluators so they understand the project within ~30 seconds.
- Reduce confusion from browser/machine translations and awkward headings by surfacing a concise executive block, primary demo, and explicit non-claims.
- Keep all existing technical content, command examples, and license notes intact while improving readability for external reviewers.

### Description
- Added a one-line project summary at the top describing PythiaLabs as a deterministic temporal-causal reasoning layer that produces stable stop reasons and replayable evidence traces.
- Added a `Current focus` section listing the six priorities: deterministic reasoning loops, agent action safety gates, bitemporal authorization reasoning, Web3 DAO treasury review, evidence export/verification/tamper detection, and local deterministic demos.
- Added a `Main demo for reviewers` section with the command `mix run examples/web3_treasury_full_showcase.exs`, an explicit list of expected demo outcomes, and a pointer to `docs/web3_treasury_full_showcase_expected_output.md`. 
- Added a `What PythiaLabs is not yet` section enumerating conservative non-claims and renamed the quickstart example comment from `# benchmark` to `# benchmarks`, while preserving all existing commands, roadmap notes, and the `signed_demo` local-only disclaimer.

### Testing
- Ran `mix format` which failed because the repository currently has no `.formatter.exs` configured with `:inputs` or `:subdirectories` to format. 
- Ran `mix test` which could not complete because Hex/dependency fetching was blocked by an SSL/HTTP `403 Forbidden` error when attempting `mix local.hex --force` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede5bd3b38832d884d97ff2df62c42)