### PR TITLE
PR #28: Add Open Source Trust Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to PythiaLabs will be documented in this file.
+
+This project is currently pre-release.
+
+## [Unreleased]
+
+### Added
+
+- Deterministic agent safety showcase
+- Bitemporal authorization showcase
+- Web3 treasury action showcase
+- Structured decision traces
+- JSON-ready trace export
+- SHA-256 evidence artifact flow
+- Evidence verification and tamper rejection
+- Signature-ready unsigned evidence envelope
+- Local deterministic signed_demo envelope flow
+- Full Web3 Treasury Showcase
+- Expected output guide for reviewers
+- Grant readiness materials
+- Web3 treasury reason layer threat model
+- Grant one-pager and application summary
+
+### Notes
+
+The project is an MVP and local deterministic demo stack.
+
+It does not yet claim:
+
+- production cryptography
+- wallet integration
+- smart contract execution
+- RPC/indexer integration
+- on-chain enforcement
+- production identity verification
+- persistent external storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ This project is currently pre-release.
 - SHA-256 evidence artifact flow
 - Evidence verification and tamper rejection
 - Signature-ready unsigned evidence envelope
-- Local deterministic signed_demo envelope flow
+- Local deterministic `signed_demo` envelope flow
 - Full Web3 Treasury Showcase
 - Expected output guide for reviewers
 - Grant readiness materials
 - Web3 treasury reason layer threat model
-- Grant one-pager and application summary
+- Grant one-pager
 
 ### Notes
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our pledge
+
+We want PythiaLabs to be a respectful, focused, and constructive project space.
+
+Participants are expected to communicate with clarity, patience, and professionalism.
+
+## Expected behavior
+
+Examples of positive behavior:
+
+- giving actionable feedback
+- respecting different experience levels
+- focusing criticism on ideas and code, not people
+- being honest about limitations
+- helping make safety and auditability easier to understand
+
+## Unacceptable behavior
+
+Unacceptable behavior includes:
+
+- harassment or personal attacks
+- abusive or discriminatory language
+- deliberate misinformation about project capabilities
+- pressuring maintainers to make unsupported production claims
+- introducing hidden or misleading security claims
+
+## Scope
+
+This code of conduct applies to project discussions, issues, pull requests, documentation, and related community spaces.
+
+## Enforcement
+
+Maintainers may remove comments, close issues, reject PRs, or block participants who violate this code of conduct.
+
+## Contact
+
+For concerns, contact the repository maintainer through GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to PythiaLabs
+
+Thank you for your interest in contributing to PythiaLabs.
+
+PythiaLabs is currently an MVP focused on deterministic temporal-causal reasoning, agent action safety, replayable traces, and evidence-oriented auditability.
+
+## Current contribution scope
+
+Good first contribution areas include:
+
+- documentation improvements
+- deterministic test scenarios
+- threat model expansion
+- example outputs
+- grant/reviewer materials
+- negative-path tests
+- evidence artifact validation examples
+
+Please avoid large architectural rewrites unless discussed first.
+
+## Development setup
+
+```bash
+mix deps.get
+mix compile
+mix test
+```
+
+If Rust worker changes are needed:
+
+```bash
+cd workers/solver_port
+cargo build --release
+cd ../../
+mix test
+```
+
+## Before opening a PR
+
+Please run:
+
+```bash
+mix format
+mix test
+```
+
+For documentation-only PRs, still run tests when possible.
+
+## PR guidelines
+
+A good PR should include:
+
+- clear summary
+- reason for the change
+- affected files
+- test status
+- known limitations
+
+## Project posture
+
+PythiaLabs is early-stage infrastructure research.
+
+Please keep claims honest:
+
+- do not claim production cryptography unless implemented
+- do not claim wallet or smart contract integration unless implemented
+- do not claim on-chain enforcement unless implemented
+- keep Web3 integration described as roadmap or demo unless production integration exists
+
+## Design principles
+
+Core principles:
+
+- deterministic reasoning over opaque decisions
+- stable stop reasons
+- replayable traces
+- temporal authorization awareness
+- audit-friendly evidence artifacts
+- clear non-goals and limitations
+
+For more context, see:
+
+- `docs/design_principles.md`
+- `docs/web3_treasury_action_showcase.md`
+- `docs/threat_model_web3_treasury_reason_layer.md`

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ For grant preparation materials, see:
 - `docs/threat_model_web3_treasury_reason_layer.md`
 - `docs/grant_one_pager_web3_treasury_reason_layer.md`
 
+## Project trust and governance
+
+Project governance and trust materials:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `CHANGELOG.md`
+- `docs/license_strategy.md`
+
+These documents describe contribution expectations, security reporting, project maturity, release notes, and licensing strategy.
+
 Additional roadmap items:
 
 - temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ For grant preparation materials, see:
 - `docs/threat_model_web3_treasury_reason_layer.md`
 - `docs/grant_one_pager_web3_treasury_reason_layer.md`
 
+Additional roadmap items:
+
+- temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
+- critic triggers based on confidence, repeated failure classes, and trace patterns
+- multi-domain executors for QA, graph problems, puzzles, and agent actions
+- Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
+
 ## Project trust and governance
 
 Project governance and trust materials:
@@ -153,13 +160,6 @@ Project governance and trust materials:
 - `docs/license_strategy.md`
 
 These documents describe contribution expectations, security reporting, project maturity, release notes, and licensing strategy.
-
-Additional roadmap items:
-
-- temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
-- critic triggers based on confidence, repeated failure classes, and trace patterns
-- multi-domain executors for QA, graph problems, puzzles, and agent actions
-- Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
 ## Agent Safety Showcase
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+## Current security posture
+
+PythiaLabs is an early-stage MVP and deterministic local demo stack.
+
+The project currently demonstrates:
+
+- deterministic action checks
+- temporal authorization reasoning
+- evidence artifact export
+- SHA-256 digest verification
+- tamper detection
+- unsigned evidence envelopes
+- local signed_demo envelope flow
+
+## Important limitations
+
+PythiaLabs currently does not claim:
+
+- production cryptography
+- wallet integration
+- smart contract execution
+- RPC/indexer integration
+- on-chain enforcement
+- production identity verification
+- production key management
+- persistent external storage
+
+The signed_demo flow is deterministic local demo logic only and is not production cryptography.
+
+## Reporting security issues
+
+Please do not open public issues for sensitive security reports.
+
+Instead, contact the maintainer privately through GitHub with:
+
+- summary of the issue
+- affected file or flow
+- reproduction steps
+- expected impact
+- suggested fix if available
+
+## What is in scope
+
+Security reports may include:
+
+- incorrect accept/reject behavior in safety gates
+- evidence verification bypass
+- digest mismatch not detected
+- malformed envelope accepted incorrectly
+- hidden fields influencing verification
+- unsafe production claims in documentation
+- accidental secret exposure
+
+## What is out of scope
+
+Currently out of scope:
+
+- production wallet security
+- smart contract vulnerabilities
+- chain RPC attacks
+- key compromise
+- production cryptographic signature failures
+
+These are out of scope because the current MVP does not implement those systems.
+
+## Recommended local checks
+
+Before merging changes, run:
+
+```bash
+mix format
+mix test
+```
+
+For future security hardening, the project may add:
+
+- secret scanning
+- dependency vulnerability scanning
+- static analysis
+- property-based testing
+- external verifier test vectors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ The project currently demonstrates:
 - SHA-256 digest verification
 - tamper detection
 - unsigned evidence envelopes
-- local signed_demo envelope flow
+- local `signed_demo` envelope flow
 
 ## Important limitations
 
@@ -27,7 +27,7 @@ PythiaLabs currently does not claim:
 - production key management
 - persistent external storage
 
-The signed_demo flow is deterministic local demo logic only and is not production cryptography.
+The `signed_demo` flow is deterministic local demo logic only and is not production cryptography.
 
 ## Reporting security issues
 

--- a/docs/license_strategy.md
+++ b/docs/license_strategy.md
@@ -1,0 +1,75 @@
+# License Strategy
+
+## Current license
+
+PythiaLabs currently uses the Pythia Labs Custom License v1.0.
+
+This reflects the current early-stage research and MVP status of the project.
+
+## Why license strategy matters
+
+PythiaLabs sits between several domains:
+
+- open safety research
+- agent governance
+- auditability infrastructure
+- Web3 public goods
+- potential commercial infrastructure
+
+The license should balance:
+
+- public reviewability
+- grant eligibility
+- contributor trust
+- ecosystem adoption
+- long-term commercial sustainability
+- protection against misleading or unsafe reuse
+
+## Current position
+
+The current repository is public, but not yet positioned as a fully standard open-source framework.
+
+The project may later consider:
+
+- Apache-2.0 for public-good modules
+- dual licensing for commercial use
+- separate licensing for protocol specs vs implementation
+- permissive licensing for test vectors and documentation
+- stricter licensing for production-oriented commercial packages
+
+## Why not change immediately
+
+A sudden license change should not be made casually.
+
+Before changing the license, the project should clarify:
+
+- expected contributor model
+- grant requirements
+- commercial intent
+- public-good scope
+- governance model
+- which modules should be maximally reusable
+
+## Possible future direction
+
+A possible future structure:
+
+- documentation/specs: permissive public-good license
+- test vectors/conformance suites: permissive license
+- core demo implementation: Apache-2.0 or similar
+- commercial integrations: separate commercial license
+
+## Current recommendation
+
+For now:
+
+- keep the current license
+- document the strategy clearly
+- avoid misleading open-source claims
+- revisit licensing before major grant submissions or external contributor onboarding
+
+## Non-goals
+
+This document is not legal advice.
+
+Before changing the license, consult qualified legal guidance if needed.


### PR DESCRIPTION
### Motivation

- Close an open-source maturity gap by providing basic trust, governance, and contribution documentation to improve reviewer and grant readiness.
- Make project posture explicit about limitations (security, cryptography, integrations) to avoid misleading production claims.

### Description

- Added governance and trust files: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, and `docs/license_strategy.md` describing contribution scope, conduct, security reporting, changelog, and license strategy.
- Updated `README.md` to include a new `## Project trust and governance` section that links the added documents and explains their purpose.
- This is documentation-only: no implementation code changes, no dependency changes, and the repository license was not altered in this PR.

### Testing

- Ran `mix format` which did not complete because the repository lacks a `.formatter.exs` with `:inputs`/`:subdirectories` (formatting check not applicable to these docs). (failed)
- Ran `mix test` which could not complete due to environment dependency/network constraints preventing Hex and native dependencies from being fetched (`rustler` dependency missing). (blocked)
- Attempted `mix local.hex --force` which failed due to network access issues (HTTP 403) in the environment; these are environmental/tooling failures unrelated to the documentation changes. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf503b03c832daab5f88aadf75fef)