### PR TITLE
PR #29: Add CI security checks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,28 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project is currently pre-release.
 - Grant readiness materials
 - Web3 treasury reason layer threat model
 - Grant one-pager
+- GitHub Actions security workflow for repository secret scanning
+- Security automation documentation
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,11 @@ Project governance and trust materials:
 - `SECURITY.md`
 - `CHANGELOG.md`
 - `docs/license_strategy.md`
+- `docs/security_automation.md`
 
 These documents describe contribution expectations, security reporting, project maturity, release notes, and licensing strategy.
+
+The repository also includes a minimal GitHub Actions security workflow for secret scanning.
 
 ## Agent Safety Showcase
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,7 +90,8 @@ It does not replace production security review, cryptographic review, smart cont
 
 For future security hardening, the project may add:
 
-- secret scanning
+- expanded secret scanning configuration
+- custom allowlist policy for false positives
 - dependency vulnerability scanning
 - static analysis
 - property-based testing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,20 @@ mix format
 mix test
 ```
 
+
+## CI security automation
+
+PythiaLabs includes a GitHub Actions security workflow for secret scanning.
+
+See:
+
+- `.github/workflows/security.yml`
+- `docs/security_automation.md`
+
+This is an initial security hygiene layer.
+
+It does not replace production security review, cryptographic review, smart contract auditing, wallet security, or key management.
+
 For future security hardening, the project may add:
 
 - secret scanning

--- a/docs/security_automation.md
+++ b/docs/security_automation.md
@@ -1,0 +1,70 @@
+# Security Automation
+
+## Current status
+
+PythiaLabs includes a minimal CI security workflow for repository secret scanning.
+
+The workflow runs on:
+
+- pull requests
+- pushes to `main`
+- manual dispatch
+
+## Implemented checks
+
+### Secret scanning
+
+The repository uses Gitleaks through GitHub Actions to detect accidentally committed secrets.
+
+Workflow:
+
+```bash
+.github/workflows/security.yml
+```
+
+This helps detect:
+
+- API keys
+- tokens
+- private keys
+- credentials
+- accidental secret-like strings
+
+## Why this matters
+
+PythiaLabs works with evidence artifacts, governance traces, and future authorization flows.
+
+Even though the current MVP does not include production keys, wallets, or live credentials, early secret scanning reduces the chance of unsafe project hygiene as the repository grows.
+
+## Current limitations
+
+This workflow does not yet provide:
+
+- dependency vulnerability scanning
+- static security analysis
+- container image scanning
+- production cryptographic review
+- smart contract security checks
+- wallet or RPC security checks
+
+These are future hardening areas.
+
+## Recommended local checks
+
+Before opening or merging a PR:
+
+```bash
+mix format
+mix test
+```
+
+## Future hardening ideas
+
+Potential future additions:
+
+- dependency vulnerability scanning
+- static analysis for Elixir code
+- Rust dependency audit
+- signed release artifacts
+- external verifier test vectors
+- CI checks for documentation claims


### PR DESCRIPTION
### Motivation
- Add a minimal, focused CI security gate to detect accidentally committed secrets via GitHub Actions and reduce early risk surface.
- Provide documentation of the automation, its scope, and limitations so reviewers and contributors understand this is an initial hygiene layer and not a replacement for production security reviews.
- Keep the change small and non-invasive: docs + CI only, no application code, no runtime dependency changes, and no license edits.

### Description
- Added a GitHub Actions workflow at `.github/workflows/security.yml` that runs Gitleaks on pull requests, pushes to `main`, and on manual dispatch with limited read permissions.
- Added `docs/security_automation.md` documenting the secret-scanning workflow, triggers, current limitations, recommended local checks, and future hardening ideas.
- Updated `SECURITY.md` with a new "CI security automation" section linking the workflow and the new docs and clarifying this is an initial hygiene layer.
- Updated `README.md` to list `docs/security_automation.md` in the Project trust and governance section and add a short sentence describing the minimal secret-scanning workflow, and updated `CHANGELOG.md` under [Unreleased] → Added with entries for the workflow and docs.
- No application code or dependency/runtime changes were made, and no production security claims were added.
- No skills were required or used for these changes.

### Testing
- Ran `mix format` which failed because the repository has no formatter inputs configured, matching the repository's current setup (expected failure).
- Ran `mix format .` which failed because no files matched the Mix formatter invocation in this environment (expected given repo layout).
- Ran `mix test` which could not proceed because Hex could not be installed/fetched in this environment (SSL/403) and dependencies could not be resolved; tests could not be executed here.
- The CI workflow itself is a docs + Actions addition and does not require repository runtime changes; expected behaviour is that GitHub Actions will run the Gitleaks job on PRs and pushes to `main` when used in the upstream repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0b96b4ac832db0b9afc3c5c425f0)