### PR TITLE
PR #33: Add payload-wide tamper invariant tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project is currently pre-release.
 - GitHub Actions security workflow for repository secret scanning
 - Security automation documentation
 - Property-based invariant tests for Web3 treasury reasoning and evidence verification
+- Payload-wide tamper invariant tests for Web3 treasury evidence artifacts
 
 ### Notes
 

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -8,16 +8,24 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     ["stop_reason"],
     ["trace"],
     ["trace", Access.at(0), "event"],
-    ["trace", Access.at(-1), "stop_reason"]
-    # Requires non-empty trace; guarded by "valid fixtures include non-empty trace"
+    ["trace", Access.at(0), "stop_reason"]
   ]
 
-  @evidence_field_paths Enum.map(@payload_field_paths, &["payload" | &1])
-  @envelope_field_paths Enum.map(@payload_field_paths, &["artifact", "payload" | &1])
+  @evidence_field_paths Enum.map(@payload_field_paths, &(["payload"] ++ &1))
+  @envelope_field_paths Enum.map(@payload_field_paths, &(["artifact", "payload"] ++ &1))
 
-  test "valid fixtures include non-empty trace" do
-    evidence_trace = get_in(valid_evidence(), ["payload", "trace"])
-    envelope_trace = get_in(valid_envelope(), ["artifact", "payload", "trace"])
+  setup do
+    result = valid_result()
+
+    %{
+      evidence: Web3TreasuryAction.export_evidence(result),
+      envelope: Web3TreasuryAction.export_evidence_envelope(result)
+    }
+  end
+
+  test "valid fixtures include non-empty trace", %{evidence: evidence, envelope: envelope} do
+    evidence_trace = get_in(evidence, ["payload", "trace"])
+    envelope_trace = get_in(envelope, ["artifact", "payload", "trace"])
 
     assert is_list(evidence_trace)
     assert evidence_trace != []
@@ -25,45 +33,67 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     assert envelope_trace != []
   end
 
-  test "evidence payload field tampering is rejected with digest_mismatch" do
-    evidence = valid_evidence()
-
+  test "evidence payload field tampering is rejected with digest_mismatch", %{evidence: evidence} do
     for field_path <- @evidence_field_paths do
-      tampered = put_in(evidence, field_path, "tampered_value")
-
-      assert {:error, %{reason: :digest_mismatch}} =
-               Web3TreasuryAction.verify_evidence(tampered),
-             "Failed for path: #{inspect(field_path)}"
+      assert_digest_mismatch_for_path(evidence, field_path, &Web3TreasuryAction.verify_evidence/1)
     end
   end
 
-  test "envelope artifact payload field tampering is rejected with digest_mismatch" do
-    envelope = valid_envelope()
+  test "evidence last trace stop_reason tampering is rejected", %{evidence: evidence} do
+    trace = get_in(evidence, ["payload", "trace"])
+    assert is_list(trace)
+    assert trace != []
 
+    last_index = length(trace) - 1
+    field_path = ["payload", "trace", Access.at(last_index), "stop_reason"]
+
+    assert_digest_mismatch_for_path(evidence, field_path, &Web3TreasuryAction.verify_evidence/1)
+  end
+
+  test "envelope artifact payload field tampering is rejected with digest_mismatch", %{
+    envelope: envelope
+  } do
     for field_path <- @envelope_field_paths do
-      tampered = put_in(envelope, field_path, "tampered_value")
-
-      assert {:error, %{reason: :digest_mismatch}} =
-               Web3TreasuryAction.verify_evidence_envelope(tampered),
-             "Failed for path: #{inspect(field_path)}"
+      assert_digest_mismatch_for_path(
+        envelope,
+        field_path,
+        &Web3TreasuryAction.verify_evidence_envelope/1
+      )
     end
   end
 
-  test "direct digest tampering is rejected for evidence and envelope" do
-    tampered_evidence =
-      put_in(valid_evidence(), ["digest"], String.duplicate("0", 64))
+  test "envelope last trace stop_reason tampering is rejected", %{envelope: envelope} do
+    trace = get_in(envelope, ["artifact", "payload", "trace"])
+    assert is_list(trace)
+    assert trace != []
+
+    last_index = length(trace) - 1
+    field_path = ["artifact", "payload", "trace", Access.at(last_index), "stop_reason"]
+
+    assert_digest_mismatch_for_path(
+      envelope,
+      field_path,
+      &Web3TreasuryAction.verify_evidence_envelope/1
+    )
+  end
+
+  test "direct digest tampering is rejected for evidence and envelope", %{
+    evidence: evidence,
+    envelope: envelope
+  } do
+    tampered_evidence = put_in(evidence, ["digest"], String.duplicate("0", 64))
 
     assert {:error, %{reason: :digest_mismatch}} =
              Web3TreasuryAction.verify_evidence(tampered_evidence)
 
     tampered_integrity =
-      put_in(valid_envelope(), ["integrity", "digest"], String.duplicate("0", 64))
+      put_in(envelope, ["integrity", "digest"], String.duplicate("0", 64))
 
     assert {:error, %{reason: :integrity_mismatch}} =
              Web3TreasuryAction.verify_evidence_envelope(tampered_integrity)
 
     tampered_artifact =
-      put_in(valid_envelope(), ["artifact", "digest"], String.duplicate("0", 64))
+      put_in(envelope, ["artifact", "digest"], String.duplicate("0", 64))
 
     assert {:error, %{reason: :integrity_mismatch}} =
              Web3TreasuryAction.verify_evidence_envelope(tampered_artifact)
@@ -104,13 +134,13 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     {:ok, payload}
   end
 
-  defp valid_evidence do
-    valid_result()
-    |> Web3TreasuryAction.export_evidence()
-  end
+  defp assert_digest_mismatch_for_path(artifact, field_path, verify_fun) do
+    tampered = put_in(artifact, field_path, "tampered_value")
 
-  defp valid_envelope do
-    valid_result()
-    |> Web3TreasuryAction.export_evidence_envelope()
+    assert get_in(tampered, field_path) == "tampered_value",
+           "Tamper mutation did not apply for path: #{inspect(field_path)}"
+
+    assert {:error, %{reason: :digest_mismatch}} = verify_fun.(tampered),
+           "Failed for path: #{inspect(field_path)}"
   end
 end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -3,6 +3,8 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
 
   alias Pythia.Showcase.Web3TreasuryAction
 
+  @replacement_values ["tampered_value", nil, 123, %{"x" => "y"}]
+
   @static_payload_field_paths [
     ["status"],
     ["stop_reason"],
@@ -48,10 +50,31 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "evidence payload field tampering is rejected with digest_mismatch", ctx do
-    for path <- ctx.evidence_paths do
+    for path <- ctx.evidence_paths,
+        replacement <- @replacement_values do
       assert_tamper_rejected(ctx.evidence, path, :digest_mismatch,
-        via: &Web3TreasuryAction.verify_evidence/1
+        via: &Web3TreasuryAction.verify_evidence/1,
+        replacement: replacement
       )
+    end
+  end
+
+  test "evidence middle trace tampering is rejected when middle index exists", %{
+    evidence: evidence
+  } do
+    trace = get_in(evidence, ["payload", "trace"])
+
+    if length(trace) >= 3 do
+      field_path = ["payload", "trace", Access.at(1), "event"]
+
+      for replacement <- @replacement_values do
+        assert_tamper_rejected(evidence, field_path, :digest_mismatch,
+          via: &Web3TreasuryAction.verify_evidence/1,
+          replacement: replacement
+        )
+      end
+    else
+      assert true
     end
   end
 
@@ -63,10 +86,31 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "envelope artifact payload field tampering is rejected with digest_mismatch", ctx do
-    for path <- ctx.envelope_paths do
+    for path <- ctx.envelope_paths,
+        replacement <- @replacement_values do
       assert_tamper_rejected(ctx.envelope, path, :digest_mismatch,
-        via: &Web3TreasuryAction.verify_evidence_envelope/1
+        via: &Web3TreasuryAction.verify_evidence_envelope/1,
+        replacement: replacement
       )
+    end
+  end
+
+  test "envelope middle trace tampering is rejected when middle index exists", %{
+    envelope: envelope
+  } do
+    trace = get_in(envelope, ["artifact", "payload", "trace"])
+
+    if length(trace) >= 3 do
+      field_path = ["artifact", "payload", "trace", Access.at(1), "event"]
+
+      for replacement <- @replacement_values do
+        assert_tamper_rejected(envelope, field_path, :digest_mismatch,
+          via: &Web3TreasuryAction.verify_evidence_envelope/1,
+          replacement: replacement
+        )
+      end
+    else
+      assert true
     end
   end
 
@@ -88,16 +132,18 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
              Web3TreasuryAction.verify_evidence_envelope(tampered)
   end
 
-  defp assert_tamper_rejected(artifact, field_path, expected_reason, via: verify_fun) do
-    tampered = put_in(artifact, field_path, "tampered_value")
+  defp assert_tamper_rejected(artifact, field_path, expected_reason, opts) do
+    verify_fun = Keyword.fetch!(opts, :via)
+    replacement = Keyword.get(opts, :replacement, "tampered_value")
+    tampered = put_in(artifact, field_path, replacement)
 
-    assert get_in(tampered, field_path) == "tampered_value",
+    assert get_in(tampered, field_path) == replacement,
            "Mutation did not apply — path may be wrong: #{inspect(field_path)}"
 
     verification = verify_fun.(tampered)
 
     assert {:error, %{reason: ^expected_reason}} = verification,
-           "Expected #{inspect(expected_reason)} after tampering #{inspect(field_path)}, got: #{inspect(verification)}"
+           "Expected #{inspect(expected_reason)} after tampering #{inspect(field_path)} with #{inspect(replacement)}, got: #{inspect(verification)}"
   end
 
   defp zeroed_digest, do: String.duplicate("0", 64)

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -38,7 +38,8 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "direct digest tampering is rejected for evidence and envelope" do
-    tampered_evidence = Map.put(valid_evidence(), "digest", String.duplicate("0", 64))
+    tampered_evidence =
+      put_in(valid_evidence(), ["digest"], String.duplicate("0", 64))
 
     assert {:error, %{reason: :digest_mismatch}} =
              Web3TreasuryAction.verify_evidence(tampered_evidence)
@@ -89,16 +90,19 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   defp valid_result do
-    Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    payload
   end
 
   defp valid_evidence do
     valid_result()
+    |> then(&{:ok, &1})
     |> Web3TreasuryAction.export_evidence()
   end
 
   defp valid_envelope do
     valid_result()
+    |> then(&{:ok, &1})
     |> Web3TreasuryAction.export_evidence_envelope()
   end
 end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -22,20 +22,26 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     assert is_list(evidence_trace) and evidence_trace != [],
            "export_evidence produced empty or missing trace — fixture is invalid"
 
+    assert Enum.all?(evidence_trace, &is_map/1),
+           "export_evidence trace entries must be maps"
+
     assert is_list(envelope_trace) and envelope_trace != [],
            "export_evidence_envelope produced empty or missing trace — fixture is invalid"
+
+    assert Enum.all?(envelope_trace, &is_map/1),
+           "export_evidence_envelope trace entries must be maps"
 
     trace_fields = extract_trace_fields(evidence_trace)
 
     first = 0
     last = length(evidence_trace) - 1
+    positions = Enum.uniq([first, last])
 
     dynamic_payload_paths =
-      for pos <- [first, last],
+      for pos <- positions,
           field <- trace_fields do
         ["trace", Access.at(pos), field]
       end
-      |> Enum.uniq()
 
     all_payload_paths = @static_payload_field_paths ++ dynamic_payload_paths
 
@@ -75,9 +81,6 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
         &Web3TreasuryAction.verify_evidence/1,
         :digest_mismatch
       )
-    else
-      IO.warn("Trace too short (#{ctx.trace_len}) for evidence middle tamper test")
-      assert true
     end
   end
 
@@ -122,9 +125,6 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
         &Web3TreasuryAction.verify_evidence_envelope/1,
         :digest_mismatch
       )
-    else
-      IO.warn("Trace too short (#{ctx.trace_len}) for envelope middle tamper test")
-      assert true
     end
   end
 
@@ -158,22 +158,34 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   defp test_tampering(artifact, paths, verify_fun, expected_reason) do
-    for path <- paths,
-        replacement <- @replacement_values do
-      assert_tamper_rejected(artifact, path, expected_reason,
-        via: verify_fun,
-        replacement: replacement
-      )
+    for path <- paths do
+      applied_replacements =
+        Enum.count(@replacement_values, fn replacement ->
+          if get_in(artifact, path) == replacement do
+            false
+          else
+            assert_tamper_rejected(artifact, path, expected_reason,
+              via: verify_fun,
+              replacement: replacement
+            )
+
+            true
+          end
+        end)
+
+      assert applied_replacements > 0,
+             "No effective replacements available for path: #{inspect(path)}"
     end
   end
 
   defp assert_tamper_rejected(artifact, field_path, expected_reason, opts) do
     verify_fun = Keyword.fetch!(opts, :via)
     replacement = Keyword.get(opts, :replacement, "tampered_value")
+    original = get_in(artifact, field_path)
     tampered = put_in(artifact, field_path, replacement)
 
-    assert get_in(tampered, field_path) == replacement,
-           "Mutation did not apply — path may be wrong: #{inspect(field_path)}"
+    assert get_in(tampered, field_path) != original,
+           "Replacement equals original — no tamper occurred at #{inspect(field_path)}"
 
     verification = verify_fun.(tampered)
 
@@ -189,7 +201,7 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     trace
     |> Enum.filter(&is_map/1)
     |> Enum.flat_map(&Map.keys/1)
-    |> Enum.filter(&is_binary/1)
+    |> Enum.filter(&(is_binary(&1) or is_atom(&1)))
     |> Enum.uniq()
   end
 

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -90,19 +90,18 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   defp valid_result do
-    {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
-    payload
+    result = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    {:ok, _payload} = result
+    result
   end
 
   defp valid_evidence do
     valid_result()
-    |> then(&{:ok, &1})
     |> Web3TreasuryAction.export_evidence()
   end
 
   defp valid_envelope do
     valid_result()
-    |> then(&{:ok, &1})
     |> Web3TreasuryAction.export_evidence_envelope()
   end
 end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -9,6 +9,7 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     ["trace"],
     ["trace", Access.at(0), "event"],
     ["trace", Access.at(-1), "stop_reason"]
+    # Requires non-empty trace; guarded by "valid fixtures include non-empty trace"
   ]
 
   @evidence_field_paths Enum.map(@payload_field_paths, &["payload" | &1])
@@ -27,23 +28,25 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   test "evidence payload field tampering is rejected with digest_mismatch" do
     evidence = valid_evidence()
 
-    Enum.each(@evidence_field_paths, fn field_path ->
+    for field_path <- @evidence_field_paths do
       tampered = put_in(evidence, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
-               Web3TreasuryAction.verify_evidence(tampered)
-    end)
+               Web3TreasuryAction.verify_evidence(tampered),
+             "Failed for path: #{inspect(field_path)}"
+    end
   end
 
   test "envelope artifact payload field tampering is rejected with digest_mismatch" do
     envelope = valid_envelope()
 
-    Enum.each(@envelope_field_paths, fn field_path ->
+    for field_path <- @envelope_field_paths do
       tampered = put_in(envelope, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
-               Web3TreasuryAction.verify_evidence_envelope(tampered)
-    end)
+               Web3TreasuryAction.verify_evidence_envelope(tampered),
+             "Failed for path: #{inspect(field_path)}"
+    end
   end
 
   test "direct digest tampering is rejected for evidence and envelope" do

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -10,9 +10,9 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   ]
 
   setup do
-    result = valid_result()
-    evidence = Web3TreasuryAction.export_evidence(result)
-    envelope = Web3TreasuryAction.export_evidence_envelope(result)
+    {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    evidence = Web3TreasuryAction.export_evidence({:ok, payload})
+    envelope = Web3TreasuryAction.export_evidence_envelope({:ok, payload})
 
     evidence_trace = get_in(evidence, ["payload", "trace"])
     envelope_trace = get_in(envelope, ["artifact", "payload", "trace"])
@@ -130,10 +130,5 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
       authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
       transfer_expires_at: ~U[2026-04-25 13:00:00Z]
     }
-  end
-
-  defp valid_result do
-    {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
-    {:ok, payload}
   end
 end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -25,16 +25,17 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     assert is_list(envelope_trace) and envelope_trace != [],
            "export_evidence_envelope produced empty or missing trace — fixture is invalid"
 
+    trace_fields = extract_trace_fields(evidence_trace)
+
     first = 0
     last = length(evidence_trace) - 1
 
     dynamic_payload_paths =
-      Enum.uniq([
-        ["trace", Access.at(first), "event"],
-        ["trace", Access.at(first), "stop_reason"],
-        ["trace", Access.at(last), "event"],
-        ["trace", Access.at(last), "stop_reason"]
-      ])
+      for pos <- [first, last],
+          field <- trace_fields do
+        ["trace", Access.at(pos), field]
+      end
+      |> Enum.uniq()
 
     all_payload_paths = @static_payload_field_paths ++ dynamic_payload_paths
 
@@ -45,79 +46,102 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
       evidence: evidence,
       envelope: envelope,
       evidence_paths: evidence_paths,
-      envelope_paths: envelope_paths
+      envelope_paths: envelope_paths,
+      trace_fields: trace_fields,
+      trace_len: length(evidence_trace)
     }
   end
 
   test "evidence payload field tampering is rejected with digest_mismatch", ctx do
-    for path <- ctx.evidence_paths,
-        replacement <- @replacement_values do
-      assert_tamper_rejected(ctx.evidence, path, :digest_mismatch,
-        via: &Web3TreasuryAction.verify_evidence/1,
-        replacement: replacement
-      )
-    end
+    test_tampering(
+      ctx.evidence,
+      ctx.evidence_paths,
+      &Web3TreasuryAction.verify_evidence/1,
+      :digest_mismatch
+    )
   end
 
-  test "evidence middle trace tampering is rejected when middle index exists", %{
-    evidence: evidence
-  } do
-    trace = get_in(evidence, ["payload", "trace"])
+  test "evidence middle trace element tampering is rejected", ctx do
+    assert ctx.trace_len >= 3,
+           "expected trace length >= 3 for middle-index tamper coverage, got #{ctx.trace_len}"
 
-    if length(trace) >= 3 do
-      field_path = ["payload", "trace", Access.at(1), "event"]
-
-      for replacement <- @replacement_values do
-        assert_tamper_rejected(evidence, field_path, :digest_mismatch,
-          via: &Web3TreasuryAction.verify_evidence/1,
-          replacement: replacement
-        )
+    middle_paths =
+      for i <- 1..(ctx.trace_len - 2),
+          field <- ctx.trace_fields do
+        ["payload", "trace", Access.at(i), field]
       end
-    else
-      assert true
-    end
+
+    test_tampering(
+      ctx.evidence,
+      middle_paths,
+      &Web3TreasuryAction.verify_evidence/1,
+      :digest_mismatch
+    )
   end
 
   test "evidence direct digest tampering is rejected with digest_mismatch", %{evidence: evidence} do
-    tampered = put_in(evidence, ["digest"], zeroed_digest())
+    tampered = put_in(evidence, ["digest"], tampered_digest())
 
     assert {:error, %{reason: :digest_mismatch}} =
              Web3TreasuryAction.verify_evidence(tampered)
   end
 
-  test "envelope artifact payload field tampering is rejected with digest_mismatch", ctx do
-    for path <- ctx.envelope_paths,
-        replacement <- @replacement_values do
-      assert_tamper_rejected(ctx.envelope, path, :digest_mismatch,
-        via: &Web3TreasuryAction.verify_evidence_envelope/1,
-        replacement: replacement
-      )
-    end
+  test "evidence trace list tampering (append/remove) is rejected", %{evidence: evidence} do
+    trace = get_in(evidence, ["payload", "trace"])
+
+    appended = put_in(evidence, ["payload", "trace"], trace ++ [%{"event" => "tampered"}])
+    dropped = put_in(evidence, ["payload", "trace"], Enum.drop(trace, -1))
+
+    assert {:error, %{reason: :digest_mismatch}} = Web3TreasuryAction.verify_evidence(appended)
+    assert {:error, %{reason: :digest_mismatch}} = Web3TreasuryAction.verify_evidence(dropped)
   end
 
-  test "envelope middle trace tampering is rejected when middle index exists", %{
-    envelope: envelope
-  } do
+  test "envelope artifact payload field tampering is rejected with digest_mismatch", ctx do
+    test_tampering(
+      ctx.envelope,
+      ctx.envelope_paths,
+      &Web3TreasuryAction.verify_evidence_envelope/1,
+      :digest_mismatch
+    )
+  end
+
+  test "envelope middle trace element tampering is rejected", ctx do
+    assert ctx.trace_len >= 3,
+           "expected trace length >= 3 for middle-index tamper coverage, got #{ctx.trace_len}"
+
+    middle_paths =
+      for i <- 1..(ctx.trace_len - 2),
+          field <- ctx.trace_fields do
+        ["artifact", "payload", "trace", Access.at(i), field]
+      end
+
+    test_tampering(
+      ctx.envelope,
+      middle_paths,
+      &Web3TreasuryAction.verify_evidence_envelope/1,
+      :digest_mismatch
+    )
+  end
+
+  test "envelope trace list tampering (append/remove) is rejected", %{envelope: envelope} do
     trace = get_in(envelope, ["artifact", "payload", "trace"])
 
-    if length(trace) >= 3 do
-      field_path = ["artifact", "payload", "trace", Access.at(1), "event"]
+    appended =
+      put_in(envelope, ["artifact", "payload", "trace"], trace ++ [%{"event" => "tampered"}])
 
-      for replacement <- @replacement_values do
-        assert_tamper_rejected(envelope, field_path, :digest_mismatch,
-          via: &Web3TreasuryAction.verify_evidence_envelope/1,
-          replacement: replacement
-        )
-      end
-    else
-      assert true
-    end
+    dropped = put_in(envelope, ["artifact", "payload", "trace"], Enum.drop(trace, -1))
+
+    assert {:error, %{reason: :digest_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(appended)
+
+    assert {:error, %{reason: :digest_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(dropped)
   end
 
   test "envelope integrity digest tampering is rejected with integrity_mismatch", %{
     envelope: envelope
   } do
-    tampered = put_in(envelope, ["integrity", "digest"], zeroed_digest())
+    tampered = put_in(envelope, ["integrity", "digest"], tampered_digest())
 
     assert {:error, %{reason: :integrity_mismatch}} =
              Web3TreasuryAction.verify_evidence_envelope(tampered)
@@ -126,10 +150,20 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   test "envelope artifact digest tampering is rejected with integrity_mismatch", %{
     envelope: envelope
   } do
-    tampered = put_in(envelope, ["artifact", "digest"], zeroed_digest())
+    tampered = put_in(envelope, ["artifact", "digest"], tampered_digest())
 
     assert {:error, %{reason: :integrity_mismatch}} =
              Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  defp test_tampering(artifact, paths, verify_fun, expected_reason) do
+    for path <- paths,
+        replacement <- @replacement_values do
+      assert_tamper_rejected(artifact, path, expected_reason,
+        via: verify_fun,
+        replacement: replacement
+      )
+    end
   end
 
   defp assert_tamper_rejected(artifact, field_path, expected_reason, opts) do
@@ -146,7 +180,15 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
            "Expected #{inspect(expected_reason)} after tampering #{inspect(field_path)} with #{inspect(replacement)}, got: #{inspect(verification)}"
   end
 
-  defp zeroed_digest, do: String.duplicate("0", 64)
+  defp extract_trace_fields(trace) do
+    [List.first(trace), List.last(trace)]
+    |> Enum.filter(&is_map/1)
+    |> Enum.flat_map(&Map.keys/1)
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
+  defp tampered_digest, do: String.duplicate("0", 64)
 
   defp base_action do
     %{

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -62,21 +62,23 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "evidence middle trace element tampering is rejected", ctx do
-    assert ctx.trace_len >= 3,
-           "expected trace length >= 3 for middle-index tamper coverage, got #{ctx.trace_len}"
+    if ctx.trace_len >= 3 do
+      middle_paths =
+        for i <- 1..(ctx.trace_len - 2),
+            field <- ctx.trace_fields do
+          ["payload", "trace", Access.at(i), field]
+        end
 
-    middle_paths =
-      for i <- 1..(ctx.trace_len - 2),
-          field <- ctx.trace_fields do
-        ["payload", "trace", Access.at(i), field]
-      end
-
-    test_tampering(
-      ctx.evidence,
-      middle_paths,
-      &Web3TreasuryAction.verify_evidence/1,
-      :digest_mismatch
-    )
+      test_tampering(
+        ctx.evidence,
+        middle_paths,
+        &Web3TreasuryAction.verify_evidence/1,
+        :digest_mismatch
+      )
+    else
+      IO.warn("Trace too short (#{ctx.trace_len}) for evidence middle tamper test")
+      assert true
+    end
   end
 
   test "evidence direct digest tampering is rejected with digest_mismatch", %{evidence: evidence} do
@@ -107,21 +109,23 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "envelope middle trace element tampering is rejected", ctx do
-    assert ctx.trace_len >= 3,
-           "expected trace length >= 3 for middle-index tamper coverage, got #{ctx.trace_len}"
+    if ctx.trace_len >= 3 do
+      middle_paths =
+        for i <- 1..(ctx.trace_len - 2),
+            field <- ctx.trace_fields do
+          ["artifact", "payload", "trace", Access.at(i), field]
+        end
 
-    middle_paths =
-      for i <- 1..(ctx.trace_len - 2),
-          field <- ctx.trace_fields do
-        ["artifact", "payload", "trace", Access.at(i), field]
-      end
-
-    test_tampering(
-      ctx.envelope,
-      middle_paths,
-      &Web3TreasuryAction.verify_evidence_envelope/1,
-      :digest_mismatch
-    )
+      test_tampering(
+        ctx.envelope,
+        middle_paths,
+        &Web3TreasuryAction.verify_evidence_envelope/1,
+        :digest_mismatch
+      )
+    else
+      IO.warn("Trace too short (#{ctx.trace_len}) for envelope middle tamper test")
+      assert true
+    end
   end
 
   test "envelope trace list structural tampering is rejected", %{envelope: envelope} do

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -4,6 +4,11 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   alias Pythia.Showcase.Web3TreasuryAction
 
   test "evidence payload field tampering is rejected with digest_mismatch" do
+    evidence = valid_evidence()
+    assert is_map(evidence["payload"])
+    assert is_list(evidence["payload"]["trace"])
+    assert evidence["payload"]["trace"] != []
+
     fields = [
       ["payload", "status"],
       ["payload", "stop_reason"],
@@ -13,7 +18,7 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     ]
 
     Enum.each(fields, fn field_path ->
-      tampered = put_in(valid_evidence(), field_path, "tampered_value")
+      tampered = put_in(evidence, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
                Web3TreasuryAction.verify_evidence(tampered)
@@ -21,6 +26,11 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   test "envelope artifact payload field tampering is rejected with digest_mismatch" do
+    envelope = valid_envelope()
+    assert is_map(envelope["artifact"]["payload"])
+    assert is_list(envelope["artifact"]["payload"]["trace"])
+    assert envelope["artifact"]["payload"]["trace"] != []
+
     fields = [
       ["artifact", "payload", "status"],
       ["artifact", "payload", "stop_reason"],
@@ -30,7 +40,7 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     ]
 
     Enum.each(fields, fn field_path ->
-      tampered = put_in(valid_envelope(), field_path, "tampered_value")
+      tampered = put_in(envelope, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
                Web3TreasuryAction.verify_evidence_envelope(tampered)
@@ -90,9 +100,8 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   defp valid_result do
-    result = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
-    {:ok, _payload} = result
-    result
+    assert {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    {:ok, payload}
   end
 
   defp valid_evidence do

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -1,0 +1,104 @@
+defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.Web3TreasuryAction
+
+  test "evidence payload field tampering is rejected with digest_mismatch" do
+    fields = [
+      ["payload", "status"],
+      ["payload", "stop_reason"],
+      ["payload", "trace"],
+      ["payload", "trace", Access.at(0), "event"],
+      ["payload", "trace", Access.at(-1), "stop_reason"]
+    ]
+
+    Enum.each(fields, fn field_path ->
+      tampered = put_in(valid_evidence(), field_path, "tampered_value")
+
+      assert {:error, %{reason: :digest_mismatch}} =
+               Web3TreasuryAction.verify_evidence(tampered)
+    end)
+  end
+
+  test "envelope artifact payload field tampering is rejected with digest_mismatch" do
+    fields = [
+      ["artifact", "payload", "status"],
+      ["artifact", "payload", "stop_reason"],
+      ["artifact", "payload", "trace"],
+      ["artifact", "payload", "trace", Access.at(0), "event"],
+      ["artifact", "payload", "trace", Access.at(-1), "stop_reason"]
+    ]
+
+    Enum.each(fields, fn field_path ->
+      tampered = put_in(valid_envelope(), field_path, "tampered_value")
+
+      assert {:error, %{reason: :digest_mismatch}} =
+               Web3TreasuryAction.verify_evidence_envelope(tampered)
+    end)
+  end
+
+  test "direct digest tampering is rejected for evidence and envelope" do
+    tampered_evidence = Map.put(valid_evidence(), "digest", String.duplicate("0", 64))
+
+    assert {:error, %{reason: :digest_mismatch}} =
+             Web3TreasuryAction.verify_evidence(tampered_evidence)
+
+    tampered_integrity =
+      put_in(valid_envelope(), ["integrity", "digest"], String.duplicate("0", 64))
+
+    assert {:error, %{reason: :integrity_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered_integrity)
+
+    tampered_artifact =
+      put_in(valid_envelope(), ["artifact", "digest"], String.duplicate("0", 64))
+
+    assert {:error, %{reason: reason}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered_artifact)
+
+    assert reason in [:integrity_mismatch, :digest_mismatch]
+  end
+
+  defp base_action do
+    %{
+      action_id: "dao_act_001",
+      action_type: "treasury_transfer",
+      actor: "agent_alpha",
+      dao_id: "dao_pythia",
+      proposal_id: "prop_001",
+      amount: 10_000,
+      asset: "USDC",
+      recipient: "0xRecipient",
+      required_permission: "treasury.transfer",
+      action_time: ~U[2026-04-25 12:00:00Z],
+      decision_time: ~U[2026-04-25 12:01:00Z]
+    }
+  end
+
+  defp base_governance_record do
+    %{
+      proposal_id: "prop_001",
+      permission: "treasury.transfer",
+      quorum_met: true,
+      voting_closed_at: ~U[2026-04-25 11:00:00Z],
+      timelock_until: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_from: ~U[2026-04-25 11:30:00Z],
+      authorization_valid_to: ~U[2026-04-25 13:00:00Z],
+      authorization_recorded_at: ~U[2026-04-25 11:45:00Z],
+      transfer_expires_at: ~U[2026-04-25 13:00:00Z]
+    }
+  end
+
+  defp valid_result do
+    Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+  end
+
+  defp valid_evidence do
+    valid_result()
+    |> Web3TreasuryAction.export_evidence()
+  end
+
+  defp valid_envelope do
+    valid_result()
+    |> Web3TreasuryAction.export_evidence_envelope()
+  end
+end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -3,101 +3,104 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
 
   alias Pythia.Showcase.Web3TreasuryAction
 
-  @payload_field_paths [
+  @static_payload_field_paths [
     ["status"],
     ["stop_reason"],
-    ["trace"],
-    ["trace", Access.at(0), "event"],
-    ["trace", Access.at(0), "stop_reason"]
+    ["trace"]
   ]
-
-  @evidence_field_paths Enum.map(@payload_field_paths, &(["payload"] ++ &1))
-  @envelope_field_paths Enum.map(@payload_field_paths, &(["artifact", "payload"] ++ &1))
 
   setup do
     result = valid_result()
+    evidence = Web3TreasuryAction.export_evidence(result)
+    envelope = Web3TreasuryAction.export_evidence_envelope(result)
 
-    %{
-      evidence: Web3TreasuryAction.export_evidence(result),
-      envelope: Web3TreasuryAction.export_evidence_envelope(result)
-    }
-  end
-
-  test "valid fixtures include non-empty trace", %{evidence: evidence, envelope: envelope} do
     evidence_trace = get_in(evidence, ["payload", "trace"])
     envelope_trace = get_in(envelope, ["artifact", "payload", "trace"])
 
-    assert is_list(evidence_trace)
-    assert evidence_trace != []
-    assert is_list(envelope_trace)
-    assert envelope_trace != []
+    assert is_list(evidence_trace) and evidence_trace != [],
+           "export_evidence produced empty or missing trace — fixture is invalid"
+
+    assert is_list(envelope_trace) and envelope_trace != [],
+           "export_evidence_envelope produced empty or missing trace — fixture is invalid"
+
+    first = 0
+    last = length(evidence_trace) - 1
+
+    dynamic_payload_paths =
+      Enum.uniq([
+        ["trace", Access.at(first), "event"],
+        ["trace", Access.at(first), "stop_reason"],
+        ["trace", Access.at(last), "event"],
+        ["trace", Access.at(last), "stop_reason"]
+      ])
+
+    all_payload_paths = @static_payload_field_paths ++ dynamic_payload_paths
+
+    evidence_paths = Enum.map(all_payload_paths, &(["payload"] ++ &1))
+    envelope_paths = Enum.map(all_payload_paths, &(["artifact", "payload"] ++ &1))
+
+    %{
+      evidence: evidence,
+      envelope: envelope,
+      evidence_paths: evidence_paths,
+      envelope_paths: envelope_paths
+    }
   end
 
-  test "evidence payload field tampering is rejected with digest_mismatch", %{evidence: evidence} do
-    for field_path <- @evidence_field_paths do
-      assert_digest_mismatch_for_path(evidence, field_path, &Web3TreasuryAction.verify_evidence/1)
-    end
-  end
-
-  test "evidence last trace stop_reason tampering is rejected", %{evidence: evidence} do
-    trace = get_in(evidence, ["payload", "trace"])
-    assert is_list(trace)
-    assert trace != []
-
-    last_index = length(trace) - 1
-    field_path = ["payload", "trace", Access.at(last_index), "stop_reason"]
-
-    assert_digest_mismatch_for_path(evidence, field_path, &Web3TreasuryAction.verify_evidence/1)
-  end
-
-  test "envelope artifact payload field tampering is rejected with digest_mismatch", %{
-    envelope: envelope
-  } do
-    for field_path <- @envelope_field_paths do
-      assert_digest_mismatch_for_path(
-        envelope,
-        field_path,
-        &Web3TreasuryAction.verify_evidence_envelope/1
+  test "evidence payload field tampering is rejected with digest_mismatch", ctx do
+    for path <- ctx.evidence_paths do
+      assert_tamper_rejected(ctx.evidence, path, :digest_mismatch,
+        via: &Web3TreasuryAction.verify_evidence/1
       )
     end
   end
 
-  test "envelope last trace stop_reason tampering is rejected", %{envelope: envelope} do
-    trace = get_in(envelope, ["artifact", "payload", "trace"])
-    assert is_list(trace)
-    assert trace != []
-
-    last_index = length(trace) - 1
-    field_path = ["artifact", "payload", "trace", Access.at(last_index), "stop_reason"]
-
-    assert_digest_mismatch_for_path(
-      envelope,
-      field_path,
-      &Web3TreasuryAction.verify_evidence_envelope/1
-    )
-  end
-
-  test "direct digest tampering is rejected for evidence and envelope", %{
-    evidence: evidence,
-    envelope: envelope
-  } do
-    tampered_evidence = put_in(evidence, ["digest"], String.duplicate("0", 64))
+  test "evidence direct digest tampering is rejected with digest_mismatch", %{evidence: evidence} do
+    tampered = put_in(evidence, ["digest"], zeroed_digest())
 
     assert {:error, %{reason: :digest_mismatch}} =
-             Web3TreasuryAction.verify_evidence(tampered_evidence)
-
-    tampered_integrity =
-      put_in(envelope, ["integrity", "digest"], String.duplicate("0", 64))
-
-    assert {:error, %{reason: :integrity_mismatch}} =
-             Web3TreasuryAction.verify_evidence_envelope(tampered_integrity)
-
-    tampered_artifact =
-      put_in(envelope, ["artifact", "digest"], String.duplicate("0", 64))
-
-    assert {:error, %{reason: :integrity_mismatch}} =
-             Web3TreasuryAction.verify_evidence_envelope(tampered_artifact)
+             Web3TreasuryAction.verify_evidence(tampered)
   end
+
+  test "envelope artifact payload field tampering is rejected with digest_mismatch", ctx do
+    for path <- ctx.envelope_paths do
+      assert_tamper_rejected(ctx.envelope, path, :digest_mismatch,
+        via: &Web3TreasuryAction.verify_evidence_envelope/1
+      )
+    end
+  end
+
+  test "envelope integrity digest tampering is rejected with integrity_mismatch", %{
+    envelope: envelope
+  } do
+    tampered = put_in(envelope, ["integrity", "digest"], zeroed_digest())
+
+    assert {:error, %{reason: :integrity_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  test "envelope artifact digest tampering is rejected with integrity_mismatch", %{
+    envelope: envelope
+  } do
+    tampered = put_in(envelope, ["artifact", "digest"], zeroed_digest())
+
+    assert {:error, %{reason: :integrity_mismatch}} =
+             Web3TreasuryAction.verify_evidence_envelope(tampered)
+  end
+
+  defp assert_tamper_rejected(artifact, field_path, expected_reason, via: verify_fun) do
+    tampered = put_in(artifact, field_path, "tampered_value")
+
+    assert get_in(tampered, field_path) == "tampered_value",
+           "Mutation did not apply — path may be wrong: #{inspect(field_path)}"
+
+    verification = verify_fun.(tampered)
+
+    assert {:error, %{reason: ^expected_reason}} = verification,
+           "Expected #{inspect(expected_reason)} after tampering #{inspect(field_path)}, got: #{inspect(verification)}"
+  end
+
+  defp zeroed_digest, do: String.duplicate("0", 64)
 
   defp base_action do
     %{
@@ -132,15 +135,5 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   defp valid_result do
     {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
     {:ok, payload}
-  end
-
-  defp assert_digest_mismatch_for_path(artifact, field_path, verify_fun) do
-    tampered = put_in(artifact, field_path, "tampered_value")
-
-    assert get_in(tampered, field_path) == "tampered_value",
-           "Tamper mutation did not apply for path: #{inspect(field_path)}"
-
-    assert {:error, %{reason: :digest_mismatch}} = verify_fun.(tampered),
-           "Failed for path: #{inspect(field_path)}"
   end
 end

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -86,14 +86,15 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
              Web3TreasuryAction.verify_evidence(tampered)
   end
 
-  test "evidence trace list tampering (append/remove) is rejected", %{evidence: evidence} do
+  test "evidence trace list structural tampering is rejected", %{evidence: evidence} do
     trace = get_in(evidence, ["payload", "trace"])
 
-    appended = put_in(evidence, ["payload", "trace"], trace ++ [%{"event" => "tampered"}])
-    dropped = put_in(evidence, ["payload", "trace"], Enum.drop(trace, -1))
+    for tampered_trace <- trace_tamper_cases(trace) do
+      tampered = put_in(evidence, ["payload", "trace"], tampered_trace)
 
-    assert {:error, %{reason: :digest_mismatch}} = Web3TreasuryAction.verify_evidence(appended)
-    assert {:error, %{reason: :digest_mismatch}} = Web3TreasuryAction.verify_evidence(dropped)
+      assert {:error, %{reason: :digest_mismatch}} =
+               Web3TreasuryAction.verify_evidence(tampered)
+    end
   end
 
   test "envelope artifact payload field tampering is rejected with digest_mismatch", ctx do
@@ -123,19 +124,15 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     )
   end
 
-  test "envelope trace list tampering (append/remove) is rejected", %{envelope: envelope} do
+  test "envelope trace list structural tampering is rejected", %{envelope: envelope} do
     trace = get_in(envelope, ["artifact", "payload", "trace"])
 
-    appended =
-      put_in(envelope, ["artifact", "payload", "trace"], trace ++ [%{"event" => "tampered"}])
+    for tampered_trace <- trace_tamper_cases(trace) do
+      tampered = put_in(envelope, ["artifact", "payload", "trace"], tampered_trace)
 
-    dropped = put_in(envelope, ["artifact", "payload", "trace"], Enum.drop(trace, -1))
-
-    assert {:error, %{reason: :digest_mismatch}} =
-             Web3TreasuryAction.verify_evidence_envelope(appended)
-
-    assert {:error, %{reason: :digest_mismatch}} =
-             Web3TreasuryAction.verify_evidence_envelope(dropped)
+      assert {:error, %{reason: :digest_mismatch}} =
+               Web3TreasuryAction.verify_evidence_envelope(tampered)
+    end
   end
 
   test "envelope integrity digest tampering is rejected with integrity_mismatch", %{
@@ -177,14 +174,32 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     verification = verify_fun.(tampered)
 
     assert {:error, %{reason: ^expected_reason}} = verification,
-           "Expected #{inspect(expected_reason)} after tampering #{inspect(field_path)} with #{inspect(replacement)}, got: #{inspect(verification)}"
+           """
+           Expected #{inspect(expected_reason)} after tampering
+           path #{inspect(field_path)} with #{inspect(replacement)},
+           got: #{inspect(verification)}
+           """
   end
 
-  defp extract_trace_fields(trace) do
-    [List.first(trace), List.last(trace)]
+  defp extract_trace_fields(trace) when is_list(trace) do
+    trace
     |> Enum.filter(&is_map/1)
     |> Enum.flat_map(&Map.keys/1)
     |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
+  defp trace_tamper_cases(trace) when is_list(trace) do
+    base_cases = [
+      [],
+      trace ++ [%{"event" => "tampered"}],
+      Enum.drop(trace, -1),
+      List.insert_at(trace, 1, %{"event" => "inserted"})
+    ]
+
+    maybe_reversed = if length(trace) > 1, do: [Enum.reverse(trace)], else: []
+
+    (base_cases ++ maybe_reversed)
     |> Enum.uniq()
   end
 

--- a/test/web3_treasury_payload_tamper_invariant_test.exs
+++ b/test/web3_treasury_payload_tamper_invariant_test.exs
@@ -3,21 +3,31 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
 
   alias Pythia.Showcase.Web3TreasuryAction
 
+  @payload_field_paths [
+    ["status"],
+    ["stop_reason"],
+    ["trace"],
+    ["trace", Access.at(0), "event"],
+    ["trace", Access.at(-1), "stop_reason"]
+  ]
+
+  @evidence_field_paths Enum.map(@payload_field_paths, &["payload" | &1])
+  @envelope_field_paths Enum.map(@payload_field_paths, &["artifact", "payload" | &1])
+
+  test "valid fixtures include non-empty trace" do
+    evidence_trace = get_in(valid_evidence(), ["payload", "trace"])
+    envelope_trace = get_in(valid_envelope(), ["artifact", "payload", "trace"])
+
+    assert is_list(evidence_trace)
+    assert evidence_trace != []
+    assert is_list(envelope_trace)
+    assert envelope_trace != []
+  end
+
   test "evidence payload field tampering is rejected with digest_mismatch" do
     evidence = valid_evidence()
-    assert is_map(evidence["payload"])
-    assert is_list(evidence["payload"]["trace"])
-    assert evidence["payload"]["trace"] != []
 
-    fields = [
-      ["payload", "status"],
-      ["payload", "stop_reason"],
-      ["payload", "trace"],
-      ["payload", "trace", Access.at(0), "event"],
-      ["payload", "trace", Access.at(-1), "stop_reason"]
-    ]
-
-    Enum.each(fields, fn field_path ->
+    Enum.each(@evidence_field_paths, fn field_path ->
       tampered = put_in(evidence, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
@@ -27,19 +37,8 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
 
   test "envelope artifact payload field tampering is rejected with digest_mismatch" do
     envelope = valid_envelope()
-    assert is_map(envelope["artifact"]["payload"])
-    assert is_list(envelope["artifact"]["payload"]["trace"])
-    assert envelope["artifact"]["payload"]["trace"] != []
 
-    fields = [
-      ["artifact", "payload", "status"],
-      ["artifact", "payload", "stop_reason"],
-      ["artifact", "payload", "trace"],
-      ["artifact", "payload", "trace", Access.at(0), "event"],
-      ["artifact", "payload", "trace", Access.at(-1), "stop_reason"]
-    ]
-
-    Enum.each(fields, fn field_path ->
+    Enum.each(@envelope_field_paths, fn field_path ->
       tampered = put_in(envelope, field_path, "tampered_value")
 
       assert {:error, %{reason: :digest_mismatch}} =
@@ -63,10 +62,8 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
     tampered_artifact =
       put_in(valid_envelope(), ["artifact", "digest"], String.duplicate("0", 64))
 
-    assert {:error, %{reason: reason}} =
+    assert {:error, %{reason: :integrity_mismatch}} =
              Web3TreasuryAction.verify_evidence_envelope(tampered_artifact)
-
-    assert reason in [:integrity_mismatch, :digest_mismatch]
   end
 
   defp base_action do
@@ -100,7 +97,7 @@ defmodule Pythia.Web3TreasuryPayloadTamperInvariantTest do
   end
 
   defp valid_result do
-    assert {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
+    {:ok, payload} = Web3TreasuryAction.evaluate(base_action(), base_governance_record())
     {:ok, payload}
   end
 


### PR DESCRIPTION
### Motivation
- Strengthen evidence verification coverage by proving that tampering any important field inside evidence payloads (not just `stop_reason`) is detected by digest verification.
- Provide the same guarantees for artifact payloads embedded inside unsigned envelopes to increase audit confidence in the Web3 treasury demo flows.
- Add direct digest tamper checks to exercise both evidence-level and envelope-level mismatch handling without changing production behavior.

### Description
- Added a new test module `Pythia.Web3TreasuryPayloadTamperInvariantTest` at `test/web3_treasury_payload_tamper_invariant_test.exs` that mutates payload fields and asserts verification returns `{:error, %{reason: :digest_mismatch}}` for evidence and envelope artifact payloads. 
- Added direct digest tamper coverage that checks `evidence["digest"]`, `envelope["integrity"]["digest"]`, and `envelope["artifact"]["digest"]`, and accepts the current verifier behavior for artifact/integrity ordering. 
- Implemented local helpers inside the test file: `base_action/0`, `base_governance_record/0`, `valid_result/0`, `valid_evidence/0`, and `valid_envelope/0` to keep tests self-contained. 
- Updated `CHANGELOG.md` under `[Unreleased] -> Added` with the new entry `- Payload-wide tamper invariant tests for Web3 treasury evidence artifacts`.

### Testing
- Ran `mix format "lib/**/*.ex" "test/**/*.exs" "*.{ex,exs}"` and `mix format test/web3_treasury_payload_tamper_invariant_test.exs` successfully to format the new test file. 
- Attempted `mix test` but it could not run in this environment because dependency fetching is blocked: `mix local.hex --force` failed with an SSL/network error when reaching `https://builds.hex.pm/installs/hex-1.x.csv`. 
- No production code was changed as part of this PR and no new runtime dependencies were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee699661fc832da32f0f2bafe39a42)