### PR TITLE
PR #34: Add Elixir formatter config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,9 @@
+[
+  inputs: [
+    "{mix,.formatter}.exs",
+    "{config,lib,test}/**/*.{ex,exs}",
+    "examples/**/*.exs",
+    "benches/**/*.exs",
+    "mix/tasks/**/*.ex"
+  ]
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project is currently pre-release.
 - Security automation documentation
 - Property-based invariant tests for Web3 treasury reasoning and evidence verification
 - Payload-wide tamper invariant tests for Web3 treasury evidence artifacts
+- Elixir formatter configuration for consistent `mix format` checks
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ mix format
 mix test
 ```
 
+The repository includes `.formatter.exs` so formatter inputs are consistent across contributors and CI.
+
 For documentation-only PRs, still run tests when possible.
 
 ## PR guidelines


### PR DESCRIPTION
### Motivation
- Ensure `mix format` no longer fails in PR validation by supplying a repository-level formatter config so formatting is consistent across contributors and CI.
- This was required because `mix format` failed during prior validation when there was no `.formatter.exs` / default formatter inputs.

### Description
- Add a root `.formatter.exs` with explicit `inputs` covering `{mix,.formatter}.exs`, `{config,lib,test}/**/*.{ex,exs}`, `examples/**/*.exs`, `benches/**/*.exs`, and `mix/tasks/**/*.ex`.
- Update `CONTRIBUTING.md` in the “Before opening a PR” section to keep `mix format` and `mix test` and add the sentence: "The repository includes `.formatter.exs` so formatter inputs are consistent across contributors and CI.".
- Update `CHANGELOG.md` under `[Unreleased] -> Added` to include: `- Elixir formatter configuration for consistent `mix format` checks`.
- Only the allowed files were changed: `.formatter.exs`, `CONTRIBUTING.md`, and `CHANGELOG.md`; no application logic or tests were modified beyond potential formatting and no dependencies were added.

### Testing
- Ran `mix format` successfully against the repo with the new `.formatter.exs` (formatting completed as expected).
- Attempted `mix test` but execution was blocked in this environment because dependency fetching failed due to TLS/CA issues contacting `repo.hex.pm`, so tests could not be completed here.
- Attempted to install Hex; a fallback archive install from GitHub succeeded, but `mix deps.get` still failed to fetch packages due to the environment TLS errors, preventing full automated test verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7fa8ccc4832dac4ae5998998907b)