### PR TITLE
PR #35: Apply Elixir formatter

### DIFF
--- a/benches/bench.exs
+++ b/benches/bench.exs
@@ -1,9 +1,12 @@
 alias Pythia.Kernels
 
-pairs = for _ <- 1..200, do: {"kitten" <> :crypto.strong_rand_bytes(4) |> Base.encode16(), "sitting"}
+pairs =
+  for _ <- 1..200, do: {("kitten" <> :crypto.strong_rand_bytes(4)) |> Base.encode16(), "sitting"}
 
-{t1, _} = :timer.tc(fn -> Enum.each(pairs, fn {a,b} -> Pythia.KernelsFallback.levenshtein(a,b) end) end)
-{t2, _} = :timer.tc(fn -> Enum.each(pairs, fn {a,b} -> Kernels.levenshtein(a,b) end) end)
+{t1, _} =
+  :timer.tc(fn -> Enum.each(pairs, fn {a, b} -> Pythia.KernelsFallback.levenshtein(a, b) end) end)
 
-IO.puts("Fallback (Elixir): #{div(t1,1000)} ms for #{length(pairs)} pairs")
-IO.puts("NIF (Rust)    : #{div(t2,1000)} ms for #{length(pairs)} pairs")
+{t2, _} = :timer.tc(fn -> Enum.each(pairs, fn {a, b} -> Kernels.levenshtein(a, b) end) end)
+
+IO.puts("Fallback (Elixir): #{div(t1, 1000)} ms for #{length(pairs)} pairs")
+IO.puts("NIF (Rust)    : #{div(t2, 1000)} ms for #{length(pairs)} pairs")

--- a/examples/lev_demo.exs
+++ b/examples/lev_demo.exs
@@ -1,7 +1,7 @@
 alias Pythia
 
 source = System.get_env("LEV_SRC", "kitten")
- target = System.get_env("LEV_TGT", "sitting")
+target = System.get_env("LEV_TGT", "sitting")
 
 {:ok, result} = Pythia.refine(source, target, max_steps: 30, threshold: 0, no_improve_limit: 8)
 
@@ -9,4 +9,9 @@ IO.puts("\n== Levenshtein demo ==")
 IO.inspect(result.best, label: "best")
 IO.puts("steps: #{result.steps}")
 IO.puts("trace:")
-for t <- result.trace, do: IO.puts("  step=#{t.step} op=#{inspect(t.proposal)} candidate=\"#{t.candidate}\" score=#{t.score}")
+
+for t <- result.trace,
+    do:
+      IO.puts(
+        "  step=#{t.step} op=#{inspect(t.proposal)} candidate=\"#{t.candidate}\" score=#{t.score}"
+      )

--- a/examples/web3_treasury_full_showcase.exs
+++ b/examples/web3_treasury_full_showcase.exs
@@ -70,6 +70,7 @@ IO.puts("trace_event_count: #{length(accepted_payload.trace)}")
 IO.puts("final_decision: #{List.last(accepted_payload.trace).result}")
 
 print_step.("B. Rejected treasury action: quorum_not_met")
+
 rejected_quorum_result =
   Web3TreasuryAction.evaluate(base_action, %{base_governance_record | quorum_met: false})
 
@@ -80,6 +81,7 @@ IO.puts("stop_reason: #{rejected_quorum_payload.stop_reason}")
 IO.puts("failed_check: #{find_failed_check.(rejected_quorum_payload.trace)}")
 
 print_step.("C. Rejected treasury action: authorization_valid_but_unknown_at_decision_time")
+
 rejected_unknown_result =
   Web3TreasuryAction.evaluate(base_action, %{
     base_governance_record
@@ -120,6 +122,7 @@ IO.puts("digest: #{unsigned_envelope["integrity"]["digest"]}")
 print_verification.(verified_envelope)
 
 print_step.("I. Signed demo envelope")
+
 {:ok, signed_envelope} =
   Web3TreasuryAction.sign_evidence_envelope_demo(unsigned_envelope, "demo_dao_reviewer")
 
@@ -128,10 +131,14 @@ IO.puts("algorithm: #{signed_envelope["signature"]["algorithm"]}")
 IO.puts("signer_id: #{signed_envelope["signature"]["signer_id"]}")
 
 print_step.("J. Signed demo verification")
-verified_signed_envelope = Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed_envelope)
+
+verified_signed_envelope =
+  Web3TreasuryAction.verify_signed_evidence_envelope_demo(signed_envelope)
+
 print_verification.(verified_signed_envelope)
 
 print_step.("K. Tampered signed demo envelope rejection")
+
 tampered_signed_envelope =
   put_in(signed_envelope, ["artifact", "payload", "stop_reason"], "tampered_stop_reason")
 

--- a/lib/pythia/executor.ex
+++ b/lib/pythia/executor.ex
@@ -4,12 +4,22 @@ defmodule Pythia.Executor do
   defstruct []
   def new, do: %__MODULE__{}
 
-  @type proposal :: {:noop} | {:insert, String.t(), non_neg_integer()} | {:delete, non_neg_integer()} | {:replace, String.t(), non_neg_integer()}
+  @type proposal ::
+          {:noop}
+          | {:insert, String.t(), non_neg_integer()}
+          | {:delete, non_neg_integer()}
+          | {:replace, String.t(), non_neg_integer()}
 
   def apply_proposal(_exec, current, {:noop}), do: {current, %{op: :noop}}
-  def apply_proposal(_exec, current, {:insert, ch, pos}), do: {insert_at(current, ch, pos), %{op: :insert, ch: ch, pos: pos}}
-  def apply_proposal(_exec, current, {:delete, pos}), do: {delete_at(current, pos), %{op: :delete, pos: pos}}
-  def apply_proposal(_exec, current, {:replace, ch, pos}), do: {replace_at(current, ch, pos), %{op: :replace, ch: ch, pos: pos}}
+
+  def apply_proposal(_exec, current, {:insert, ch, pos}),
+    do: {insert_at(current, ch, pos), %{op: :insert, ch: ch, pos: pos}}
+
+  def apply_proposal(_exec, current, {:delete, pos}),
+    do: {delete_at(current, pos), %{op: :delete, pos: pos}}
+
+  def apply_proposal(_exec, current, {:replace, ch, pos}),
+    do: {replace_at(current, ch, pos), %{op: :replace, ch: ch, pos: pos}}
 
   def score(_exec, a, b), do: Kernels.levenshtein(a, b)
 
@@ -20,6 +30,7 @@ defmodule Pythia.Executor do
 
   defp delete_at(str, pos) do
     {left, right} = String.split_at(str, pos)
+
     case String.graphemes(right) do
       [] -> left
       [_h | t] -> left <> Enum.join(t)
@@ -28,6 +39,7 @@ defmodule Pythia.Executor do
 
   defp replace_at(str, ch, pos) do
     {left, right} = String.split_at(str, pos)
+
     case String.graphemes(right) do
       [] -> left <> ch
       [_h | t] -> left <> ch <> Enum.join(t)

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "rustler": {:hex, :rustler, "0.37.3", "5f4e6634d43b26f0a69834dd1d3ed4e1710b022a053bf4a670220c9540c92602", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "a6872c6f53dcf00486d1e7f9e046e20e01bf1654bdacc4193016c2e8002b32a2"},
+  "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
+  "telemetry": {:hex, :telemetry, "1.4.1", "ab6de178e2b29b58e8256b92b382ea3f590a47152ca3651ea857a6cae05ac423", [:rebar3], [], "hexpm", "2172e05a27531d3d31dd9782841065c50dd5c3c7699d95266b2edd54c2dafa1c"},
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the repository `.formatter.exs` rules so the remaining Elixir sources use normal multi-line layout. No application logic changes.

## Changes

- Reformatted `lib/pythia/executor.ex`, `examples/lev_demo.exs`, `examples/web3_treasury_full_showcase.exs`, and `benches/bench.exs` via `mix format`.
- Added `mix.lock` produced by `mix deps.get` so the workflow cache key (`hashFiles('**/mix.lock')`) matches a committed file and dependency resolution is reproducible.

## Verification

- `mix deps.get`
- `mix format` (and `mix format --check-formatted`)
- `mix test` — 132 tests, 0 failures

## Notes

Most other `.ex`/`.exs` files on `main` were already multi-line; this PR covers the files that still needed formatting after PR #34.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

