### PR TITLE
PR #37: Add gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Elixir / Mix
+/_build/
+/deps/
+*.ez
+/priv/
+
+# Erlang / Elixir releases
+/rel/
+*.beam
+
+# Rust
+/target/
+**/target/
+
+# Logs and crash dumps
+erl_crash.dump
+*.log
+
+# Coverage / test artifacts
+/cover/
+/coverage/
+.junit/
+tmp/
+
+# OS/editor
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment files
+.env
+.env.*
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project is currently pre-release.
 - Payload-wide tamper invariant tests for Web3 treasury evidence artifacts
 - Elixir formatter configuration for consistent `mix format` checks
 - CI formatting check for Elixir code
+- Git ignore rules for local build, dependency, coverage, and editor artifacts
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Please avoid large architectural rewrites unless discussed first.
 
 ## Development setup
 
+Build outputs such as `_build/`, `deps/`, Rust `target/` directories, and compiled NIF artifacts under `priv/` are listed in `.gitignore` so they are not committed by mistake.
+
 ```bash
 mix deps.get
 mix compile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a root `.gitignore` so local Elixir/Mix output, Rust build trees, coverage metadata, editor files, and env files are not accidentally committed. `Cargo.lock` is **not** ignored (reproducible Rust builds; matches project practice for `workers/solver_port`).

`priv/` is ignored because Rustler copies compiled NIF shared objects there; they should not be versioned.

## Changes

- **`.gitignore`** — patterns per project needs (includes `/priv/` for NIF artifacts; no `Cargo.lock` line).
- **`CHANGELOG.md`** — line under `[Unreleased]` → Added.
- **`CONTRIBUTING.md`** — short note pointing contributors at `.gitignore`.

## Verification

- `mix format --check-formatted`
- `mix test` — 132 tests, 0 failures

No application or test code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

