### PR TITLE
PR #40: Switch project license to Apache-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ This project is currently pre-release.
 - Git ignore rules for local build, dependency, coverage, and editor artifacts
 - Draft EF Ecosystem Support Program (USD 50k) grant application text (`docs/grant_application_ef_esp_50k.md`)
 
+### Changed
+
+- Switched project license from Pythia Labs Custom License v1.0 to Apache License 2.0
+
 ### Notes
 
 The project is an MVP and local deterministic demo stack.

--- a/LICENSE
+++ b/LICENSE
@@ -1,145 +1,202 @@
-PYTHIA LABS CUSTOM LICENSE
-Version 1.0, October 2025
 
-Copyright (c) 2025 Pythia Labs Contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-PREAMBLE
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-This software implements transparent, explainable AI reasoning systems. We believe
-in open collaboration while ensuring responsible use of AI technology that respects
-human values, transparency, and ethical considerations.
+   1. Definitions.
 
-TERMS AND CONDITIONS
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-1. DEFINITIONS
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-   "Software" refers to the Pythia Labs codebase, documentation, and associated materials.
-   "You" refers to any individual or legal entity exercising permissions under this License.
-   "Derivative Works" refers to any work based on or derived from the Software.
-   "Commercial Use" refers to use intended for or directed toward commercial advantage.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-2. GRANT OF RIGHTS
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-   Subject to the terms and conditions of this License, You are granted:
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-   a) Personal and Research Use: Unrestricted rights to use, modify, and distribute
-      the Software for personal, educational, and non-commercial research purposes.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-   b) Commercial Use: Rights to use the Software commercially, subject to the
-      Ethical Use Requirements (Section 4) and Attribution Requirements (Section 5).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-   c) Derivative Works: Rights to create and distribute Derivative Works under
-      the same license terms.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-3. REDISTRIBUTION
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-   You may reproduce and distribute copies of the Software or Derivative Works in
-   any medium, with or without modifications, provided that You meet the following:
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-   a) You must give any other recipients a copy of this License;
-   b) You must cause any modified files to carry prominent notices stating that
-      You changed the files;
-   c) You must retain all copyright, patent, trademark, and attribution notices;
-   d) If the Software includes a "NOTICE" file, You must include a readable copy
-      of the attribution notices contained therein.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-4. ETHICAL USE REQUIREMENTS
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-   You agree NOT to use the Software or Derivative Works for:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-   a) Development of autonomous weapons systems or military applications intended
-      to cause harm;
-   b) Surveillance systems that violate privacy rights or enable mass surveillance
-      without consent;
-   c) Discriminatory systems that unfairly target individuals based on protected
-      characteristics;
-   d) Deceptive practices including deepfakes, misinformation campaigns, or fraud;
-   e) Any purpose that violates human rights, dignity, or applicable laws.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-   TRANSPARENCY PRINCIPLE: Any system built using this Software that makes decisions
-   affecting individuals must provide explainable reasoning traces when technically
-   feasible.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-5. ATTRIBUTION REQUIREMENTS
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-   All use of the Software must include prominent attribution:
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-   "Powered by Pythia Labs - Transparent AI Reasoning"
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-   For commercial products, this attribution must be visible to end users in:
-   - Product documentation
-   - About/Credits section of the application
-   - Public-facing materials (if applicable)
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-6. PATENT GRANT
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-   Each contributor grants You a perpetual, worldwide, non-exclusive, no-charge,
-   royalty-free, irrevocable patent license to make, use, sell, offer for sale,
-   import, and otherwise transfer the Software, where such license applies only to
-   those patent claims licensable by such contributor that are necessarily infringed
-   by their contribution(s) alone or by combination of their contribution(s) with
-   the Software.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-7. NO WARRANTY
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-8. LIMITATION OF LIABILITY
+   END OF TERMS AND CONDITIONS
 
-   In no event shall any contributor be liable for any direct, indirect, incidental,
-   special, exemplary, or consequential damages (including, but not limited to,
-   procurement of substitute goods or services; loss of use, data, or profits; or
-   business interruption) however caused and on any theory of liability, whether
-   in contract, strict liability, or tort (including negligence or otherwise)
-   arising in any way out of the use of this Software, even if advised of the
-   possibility of such damage.
+   APPENDIX: How to apply the Apache License to your work.
 
-9. TERMINATION
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-   This License and the rights granted hereunder will terminate automatically upon
-   any breach by You of the terms of this License. Individuals or entities who have
-   received Derivative Works from You under this License, however, will not have
-   their licenses terminated provided they remain in full compliance.
+   Copyright [yyyy] [name of copyright owner]
 
-10. ACCEPTING WARRANTY OR ADDITIONAL LIABILITY
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    You may choose to offer and charge a fee for warranty, support, indemnity or
-    liability obligations to recipients of the Software. However, You may do so
-    only on Your own behalf and not on behalf of any contributor.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-11. GOVERNING LAW
-
-    This License shall be governed by and construed in accordance with the laws
-    of the jurisdiction in which the primary development occurs, excluding its
-    conflicts of law provisions.
-
-12. COMMUNITY VALUES
-
-    Users of this Software are encouraged to:
-    - Contribute improvements back to the community
-    - Share knowledge and documentation
-    - Report bugs and security issues responsibly
-    - Build systems that enhance rather than replace human judgment
-    - Prioritize transparency and explainability in AI systems
-
-END OF TERMS AND CONDITIONS
-
----
-
-HOW TO APPLY THIS LICENSE TO YOUR WORK
-
-To apply this License to your Derivative Works, attach the following notice:
-
-   Copyright (c) [year] [your name/organization]
-
-   Licensed under the Pythia Labs Custom License, Version 1.0.
-   You may obtain a copy of the License at:
-   https://github.com/safal207/pythiaLabs/blob/main/LICENSE
-
-For questions about this license, contact the Pythia Labs maintainers.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ PythiaLabs currently does not claim:
 - Rust Port worker for sandboxed solvers (BFS maze)
 - JSON via `jason`
 - CI: GitHub Actions
-- License: Pythia Labs Custom License v1.0
+- License: Apache License 2.0
 
 ## Values
 ### Business Value

--- a/docs/license_strategy.md
+++ b/docs/license_strategy.md
@@ -1,75 +1,26 @@
 # License Strategy
 
-## Current license
+## Current license (SPDX: Apache-2.0)
 
-PythiaLabs currently uses the Pythia Labs Custom License v1.0.
+The PythiaLabs **core repository** is licensed under the **Apache License, Version 2.0** (`Apache-2.0`).
 
-This reflects the current early-stage research and MVP status of the project.
+This supports:
 
-## Why license strategy matters
+- public review and reproducible evaluation of demos, docs, and tests
+- grant and ecosystem alignment with common open infrastructure practice
+- contributor and downstream trust in a well-known, SPDX-listed license
+- enterprise and tooling adoption with familiar redistribution and notice rules
 
-PythiaLabs sits between several domains:
+## Commercial and hosted offerings
 
-- open safety research
-- agent governance
-- auditability infrastructure
-- Web3 public goods
-- potential commercial infrastructure
+**Apache-2.0 does not** prevent building products or services on top of the project.
 
-The license should balance:
+Future **hosted services**, **managed deployments**, **production integrations** (e.g. signing, wallet, or chain-facing adapters not present in the current MVP), or **enterprise modules** may use **separate commercial terms** and live outside this repository, while this repo remains the public reference implementation and documentation home.
 
-- public reviewability
-- grant eligibility
-- contributor trust
-- ecosystem adoption
-- long-term commercial sustainability
-- protection against misleading or unsafe reuse
+## MVP limitations
 
-## Current position
-
-The current repository is public, but not yet positioned as a fully standard open-source framework.
-
-The project may later consider:
-
-- Apache-2.0 for public-good modules
-- dual licensing for commercial use
-- separate licensing for protocol specs vs implementation
-- permissive licensing for test vectors and documentation
-- stricter licensing for production-oriented commercial packages
-
-## Why not change immediately
-
-A sudden license change should not be made casually.
-
-Before changing the license, the project should clarify:
-
-- expected contributor model
-- grant requirements
-- commercial intent
-- public-good scope
-- governance model
-- which modules should be maximally reusable
-
-## Possible future direction
-
-A possible future structure:
-
-- documentation/specs: permissive public-good license
-- test vectors/conformance suites: permissive license
-- core demo implementation: Apache-2.0 or similar
-- commercial integrations: separate commercial license
-
-## Current recommendation
-
-For now:
-
-- keep the current license
-- document the strategy clearly
-- avoid misleading open-source claims
-- revisit licensing before major grant submissions or external contributor onboarding
+The [README](../README.md) **“What PythiaLabs is not yet”** limitations (no production crypto, no wallet, no on-chain enforcement, etc.) are unchanged. Licensing choices do not alter project scope or security posture.
 
 ## Non-goals
 
-This document is not legal advice.
-
-Before changing the license, consult qualified legal guidance if needed.
+This document is **not legal advice**. Consult qualified counsel for your situation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the Pythia Labs Custom License v1.0 with the **official Apache License, Version 2.0** text in `LICENSE` (SPDX: `Apache-2.0`).

## Changes

- **`LICENSE`** — full Apache-2.0 text from apache.org.
- **`README.md`** — Stack line: `License: Apache License 2.0`.
- **`docs/license_strategy.md`** — Rewritten: core repo under Apache-2.0; notes on future hosted/commercial offerings; MVP limitations unchanged; not legal advice.
- **`CHANGELOG.md`** — `[Unreleased]` → **Changed**: license switch.

## Verification

- `mix format --check-formatted`
- `mix test` — 132 tests, 0 failures

No application or test code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

