### PR TITLE
PR #41: Add ESP Office Hours prep note (official EF links)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project is currently pre-release.
 - CI formatting check for Elixir code
 - Git ignore rules for local build, dependency, coverage, and editor artifacts
 - Draft EF Ecosystem Support Program (USD 50k) grant application text (`docs/grant_application_ef_esp_50k.md`)
+- Draft ESP Office Hours prep note (official EF links only) (`docs/grant_office_hours_ef_esp.md`)
 
 ### Changed
 

--- a/docs/grant_office_hours_ef_esp.md
+++ b/docs/grant_office_hours_ef_esp.md
@@ -1,0 +1,70 @@
+# Ethereum Foundation ESP — Office Hours request (draft)
+
+This document is an **internal draft** for booking [EF Ecosystem Support Program (ESP) Office Hours](https://esp.ethereum.foundation/applicants/office-hours). It is **not** a funding application. Office Hours are short guidance sessions to understand next steps—not a pitch for financial support. See the [Office Hours page](https://esp.ethereum.foundation/applicants/office-hours) for what to expect.
+
+**Official ESP references (use these only):**
+
+- [Applicants overview](https://esp.ethereum.foundation/applicants) — how ESP supports projects that strengthen Ethereum, selection themes, and practical expectations.
+- [Office Hours](https://esp.ethereum.foundation/applicants/office-hours) — booking and purpose (guidance, navigation, fit—not a grant submission).
+- [Requests for proposals (RFP)](https://esp.ethereum.foundation/applicants/rfp) — how RFPs work in the ESP context.
+- [PhD Fellowship Program (PhDFP)](https://esp.ethereum.foundation/rounds/phdfp26) — separate round; not the same as a general ESP project grant.
+
+---
+
+## Project snapshot (PythiaLabs)
+
+- **Repository:** [github.com/safal207/pythiaLabs](https://github.com/safal207/pythiaLabs)
+- **One line:** Deterministic temporal-causal reasoning layer for agentic governance actions, with pre-execution evaluation of Web3 treasury-style scenarios, replayable traces, and evidence-oriented demos (MVP).
+- **License:** Apache-2.0 (SPDX: `Apache-2.0`; see `LICENSE` and `docs/license_strategy.md`).
+- **Release anchor for reviewers:** tag `v0.1.0-pregrant` ([release](https://github.com/safal207/pythiaLabs/releases/tag/v0.1.0-pregrant)).
+- **Longer narrative (USD 50k-shaped):** `docs/grant_application_ef_esp_50k.md` (draft application text; not submitted via this Office Hours note).
+
+---
+
+## What PythiaLabs is not yet (explicit non-goals)
+
+The project does **not** claim:
+
+- production cryptography  
+- wallet integration  
+- smart contract execution  
+- RPC/indexer integration  
+- on-chain enforcement  
+- production identity verification  
+- persistent external storage  
+
+---
+
+## Why we are not targeting PhDFP for the USD 50k track
+
+The [PhD Fellowship Program](https://esp.ethereum.foundation/rounds/phdfp26) is aimed at **current PhD students**, expects **academic research output** and open-access dissemination, and describes a **fixed fellowship-style amount** over a defined period—not a substitute for a general ESP project grant aligned with our repo-based MVP.
+
+The **2026** application deadline stated on that page (**April 22, 2026**) has **passed** relative to our current planning date, so PhDFP is **not** our primary path for near-term funding navigation in any case.
+
+**Primary path:** general [ESP applicant](https://esp.ethereum.foundation/applicants) guidance—Office Hours, [Wishlist/RFP](https://esp.ethereum.foundation/applicants/rfp) fit, and related channels—not PhDFP.
+
+---
+
+## Questions for ESP Office Hours (guidance only)
+
+We would like **navigation**, not a funding decision in the session:
+
+1. **Fit:** Does PythiaLabs plausibly align with **any current ESP Wishlist or RFP item**, or is a **general ESP project** path more appropriate? We are **not** assuming a specific “verifiable governance” or other track unless ESP confirms it.
+2. **Next step:** If a general ESP application is the right route, what should we prioritize in the application (technical approach, ecosystem impact, open outputs, budget) given the [applicant overview](https://esp.ethereum.foundation/applicants)?
+3. **Alternatives:** If ESP is not the right home for this stage, is there another **Ethereum ecosystem** funding or support channel we should consider?
+
+**Wording we intend to use live:**  
+> We would like guidance on whether PythiaLabs fits any current ESP Wishlist/RFP item, or whether a general ESP path or another Ethereum ecosystem funding channel would be more appropriate.
+
+---
+
+## Session logistics (reminder)
+
+- Keep the call to **guidance and next steps** per [Office Hours](https://esp.ethereum.foundation/applicants/office-hours)—not a substitute for a formal application.
+- Bring: repo link, `v0.1.0-pregrant` tag, one demo command (`mix run examples/web3_treasury_full_showcase.exs`), and this limitations list.
+
+---
+
+## Disclaimer
+
+This memo is for **internal preparation** only. It is not legal advice and not an official submission to the Ethereum Foundation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `docs/grant_office_hours_ef_esp.md`: an **internal draft** for EF ESP [Office Hours](https://esp.ethereum.foundation/applicants/office-hours) navigation—not a funding application.

## Content

- References **only** official ESP pages: applicants overview, Office Hours, RFP, PhDFP round.
- **PhDFP** explicitly not targeted for the USD 50k path (PhD student program, academic output, fellowship-style amount; 2026 deadline noted as passed for planning purposes).
- **ESP** framed as primary path; asks whether PythiaLabs fits Wishlist/RFP, general ESP, or another ecosystem channel—**no** claim that a specific “verifiable governance” RFP applies unless ESP confirms.
- **License:** Apache-2.0 (PR #40 is merged on `main`).
- Full **limitations** block from README.

## Changes

- New doc + `CHANGELOG.md` under `[Unreleased]` → Added.

## Verification

- `mix format --check-formatted`
- `mix test` — 132 tests, 0 failures

No application or test code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-575cb99b-eab7-411f-9d8d-e3e82cd248e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

