### PR TITLE
Add deterministic Banking AI Risk Showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project is currently pre-release.
 - Draft EF Ecosystem Support Program (USD 50k) grant application text (`docs/grant_application_ef_esp_50k.md`)
 - Draft ESP Office Hours prep note (official EF links only) (`docs/grant_office_hours_ef_esp.md`)
 - Draft OpenAI Safety Fellowship application text (official program page only) (`docs/fellowship_openai_safety_2026_application.md`)
-- Deterministic Banking AI Risk Showcase for pre-execution control of high-risk financial/agentic actions
+- Deterministic Banking AI Risk Showcase for pre-execution reasoning over high-risk financial/agentic actions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project is currently pre-release.
 - Draft EF Ecosystem Support Program (USD 50k) grant application text (`docs/grant_application_ef_esp_50k.md`)
 - Draft ESP Office Hours prep note (official EF links only) (`docs/grant_office_hours_ef_esp.md`)
 - Draft OpenAI Safety Fellowship application text (official program page only) (`docs/fellowship_openai_safety_2026_application.md`)
+- Deterministic Banking AI Risk Showcase for pre-execution control of high-risk financial/agentic actions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project is currently pre-release.
 - Draft ESP Office Hours prep note (official EF links only) (`docs/grant_office_hours_ef_esp.md`)
 - Draft OpenAI Safety Fellowship application text (official program page only) (`docs/fellowship_openai_safety_2026_application.md`)
 - Deterministic Banking AI Risk Showcase for pre-execution reasoning over high-risk financial/agentic actions
+- Reviewer-facing expected output guide for Banking AI Risk Showcase
+- Unit tests for Banking AI Risk Showcase decisioning and evidence verification paths
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project is currently pre-release.
 - Draft EF Ecosystem Support Program (USD 50k) grant application text (`docs/grant_application_ef_esp_50k.md`)
 - Draft ESP Office Hours prep note (official EF links only) (`docs/grant_office_hours_ef_esp.md`)
 - Draft OpenAI Safety Fellowship application text (official program page only) (`docs/fellowship_openai_safety_2026_application.md`)
-- Deterministic Banking AI Risk Showcase for pre-execution reasoning over high-risk financial/agentic actions
+- Deterministic Banking AI Risk Showcase for decision-time replay reasoning over high-risk financial/agentic actions
 - Reviewer-facing expected output guide for Banking AI Risk Showcase
 - Unit tests for Banking AI Risk Showcase decisioning and evidence verification paths
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ mix run examples/web3_treasury_signed_envelope_demo.exs
 ## Banking AI Risk Showcase
 
 PythiaLabs includes a deterministic banking-risk action showcase for AI-enabled financial workflows.
-It demonstrates how a proposed high-risk action can be accepted or rejected before execution based on operator approval, evidence freshness, temporal authorization, and decision-time knowledge.
+It demonstrates how a proposed high-risk action can be accepted or rejected during deterministic decision-time replay based on operator approval, evidence freshness, temporal authorization, and decision-time knowledge.
 The showcase emits stable stop reasons and replayable evidence artifacts for audit and review.
 
 Run:
@@ -265,7 +265,7 @@ Run:
 mix run examples/banking_ai_risk_showcase.exs
 ```
 
-This is a deterministic local showcase. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
+This is a deterministic local showcase for governance/audit reasoning. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
 
 
 ## Full Web3 Treasury Showcase

--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ This `signed_demo` flow is a deterministic local demo only and is not production
 mix run examples/web3_treasury_signed_envelope_demo.exs
 ```
 
+## Banking AI Risk Showcase
+
+PythiaLabs includes a deterministic banking-risk action showcase for AI-enabled financial workflows.
+It demonstrates how a proposed high-risk action can be accepted or rejected before execution based on operator approval, evidence freshness, temporal authorization, and decision-time knowledge.
+The showcase emits stable stop reasons and replayable evidence artifacts for audit and review.
+
+Run:
+
+```bash
+mix run examples/banking_ai_risk_showcase.exs
+```
+
+This is a deterministic local showcase. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
+
 
 ## Full Web3 Treasury Showcase
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ PythiaLabs currently does not claim:
 - JSON via `jason`
 - CI: GitHub Actions
 - License: Apache License 2.0
-- Runtime note: canonical float encoding in evidence paths uses Erlang/OTP 25+ behavior (`:erlang.float_to_binary/2` with `[:short]`)
+
+Runtime note: canonical float encoding in evidence paths uses Erlang/OTP 25+ behavior (`:erlang.float_to_binary/2` with `[:short]`).
 
 ## Values
 ### Business Value
@@ -265,6 +266,8 @@ Run:
 ```bash
 mix run examples/banking_ai_risk_showcase.exs
 ```
+
+For expected reviewer-facing output, see: `docs/banking_ai_risk_showcase_expected_output.md`
 
 This is a deterministic local showcase for governance/audit reasoning. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ PythiaLabs currently does not claim:
 - JSON via `jason`
 - CI: GitHub Actions
 - License: Apache License 2.0
+- Runtime note: canonical float encoding in evidence paths uses Erlang/OTP 25+ behavior (`:erlang.float_to_binary/2` with `[:short]`)
 
 ## Values
 ### Business Value

--- a/docs/banking_ai_risk_showcase_expected_output.md
+++ b/docs/banking_ai_risk_showcase_expected_output.md
@@ -1,0 +1,85 @@
+# Banking AI Risk Showcase — Expected Output Guide
+
+Run:
+
+```bash
+mix run examples/banking_ai_risk_showcase.exs
+```
+
+This is a deterministic local showcase for reviewer walkthroughs. It does **not** claim production banking integration, regulatory compliance, or cybersecurity protection.
+
+## Expected sections
+
+The script prints the following deterministic section headers:
+
+- `A. Accepted banking risk action`
+- `B. Rejected action: missing operator approval`
+- `C. Rejected action: stale evidence`
+- `D. Rejected action: valid authorization but unknown at decision time`
+- `E. Evidence export`
+- `F. Evidence digest`
+- `G. Evidence verification`
+- `H. Tampered evidence rejection`
+
+## Expected shape by section
+
+### A) Accepted banking risk action
+
+Expected lines include:
+
+- `status: accepted`
+- `stop_reason: banking_risk_action_accepted`
+- deterministic `trace_event_count`
+
+### B) Missing operator approval
+
+Expected lines include:
+
+- `status: rejected`
+- `stop_reason: missing_operator_approval`
+
+### C) Stale evidence
+
+Expected lines include:
+
+- `status: rejected`
+- `stop_reason: stale_evidence`
+
+### D) Authorization unknown at decision time
+
+Expected lines include:
+
+- `status: rejected`
+- `stop_reason: authorization_unknown_at_decision_time`
+
+### E) Evidence export
+
+Expected lines include:
+
+- `export_status: accepted`
+- `export_stop_reason: banking_risk_action_accepted`
+
+### F) Evidence digest
+
+Expected lines include:
+
+- `algorithm: sha256`
+- `digest: <64-char lowercase hex>`
+
+### G) Evidence verification
+
+Expected lines include:
+
+- `verification_status: verified`
+- `algorithm: sha256`
+
+### H) Tampered evidence rejection
+
+Expected lines include:
+
+- `verification_status: rejected`
+- `reason: digest_mismatch`
+
+## Reviewer note
+
+Banking AI risk is not only about model outputs. This deterministic demo focuses on whether high-risk AI-enabled actions should proceed **before** execution, with stable stop reasons and replayable evidence for audit/review.

--- a/docs/banking_ai_risk_showcase_expected_output.md
+++ b/docs/banking_ai_risk_showcase_expected_output.md
@@ -82,4 +82,6 @@ Expected lines include:
 
 ## Reviewer note
 
-Banking AI risk is not only about model outputs. This deterministic demo focuses on whether high-risk AI-enabled actions should proceed **before** execution, with stable stop reasons and replayable evidence for audit/review.
+Banking AI risk is not only about model outputs. This deterministic demo focuses on decision-time replay reasoning for high-risk AI-enabled actions, with stable stop reasons and replayable evidence for audit/review.
+
+This banking showcase currently focuses on decision traces and evidence verification only. It does not yet include envelope/signed-demo flows from the Web3 treasury showcase.

--- a/examples/banking_ai_risk_showcase.exs
+++ b/examples/banking_ai_risk_showcase.exs
@@ -1,0 +1,114 @@
+alias Pythia.Showcase.BankingRiskAction
+
+base_action = %{
+  action_id: "bank_act_001",
+  action_type: "fraud_response",
+  operator_id: "risk_operator_7",
+  account_id: "acct_demo_01",
+  action_time: ~U[2026-04-26 09:00:00Z],
+  decision_time: ~U[2026-04-26 09:01:00Z]
+}
+
+base_governance_record = %{
+  authorization_valid_from: ~U[2026-04-26 08:30:00Z],
+  authorization_valid_to: ~U[2026-04-26 10:30:00Z],
+  authorization_recorded_at: ~U[2026-04-26 08:45:00Z],
+  evidence_observed_at: ~U[2026-04-26 08:55:00Z],
+  evidence_valid_until: ~U[2026-04-26 09:10:00Z],
+  decision_time_knowledge_present: true,
+  operator_approval_present: true
+}
+
+extract_payload = fn
+  {:ok, payload} -> payload
+  {:error, payload} -> payload
+end
+
+print_step = fn title ->
+  IO.puts("\n=== #{title} ===")
+end
+
+print_verification = fn result ->
+  case result do
+    {:ok, payload} ->
+      IO.puts("verification_status: #{payload.status}")
+      IO.puts("algorithm: #{payload.algorithm}")
+      IO.puts("digest: #{payload.digest}")
+
+    {:error, payload} ->
+      IO.puts("verification_status: #{payload.status}")
+      IO.puts("reason: #{payload.reason}")
+  end
+end
+
+IO.puts("Banking AI Risk Showcase")
+
+IO.puts(
+  "Deterministic local showcase only; not production banking integration or regulatory compliance."
+)
+
+print_step.("A. Accepted banking risk action")
+accepted_result = BankingRiskAction.evaluate(base_action, base_governance_record)
+accepted_payload = extract_payload.(accepted_result)
+
+IO.puts("status: #{accepted_payload.status}")
+IO.puts("stop_reason: #{accepted_payload.stop_reason}")
+IO.puts("trace_event_count: #{length(accepted_payload.trace)}")
+
+print_step.("B. Rejected action: missing operator approval")
+
+missing_approval_result =
+  BankingRiskAction.evaluate(base_action, %{
+    base_governance_record
+    | operator_approval_present: false
+  })
+
+missing_approval_payload = extract_payload.(missing_approval_result)
+IO.puts("status: #{missing_approval_payload.status}")
+IO.puts("stop_reason: #{missing_approval_payload.stop_reason}")
+
+print_step.("C. Rejected action: stale evidence")
+
+stale_evidence_result =
+  BankingRiskAction.evaluate(base_action, %{
+    base_governance_record
+    | evidence_valid_until: ~U[2026-04-26 08:59:00Z]
+  })
+
+stale_evidence_payload = extract_payload.(stale_evidence_result)
+IO.puts("status: #{stale_evidence_payload.status}")
+IO.puts("stop_reason: #{stale_evidence_payload.stop_reason}")
+
+print_step.("D. Rejected action: valid authorization but unknown at decision time")
+
+unknown_auth_result =
+  BankingRiskAction.evaluate(base_action, %{
+    base_governance_record
+    | authorization_recorded_at: ~U[2026-04-26 09:03:00Z]
+  })
+
+unknown_auth_payload = extract_payload.(unknown_auth_result)
+IO.puts("status: #{unknown_auth_payload.status}")
+IO.puts("stop_reason: #{unknown_auth_payload.stop_reason}")
+
+print_step.("E. Evidence export")
+exported = BankingRiskAction.export_result(accepted_result)
+IO.puts("export_status: #{exported["status"]}")
+IO.puts("export_stop_reason: #{exported["stop_reason"]}")
+
+print_step.("F. Evidence digest")
+digest = BankingRiskAction.export_digest(accepted_result)
+IO.puts("algorithm: #{digest["algorithm"]}")
+IO.puts("digest: #{digest["digest"]}")
+
+print_step.("G. Evidence verification")
+evidence = BankingRiskAction.export_evidence(accepted_result)
+verification = BankingRiskAction.verify_evidence(evidence)
+print_verification.(verification)
+
+print_step.("H. Tampered evidence rejection")
+tampered = put_in(evidence, ["payload", "stop_reason"], "tampered_stop_reason")
+tampered_verification = BankingRiskAction.verify_evidence(tampered)
+print_verification.(tampered_verification)
+
+IO.puts("\nShowcase completed.")

--- a/examples/banking_ai_risk_showcase.exs
+++ b/examples/banking_ai_risk_showcase.exs
@@ -44,7 +44,7 @@ end
 IO.puts("Banking AI Risk Showcase")
 
 IO.puts(
-  "Deterministic local showcase only; not production banking integration or regulatory compliance."
+  "Deterministic local showcase only; not production banking integration, regulatory compliance, or cybersecurity protection."
 )
 
 print_step.("A. Accepted banking risk action")

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -92,14 +92,9 @@ defmodule Pythia.Showcase.BankingRiskAction do
 
   @spec export_digest({:ok, map()} | {:error, map()}) :: map()
   def export_digest(result) do
-    digest =
-      result
-      |> export_result()
-      |> canonical_encode()
-      |> then(&:crypto.hash(:sha256, &1))
-      |> Base.encode16(case: :lower)
-
-    %{"algorithm" => @integrity_algorithm, "digest" => digest}
+    result
+    |> export_result()
+    |> digest_export_payload()
   end
 
   @spec export_evidence({:ok, map()} | {:error, map()}) :: map()
@@ -160,10 +155,21 @@ defmodule Pythia.Showcase.BankingRiskAction do
 
   def verify_evidence(_evidence), do: rejected(:invalid_evidence_shape)
 
+  @doc """
+  Returns a canonical SHA-256 digest for an export-shaped payload.
+
+  The payload is normalized and then validated against the export schema
+  (`status`, `stop_reason`, `trace`) before digesting.
+  """
   @spec digest_export_payload(map()) :: map()
   def digest_export_payload(payload) when is_map(payload) do
-    digest =
+    normalized_payload =
       payload
+      |> normalize_value()
+      |> whitelist_payload_fields()
+
+    digest =
+      normalized_payload
       |> canonical_encode()
       |> then(&:crypto.hash(:sha256, &1))
       |> Base.encode16(case: :lower)

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -1,6 +1,7 @@
 defmodule Pythia.Showcase.BankingRiskAction do
   @moduledoc """
-  Deterministic local showcase for banking AI-risk pre-execution action control.
+  Deterministic local showcase for banking AI-risk decision-time replay and audit reasoning.
+  This module is a local governance/audit showcase and does not implement real banking controls.
   """
 
   @supported_action_types MapSet.new([
@@ -15,6 +16,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
     :action_id,
     :action_type,
     :operator_id,
+    :account_id,
     :action_time,
     :decision_time
   ]
@@ -43,7 +45,9 @@ defmodule Pythia.Showcase.BankingRiskAction do
   @evidence_keys MapSet.new(["artifact_type", "algorithm", "digest", "payload"])
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
-  def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
+  def evaluate(action, governance_record)
+      when is_map(action) and not is_struct(action) and is_map(governance_record) and
+             not is_struct(governance_record) do
     proposed_trace = [proposed_action_trace(action)]
 
     with :ok <- validate_action(action),
@@ -68,6 +72,17 @@ defmodule Pythia.Showcase.BankingRiskAction do
             ]
 
         reject(stop_reason, trace)
+
+      {:error, stop_reason, failed_check, details}
+      when is_atom(failed_check) and is_map(details) ->
+        trace =
+          proposed_trace ++
+            [
+              check_trace(failed_check, :fail, Map.put(details, :reason, stop_reason)),
+              decision_trace(:reject, stop_reason)
+            ]
+
+        reject(stop_reason, trace)
     end
   end
 
@@ -82,7 +97,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
   def export_result({status, payload}) when status in [:ok, :error] and is_map(payload) do
     payload
     |> normalize_value()
-    |> ensure_export_status()
+    |> whitelist_payload_fields()
   end
 
   @spec export_digest({:ok, map()} | {:error, map()}) :: map()
@@ -192,18 +207,23 @@ defmodule Pythia.Showcase.BankingRiskAction do
   end
 
   defp validate_required_fields(record, fields, stop_reason) do
-    if Enum.all?(fields, &Map.has_key?(record, &1)) do
-      :ok
-    else
-      {:error, stop_reason, :shape_validation_check}
+    case Enum.find(fields, &(not Map.has_key?(record, &1))) do
+      nil ->
+        :ok
+
+      missing_field ->
+        {:error, stop_reason, :shape_validation_check, %{missing_field: missing_field}}
     end
   end
 
   defp validate_datetime_fields(record, fields, stop_reason) do
-    if Enum.all?(fields, &match?(%DateTime{}, record[&1])) do
-      :ok
-    else
-      {:error, stop_reason, :shape_validation_check}
+    case Enum.find(fields, &(not match?(%DateTime{}, record[&1]))) do
+      nil ->
+        :ok
+
+      invalid_field ->
+        {:error, stop_reason, :shape_validation_check,
+         %{invalid_field: invalid_field, expected_type: :datetime}}
     end
   end
 
@@ -211,7 +231,8 @@ defmodule Pythia.Showcase.BankingRiskAction do
     if is_boolean(record[field]) do
       :ok
     else
-      {:error, :invalid_governance_record, :shape_validation_check}
+      {:error, :invalid_governance_record, :shape_validation_check,
+       %{invalid_field: field, expected_type: :boolean}}
     end
   end
 
@@ -336,13 +357,23 @@ defmodule Pythia.Showcase.BankingRiskAction do
     end
   end
 
-  defp ensure_export_status(export) do
-    status = if export["status"] == "accepted", do: "accepted", else: "rejected"
+  defp whitelist_payload_fields(export) do
+    status = Map.fetch!(export, "status")
+    stop_reason = Map.fetch!(export, "stop_reason")
+    trace = Map.fetch!(export, "trace")
+
+    unless status in ["accepted", "rejected"] do
+      raise ArgumentError, "unsupported export status: #{inspect(status)}"
+    end
+
+    unless is_list(trace) do
+      raise ArgumentError, "trace must be a list, got: #{inspect(trace)}"
+    end
 
     %{
       "status" => status,
-      "stop_reason" => export["stop_reason"],
-      "trace" => export["trace"] || []
+      "stop_reason" => stop_reason,
+      "trace" => trace
     }
   end
 
@@ -379,7 +410,8 @@ defmodule Pythia.Showcase.BankingRiskAction do
       result: :observed,
       action_id: action[:action_id],
       action_type: action[:action_type],
-      operator_id: action[:operator_id]
+      operator_id: action[:operator_id],
+      account_id: action[:account_id]
     }
   end
 
@@ -434,17 +466,29 @@ defmodule Pythia.Showcase.BankingRiskAction do
   end
 
   defp canonical_encode(value) when is_binary(value), do: "\"" <> escape_string(value) <> "\""
-  defp canonical_encode(value) when is_number(value), do: to_string(value)
+  defp canonical_encode(value) when is_integer(value), do: Integer.to_string(value)
+  defp canonical_encode(value) when is_float(value), do: :erlang.float_to_binary(value, [:short])
   defp canonical_encode(true), do: "true"
   defp canonical_encode(false), do: "false"
   defp canonical_encode(nil), do: "null"
 
   defp escape_string(value) do
     value
-    |> String.replace("\\", "\\\\")
-    |> String.replace("\"", "\\\"")
-    |> String.replace("\n", "\\n")
-    |> String.replace("\r", "\\r")
-    |> String.replace("\t", "\\t")
+    |> String.to_charlist()
+    |> Enum.map_join(&escape_codepoint/1)
   end
+
+  defp escape_codepoint(?\\), do: "\\\\"
+  defp escape_codepoint(?"), do: "\\\""
+  defp escape_codepoint(?\n), do: "\\n"
+  defp escape_codepoint(?\r), do: "\\r"
+  defp escape_codepoint(?\t), do: "\\t"
+  defp escape_codepoint(?\b), do: "\\b"
+  defp escape_codepoint(?\f), do: "\\f"
+
+  defp escape_codepoint(codepoint) when codepoint in 0..31 do
+    "\\u" <> (codepoint |> Integer.to_string(16) |> String.pad_leading(4, "0"))
+  end
+
+  defp escape_codepoint(codepoint), do: <<codepoint::utf8>>
 end

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -2,6 +2,9 @@ defmodule Pythia.Showcase.BankingRiskAction do
   @moduledoc """
   Deterministic local showcase for banking AI-risk decision-time replay and audit reasoning.
   This module is a local governance/audit showcase and does not implement real banking controls.
+
+  DateTime values are canonicalized with `DateTime.to_iso8601/1`. Evidence digests are therefore
+  sensitive to timestamp precision (e.g., second-level literals vs microsecond timestamps).
   """
 
   @supported_action_types MapSet.new([
@@ -164,6 +167,8 @@ defmodule Pythia.Showcase.BankingRiskAction do
 
   The payload is normalized and then validated against the export schema
   (`status`, `stop_reason`, `trace`) before digesting.
+  Raises `ArgumentError` if keys are missing, unexpected keys are present, status is unsupported,
+  or trace is not a list.
   """
   @spec digest_export_payload(map()) :: map()
   def digest_export_payload(payload) when is_map(payload) do
@@ -373,6 +378,12 @@ defmodule Pythia.Showcase.BankingRiskAction do
   end
 
   defp whitelist_payload_fields(export) do
+    keys = export |> Map.keys() |> MapSet.new()
+
+    unless MapSet.equal?(keys, @export_payload_keys) do
+      raise ArgumentError, "export payload must contain only status, stop_reason, trace"
+    end
+
     status = Map.fetch!(export, "status")
     stop_reason = Map.fetch!(export, "stop_reason")
     trace = Map.fetch!(export, "trace")

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -43,6 +43,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
   @artifact_type "pythia.banking_risk_action.decision_trace.v1"
   @integrity_algorithm "sha256"
   @evidence_keys MapSet.new(["artifact_type", "algorithm", "digest", "payload"])
+  @export_payload_keys MapSet.new(["status", "stop_reason", "trace"])
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record)
@@ -122,6 +123,9 @@ defmodule Pythia.Showcase.BankingRiskAction do
         rejected(:invalid_evidence_shape)
 
       not valid_evidence_shape?(artifact_type, algorithm, digest, payload) ->
+        rejected(:invalid_evidence_shape)
+
+      not valid_export_payload_shape?(payload) ->
         rejected(:invalid_evidence_shape)
 
       artifact_type != @artifact_type ->
@@ -392,6 +396,16 @@ defmodule Pythia.Showcase.BankingRiskAction do
     is_binary(artifact_type) and is_binary(algorithm) and valid_digest?(digest) and
       is_map(payload)
   end
+
+  defp valid_export_payload_shape?(payload) when is_map(payload) do
+    payload_keys = payload |> Map.keys() |> MapSet.new()
+
+    payload_keys == @export_payload_keys and
+      payload["status"] in ["accepted", "rejected"] and
+      is_list(payload["trace"])
+  end
+
+  defp valid_export_payload_shape?(_payload), do: false
 
   defp valid_evidence_key_set?(evidence) when is_map(evidence) do
     evidence

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -1,0 +1,437 @@
+defmodule Pythia.Showcase.BankingRiskAction do
+  @moduledoc """
+  Deterministic local showcase for banking AI-risk pre-execution action control.
+  """
+
+  @supported_action_types MapSet.new([
+                            "fraud_response",
+                            "account_restriction",
+                            "vulnerability_escalation",
+                            "treasury_hold",
+                            "incident_escalation"
+                          ])
+
+  @required_action_fields [
+    :action_id,
+    :action_type,
+    :operator_id,
+    :action_time,
+    :decision_time
+  ]
+
+  @required_governance_fields [
+    :authorization_valid_from,
+    :authorization_valid_to,
+    :authorization_recorded_at,
+    :evidence_observed_at,
+    :evidence_valid_until,
+    :decision_time_knowledge_present,
+    :operator_approval_present
+  ]
+
+  @check_order [
+    :action_type_check,
+    :authorization_valid_time_check,
+    :authorization_decision_time_check,
+    :evidence_freshness_check,
+    :decision_time_knowledge_check,
+    :operator_approval_check
+  ]
+
+  @artifact_type "pythia.banking_risk_action.decision_trace.v1"
+  @integrity_algorithm "sha256"
+
+  @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
+  def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
+    proposed_trace = [proposed_action_trace(action)]
+
+    with :ok <- validate_action(action),
+         :ok <- validate_governance_record(governance_record),
+         {:ok, trace} <- run_checks(action, governance_record, proposed_trace) do
+      {:ok,
+       %{
+         status: :accepted,
+         stop_reason: :banking_risk_action_accepted,
+         trace: trace ++ [decision_trace(:accept, :banking_risk_action_accepted)]
+       }}
+    else
+      {:error, stop_reason, trace} when is_list(trace) ->
+        reject(stop_reason, trace ++ [decision_trace(:reject, stop_reason)])
+
+      {:error, stop_reason, failed_check} when is_atom(failed_check) ->
+        trace =
+          proposed_trace ++
+            [
+              check_trace(failed_check, :fail, %{reason: stop_reason}),
+              decision_trace(:reject, stop_reason)
+            ]
+
+        reject(stop_reason, trace)
+    end
+  end
+
+  def evaluate(_action, _governance_record) do
+    reject(:invalid_action_or_governance_record, [
+      proposed_action_trace(%{}),
+      decision_trace(:reject, :invalid_action_or_governance_record)
+    ])
+  end
+
+  @spec export_result({:ok, map()} | {:error, map()}) :: map()
+  def export_result({status, payload}) when status in [:ok, :error] and is_map(payload) do
+    payload
+    |> normalize_value()
+    |> ensure_export_status()
+  end
+
+  @spec export_digest({:ok, map()} | {:error, map()}) :: map()
+  def export_digest(result) do
+    digest =
+      result
+      |> export_result()
+      |> canonical_encode()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    %{"algorithm" => @integrity_algorithm, "digest" => digest}
+  end
+
+  @spec export_evidence({:ok, map()} | {:error, map()}) :: map()
+  def export_evidence(result) do
+    payload = export_result(result)
+    digest = digest_payload(payload)
+
+    %{
+      "artifact_type" => @artifact_type,
+      "algorithm" => digest["algorithm"],
+      "digest" => digest["digest"],
+      "payload" => payload
+    }
+  end
+
+  @spec verify_evidence(map()) :: {:ok, map()} | {:error, map()}
+  def verify_evidence(evidence) when is_map(evidence) do
+    artifact_type = evidence["artifact_type"]
+    algorithm = evidence["algorithm"]
+    digest = evidence["digest"]
+    payload = evidence["payload"]
+
+    cond do
+      not valid_evidence_shape?(artifact_type, algorithm, digest, payload) ->
+        rejected(:invalid_evidence_shape)
+
+      artifact_type != @artifact_type ->
+        rejected(:unsupported_artifact_type)
+
+      algorithm != @integrity_algorithm ->
+        rejected(:unsupported_algorithm)
+
+      true ->
+        actual_digest = digest_payload(payload)["digest"]
+
+        if digest == actual_digest do
+          {:ok,
+           %{
+             status: :verified,
+             artifact_type: artifact_type,
+             algorithm: algorithm,
+             digest: digest
+           }}
+        else
+          {:error,
+           %{
+             status: :rejected,
+             reason: :digest_mismatch,
+             expected_digest: digest,
+             actual_digest: actual_digest
+           }}
+        end
+    end
+  end
+
+  def verify_evidence(_evidence), do: rejected(:invalid_evidence_shape)
+
+  defp validate_action(action) do
+    with :ok <- validate_required_fields(action, @required_action_fields, :invalid_action_shape),
+         :ok <-
+           validate_datetime_fields(action, [:action_time, :decision_time], :invalid_action_shape),
+         :ok <- validate_decision_time(action) do
+      :ok
+    end
+  end
+
+  defp validate_governance_record(governance_record) do
+    datetime_fields = [
+      :authorization_valid_from,
+      :authorization_valid_to,
+      :authorization_recorded_at,
+      :evidence_observed_at,
+      :evidence_valid_until
+    ]
+
+    with :ok <-
+           validate_required_fields(
+             governance_record,
+             @required_governance_fields,
+             :invalid_governance_record
+           ),
+         :ok <-
+           validate_datetime_fields(
+             governance_record,
+             datetime_fields,
+             :invalid_governance_record
+           ),
+         :ok <- validate_boolean_field(governance_record, :decision_time_knowledge_present),
+         :ok <- validate_boolean_field(governance_record, :operator_approval_present) do
+      :ok
+    end
+  end
+
+  defp validate_required_fields(record, fields, stop_reason) do
+    if Enum.all?(fields, &Map.has_key?(record, &1)) do
+      :ok
+    else
+      {:error, stop_reason, :shape_validation_check}
+    end
+  end
+
+  defp validate_datetime_fields(record, fields, stop_reason) do
+    if Enum.all?(fields, &match?(%DateTime{}, record[&1])) do
+      :ok
+    else
+      {:error, stop_reason, :shape_validation_check}
+    end
+  end
+
+  defp validate_boolean_field(record, field) do
+    if is_boolean(record[field]) do
+      :ok
+    else
+      {:error, :invalid_governance_record, :shape_validation_check}
+    end
+  end
+
+  defp validate_decision_time(action) do
+    case DateTime.compare(action.action_time, action.decision_time) do
+      :gt -> {:error, :decision_time_before_action_time, :decision_time_check}
+      _ -> :ok
+    end
+  end
+
+  defp run_checks(action, governance_record, trace) do
+    Enum.reduce_while(@check_order, {:ok, trace}, fn check, {:ok, acc_trace} ->
+      case run_check(check, action, governance_record) do
+        {:ok, details} ->
+          {:cont, {:ok, acc_trace ++ [check_trace(check, :pass, details)]}}
+
+        {:error, stop_reason, details} ->
+          fail_trace = acc_trace ++ [check_trace(check, :fail, details)]
+          {:halt, {:error, stop_reason, fail_trace}}
+      end
+    end)
+  end
+
+  defp run_check(:action_type_check, action, _governance_record) do
+    action_type = action.action_type
+
+    if MapSet.member?(@supported_action_types, action_type) do
+      {:ok, %{action_type: action_type}}
+    else
+      {:error, :unsupported_action_type,
+       %{action_type: action_type, reason: :unsupported_action_type}}
+    end
+  end
+
+  defp run_check(:authorization_valid_time_check, action, governance_record) do
+    action_time = action.action_time
+    valid_from = governance_record.authorization_valid_from
+    valid_to = governance_record.authorization_valid_to
+
+    cond do
+      DateTime.compare(action_time, valid_from) == :lt ->
+        {:error, :authorization_not_yet_valid,
+         %{reason: :authorization_not_yet_valid, action_time: action_time, valid_from: valid_from}}
+
+      DateTime.compare(action_time, valid_to) == :gt ->
+        {:error, :authorization_expired,
+         %{reason: :authorization_expired, action_time: action_time, valid_to: valid_to}}
+
+      true ->
+        {:ok, %{action_time: action_time, valid_from: valid_from, valid_to: valid_to}}
+    end
+  end
+
+  defp run_check(:authorization_decision_time_check, action, governance_record) do
+    decision_time = action.decision_time
+    authorization_recorded_at = governance_record.authorization_recorded_at
+
+    if DateTime.compare(authorization_recorded_at, decision_time) in [:lt, :eq] do
+      {:ok,
+       %{
+         decision_time: decision_time,
+         authorization_recorded_at: authorization_recorded_at
+       }}
+    else
+      {:error, :authorization_unknown_at_decision_time,
+       %{
+         reason: :authorization_unknown_at_decision_time,
+         decision_time: decision_time,
+         authorization_recorded_at: authorization_recorded_at
+       }}
+    end
+  end
+
+  defp run_check(:evidence_freshness_check, action, governance_record) do
+    decision_time = action.decision_time
+    observed_at = governance_record.evidence_observed_at
+    valid_until = governance_record.evidence_valid_until
+
+    cond do
+      DateTime.compare(valid_until, decision_time) == :lt ->
+        {:error, :stale_evidence,
+         %{
+           reason: :stale_evidence,
+           evidence_observed_at: observed_at,
+           evidence_valid_until: valid_until,
+           decision_time: decision_time
+         }}
+
+      DateTime.compare(observed_at, decision_time) == :gt ->
+        {:error, :evidence_recorded_after_decision_time,
+         %{
+           reason: :evidence_recorded_after_decision_time,
+           evidence_observed_at: observed_at,
+           decision_time: decision_time
+         }}
+
+      true ->
+        {:ok,
+         %{
+           evidence_observed_at: observed_at,
+           evidence_valid_until: valid_until,
+           decision_time: decision_time
+         }}
+    end
+  end
+
+  defp run_check(:decision_time_knowledge_check, _action, governance_record) do
+    if governance_record.decision_time_knowledge_present do
+      {:ok, %{decision_time_knowledge_present: true}}
+    else
+      {:error, :missing_decision_time_knowledge,
+       %{reason: :missing_decision_time_knowledge, decision_time_knowledge_present: false}}
+    end
+  end
+
+  defp run_check(:operator_approval_check, _action, governance_record) do
+    if governance_record.operator_approval_present do
+      {:ok, %{operator_approval_present: true}}
+    else
+      {:error, :missing_operator_approval,
+       %{reason: :missing_operator_approval, operator_approval_present: false}}
+    end
+  end
+
+  defp ensure_export_status(export) do
+    status = if export["status"] == "accepted", do: "accepted", else: "rejected"
+
+    %{
+      "status" => status,
+      "stop_reason" => export["stop_reason"],
+      "trace" => export["trace"] || []
+    }
+  end
+
+  defp digest_payload(payload) do
+    digest =
+      payload
+      |> canonical_encode()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    %{"algorithm" => @integrity_algorithm, "digest" => digest}
+  end
+
+  defp valid_evidence_shape?(artifact_type, algorithm, digest, payload) do
+    is_binary(artifact_type) and is_binary(algorithm) and valid_digest?(digest) and
+      is_map(payload)
+  end
+
+  defp valid_digest?(digest),
+    do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)
+
+  defp proposed_action_trace(action) do
+    %{
+      event: :proposed_action,
+      result: :observed,
+      action_id: action[:action_id],
+      action_type: action[:action_type],
+      operator_id: action[:operator_id]
+    }
+  end
+
+  defp check_trace(check, result, details),
+    do: Map.merge(%{event: check, result: result}, details)
+
+  defp decision_trace(result, stop_reason),
+    do: %{event: :decision, result: result, stop_reason: stop_reason}
+
+  defp reject(stop_reason, trace),
+    do: {:error, %{status: :rejected, stop_reason: stop_reason, trace: trace}}
+
+  defp rejected(reason), do: {:error, %{status: :rejected, reason: reason}}
+
+  defp normalize_value(value) when is_boolean(value) or is_nil(value), do: value
+  defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+
+  defp normalize_value(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> normalize_value()
+  end
+
+  defp normalize_value(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, item} -> {normalize_key(key), normalize_value(item)} end)
+    |> Enum.sort_by(fn {key, _item} -> key end)
+    |> Map.new()
+  end
+
+  defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
+  defp normalize_value(value) when is_binary(value) or is_number(value), do: value
+
+  defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_key(key) when is_binary(key), do: key
+  defp normalize_key(key), do: to_string(key)
+
+  defp canonical_encode(value) when is_map(value) do
+    body =
+      value
+      |> Enum.sort_by(fn {key, _value} -> key end)
+      |> Enum.map_join(",", fn {key, item} ->
+        canonical_encode(to_string(key)) <> ":" <> canonical_encode(item)
+      end)
+
+    "{" <> body <> "}"
+  end
+
+  defp canonical_encode(value) when is_list(value) do
+    "[" <> Enum.map_join(value, ",", &canonical_encode/1) <> "]"
+  end
+
+  defp canonical_encode(value) when is_binary(value), do: "\"" <> escape_string(value) <> "\""
+  defp canonical_encode(value) when is_number(value), do: to_string(value)
+  defp canonical_encode(true), do: "true"
+  defp canonical_encode(false), do: "false"
+  defp canonical_encode(nil), do: "null"
+
+  defp escape_string(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\"", "\\\"")
+    |> String.replace("\n", "\\n")
+    |> String.replace("\r", "\\r")
+    |> String.replace("\t", "\\t")
+  end
+end

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -63,16 +63,6 @@ defmodule Pythia.Showcase.BankingRiskAction do
       {:error, stop_reason, trace} when is_list(trace) ->
         reject(stop_reason, trace ++ [decision_trace(:reject, stop_reason)])
 
-      {:error, stop_reason, failed_check} when is_atom(failed_check) ->
-        trace =
-          proposed_trace ++
-            [
-              check_trace(failed_check, :fail, %{reason: stop_reason}),
-              decision_trace(:reject, stop_reason)
-            ]
-
-        reject(stop_reason, trace)
-
       {:error, stop_reason, failed_check, details}
       when is_atom(failed_check) and is_map(details) ->
         trace =
@@ -115,7 +105,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
   @spec export_evidence({:ok, map()} | {:error, map()}) :: map()
   def export_evidence(result) do
     payload = export_result(result)
-    digest = digest_payload(payload)
+    digest = digest_export_payload(payload)
 
     %{
       "artifact_type" => @artifact_type,
@@ -146,7 +136,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
         rejected(:unsupported_algorithm)
 
       true ->
-        actual_digest = digest_payload(payload)["digest"]
+        actual_digest = digest_export_payload(payload)["digest"]
 
         if digest == actual_digest do
           {:ok,
@@ -169,6 +159,17 @@ defmodule Pythia.Showcase.BankingRiskAction do
   end
 
   def verify_evidence(_evidence), do: rejected(:invalid_evidence_shape)
+
+  @spec digest_export_payload(map()) :: map()
+  def digest_export_payload(payload) when is_map(payload) do
+    digest =
+      payload
+      |> canonical_encode()
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.encode16(case: :lower)
+
+    %{"algorithm" => @integrity_algorithm, "digest" => digest}
+  end
 
   defp validate_action(action) do
     with :ok <- validate_required_fields(action, @required_action_fields, :invalid_action_shape),
@@ -238,8 +239,12 @@ defmodule Pythia.Showcase.BankingRiskAction do
 
   defp validate_decision_time(action) do
     case DateTime.compare(action.action_time, action.decision_time) do
-      :gt -> {:error, :decision_time_before_action_time, :decision_time_check}
-      _ -> :ok
+      :gt ->
+        {:error, :decision_time_before_action_time, :decision_time_check,
+         %{action_time: action.action_time, decision_time: action.decision_time}}
+
+      _ ->
+        :ok
     end
   end
 
@@ -375,16 +380,6 @@ defmodule Pythia.Showcase.BankingRiskAction do
       "stop_reason" => stop_reason,
       "trace" => trace
     }
-  end
-
-  defp digest_payload(payload) do
-    digest =
-      payload
-      |> canonical_encode()
-      |> then(&:crypto.hash(:sha256, &1))
-      |> Base.encode16(case: :lower)
-
-    %{"algorithm" => @integrity_algorithm, "digest" => digest}
   end
 
   defp valid_evidence_shape?(artifact_type, algorithm, digest, payload) do

--- a/lib/pythia/showcase/banking_risk_action.ex
+++ b/lib/pythia/showcase/banking_risk_action.ex
@@ -40,6 +40,7 @@ defmodule Pythia.Showcase.BankingRiskAction do
 
   @artifact_type "pythia.banking_risk_action.decision_trace.v1"
   @integrity_algorithm "sha256"
+  @evidence_keys MapSet.new(["artifact_type", "algorithm", "digest", "payload"])
 
   @spec evaluate(map(), map()) :: {:ok, map()} | {:error, map()}
   def evaluate(action, governance_record) when is_map(action) and is_map(governance_record) do
@@ -117,6 +118,9 @@ defmodule Pythia.Showcase.BankingRiskAction do
     payload = evidence["payload"]
 
     cond do
+      not valid_evidence_key_set?(evidence) ->
+        rejected(:invalid_evidence_shape)
+
       not valid_evidence_shape?(artifact_type, algorithm, digest, payload) ->
         rejected(:invalid_evidence_shape)
 
@@ -356,6 +360,15 @@ defmodule Pythia.Showcase.BankingRiskAction do
     is_binary(artifact_type) and is_binary(algorithm) and valid_digest?(digest) and
       is_map(payload)
   end
+
+  defp valid_evidence_key_set?(evidence) when is_map(evidence) do
+    evidence
+    |> Map.keys()
+    |> MapSet.new()
+    |> MapSet.equal?(@evidence_keys)
+  end
+
+  defp valid_evidence_key_set?(_evidence), do: false
 
   defp valid_digest?(digest),
     do: is_binary(digest) and String.match?(digest, ~r/\A[0-9a-f]{64}\z/)

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -1,0 +1,75 @@
+defmodule Pythia.Showcase.BankingRiskActionTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Showcase.BankingRiskAction
+
+  setup do
+    action = %{
+      action_id: "bank_act_001",
+      action_type: "fraud_response",
+      operator_id: "risk_operator_7",
+      account_id: "acct_demo_01",
+      action_time: ~U[2026-04-26 09:00:00Z],
+      decision_time: ~U[2026-04-26 09:01:00Z]
+    }
+
+    governance_record = %{
+      authorization_valid_from: ~U[2026-04-26 08:30:00Z],
+      authorization_valid_to: ~U[2026-04-26 10:30:00Z],
+      authorization_recorded_at: ~U[2026-04-26 08:45:00Z],
+      evidence_observed_at: ~U[2026-04-26 08:55:00Z],
+      evidence_valid_until: ~U[2026-04-26 09:10:00Z],
+      decision_time_knowledge_present: true,
+      operator_approval_present: true
+    }
+
+    %{action: action, governance_record: governance_record}
+  end
+
+  test "accepted action returns banking_risk_action_accepted", ctx do
+    assert {:ok, %{status: :accepted, stop_reason: :banking_risk_action_accepted}} =
+             BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+  end
+
+  test "missing operator approval returns missing_operator_approval", ctx do
+    record = %{ctx.governance_record | operator_approval_present: false}
+
+    assert {:error, %{status: :rejected, stop_reason: :missing_operator_approval}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "stale evidence returns stale_evidence", ctx do
+    record = %{ctx.governance_record | evidence_valid_until: ~U[2026-04-26 08:59:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :stale_evidence}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "authorization known after decision_time returns authorization_unknown_at_decision_time",
+       ctx do
+    record = %{ctx.governance_record | authorization_recorded_at: ~U[2026-04-26 09:03:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_unknown_at_decision_time}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "evidence verification succeeds for clean evidence", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+    evidence = BankingRiskAction.export_evidence(result)
+
+    assert {:ok, %{status: :verified, algorithm: "sha256"}} =
+             BankingRiskAction.verify_evidence(evidence)
+  end
+
+  test "evidence verification fails for tampered evidence", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+
+    tampered =
+      result
+      |> BankingRiskAction.export_evidence()
+      |> put_in(["payload", "stop_reason"], "tampered_stop_reason")
+
+    assert {:error, %{status: :rejected, reason: :digest_mismatch}} =
+             BankingRiskAction.verify_evidence(tampered)
+  end
+end

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -161,6 +161,45 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
              BankingRiskAction.verify_evidence("not-a-map")
   end
 
+  test "verify_evidence rejects evidence with payload missing trace", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+
+    malformed_evidence =
+      result
+      |> BankingRiskAction.export_evidence()
+      |> put_in(["payload"], %{
+        "status" => "accepted",
+        "stop_reason" => "banking_risk_action_accepted"
+      })
+
+    assert {:error, %{status: :rejected, reason: :invalid_evidence_shape}} =
+             BankingRiskAction.verify_evidence(malformed_evidence)
+  end
+
+  test "verify_evidence rejects evidence with unsupported payload status", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+
+    malformed_evidence =
+      result
+      |> BankingRiskAction.export_evidence()
+      |> put_in(["payload", "status"], "pending")
+
+    assert {:error, %{status: :rejected, reason: :invalid_evidence_shape}} =
+             BankingRiskAction.verify_evidence(malformed_evidence)
+  end
+
+  test "verify_evidence rejects evidence with non-list trace", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+
+    malformed_evidence =
+      result
+      |> BankingRiskAction.export_evidence()
+      |> put_in(["payload", "trace"], "not_a_list")
+
+    assert {:error, %{status: :rejected, reason: :invalid_evidence_shape}} =
+             BankingRiskAction.verify_evidence(malformed_evidence)
+  end
+
   test "verify_evidence remains stable when payload keys are reordered", ctx do
     result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
     evidence = BankingRiskAction.export_evidence(result)

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -164,20 +164,26 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
   test "verify_evidence remains stable when payload keys are reordered", ctx do
     result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
     evidence = BankingRiskAction.export_evidence(result)
-    shuffled_payload_pairs = evidence["payload"] |> Map.to_list() |> Enum.shuffle()
-    reordered_payload = Map.new(shuffled_payload_pairs)
-    reordered_evidence = Map.put(evidence, "payload", reordered_payload)
 
-    assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(reordered_evidence)
+    Enum.each(1..20, fn _iteration ->
+      shuffled_payload_pairs = evidence["payload"] |> Map.to_list() |> Enum.shuffle()
+      reordered_payload = Map.new(shuffled_payload_pairs)
+      reordered_evidence = Map.put(evidence, "payload", reordered_payload)
 
-    assert evidence["digest"] ==
-             BankingRiskAction.digest_export_payload(reordered_payload)["digest"]
+      assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(reordered_evidence)
+
+      assert evidence["digest"] ==
+               BankingRiskAction.digest_export_payload(reordered_payload)["digest"]
+    end)
   end
 
   test "evidence digest is stable for accepted snapshot", ctx do
     result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
     digest = BankingRiskAction.export_digest(result)
 
+    # Snapshot test:
+    # If the evidence schema intentionally changes, regenerate with:
+    #   BankingRiskAction.export_digest(BankingRiskAction.evaluate(action, governance_record))
     assert digest["algorithm"] == "sha256"
     assert digest["digest"] == "db3eaf5416545ea0d6cd50e61a904dd703b6b3933ec62b599316566f07825865"
   end

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -164,9 +164,39 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
   test "verify_evidence remains stable when payload keys are reordered", ctx do
     result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
     evidence = BankingRiskAction.export_evidence(result)
-    reordered_payload = evidence["payload"] |> Enum.reverse() |> Map.new()
+    shuffled_payload_pairs = evidence["payload"] |> Map.to_list() |> Enum.shuffle()
+    reordered_payload = Map.new(shuffled_payload_pairs)
     reordered_evidence = Map.put(evidence, "payload", reordered_payload)
 
     assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(reordered_evidence)
+
+    assert evidence["digest"] ==
+             BankingRiskAction.digest_export_payload(reordered_payload)["digest"]
+  end
+
+  test "evidence digest is stable for accepted snapshot", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+    digest = BankingRiskAction.export_digest(result)
+
+    assert digest["algorithm"] == "sha256"
+    assert digest["digest"] == "db3eaf5416545ea0d6cd50e61a904dd703b6b3933ec62b599316566f07825865"
+  end
+
+  test "canonicalization handles control characters and float values" do
+    payload = %{
+      status: :accepted,
+      stop_reason: :banking_risk_action_accepted,
+      trace: [
+        %{
+          event: :decision,
+          result: :accept,
+          note: "line1\nline2\ttab\bbackspace\fform" <> <<1>>,
+          confidence: 0.85
+        }
+      ]
+    }
+
+    evidence = BankingRiskAction.export_evidence({:ok, payload})
+    assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(evidence)
   end
 end

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -161,7 +161,7 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
              BankingRiskAction.verify_evidence("not-a-map")
   end
 
-  test "verify_evidence rejects evidence with payload missing trace", ctx do
+  test "verify_evidence rejects evidence with missing payload key set", ctx do
     result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
 
     malformed_evidence =
@@ -242,6 +242,10 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
     }
 
     evidence = BankingRiskAction.export_evidence({:ok, payload})
+
+    assert evidence["digest"] ==
+             "5bf235299710b8fd15b33db799a326a7075a620d056af29a2fd8f34b29d89767"
+
     assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(evidence)
   end
 end

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -31,6 +31,11 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
              BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
   end
 
+  test "accepted trace includes account_id in proposed_action", ctx do
+    assert {:ok, %{trace: trace}} = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+    assert hd(trace).account_id == "acct_demo_01"
+  end
+
   test "missing operator approval returns missing_operator_approval", ctx do
     record = %{ctx.governance_record | operator_approval_present: false}
 
@@ -118,5 +123,50 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
 
     assert {:error, %{status: :rejected, stop_reason: :missing_decision_time_knowledge}} =
              BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "decision_time_before_action_time is rejected", ctx do
+    action = %{ctx.action | decision_time: ~U[2026-04-26 08:59:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :decision_time_before_action_time}} =
+             BankingRiskAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "missing required action field reports missing_field details", ctx do
+    action = Map.delete(ctx.action, :account_id)
+
+    assert {:error, %{status: :rejected, stop_reason: :invalid_action_shape, trace: trace}} =
+             BankingRiskAction.evaluate(action, ctx.governance_record)
+
+    assert Enum.at(trace, 1).missing_field == :account_id
+  end
+
+  test "invalid governance record boolean shape reports invalid field", ctx do
+    record = %{ctx.governance_record | operator_approval_present: "yes"}
+
+    assert {:error, %{status: :rejected, stop_reason: :invalid_governance_record, trace: trace}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+
+    assert Enum.at(trace, 1).invalid_field == :operator_approval_present
+    assert Enum.at(trace, 1).expected_type == :boolean
+  end
+
+  test "evaluate fallback rejects non-map inputs" do
+    assert {:error, %{status: :rejected, stop_reason: :invalid_action_or_governance_record}} =
+             BankingRiskAction.evaluate(nil, nil)
+  end
+
+  test "verify_evidence rejects non-map input" do
+    assert {:error, %{status: :rejected, reason: :invalid_evidence_shape}} =
+             BankingRiskAction.verify_evidence("not-a-map")
+  end
+
+  test "verify_evidence remains stable when payload keys are reordered", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+    evidence = BankingRiskAction.export_evidence(result)
+    reordered_payload = evidence["payload"] |> Enum.reverse() |> Map.new()
+    reordered_evidence = Map.put(evidence, "payload", reordered_payload)
+
+    assert {:ok, %{status: :verified}} = BankingRiskAction.verify_evidence(reordered_evidence)
   end
 end

--- a/test/pythia/showcase/banking_risk_action_test.exs
+++ b/test/pythia/showcase/banking_risk_action_test.exs
@@ -72,4 +72,51 @@ defmodule Pythia.Showcase.BankingRiskActionTest do
     assert {:error, %{status: :rejected, reason: :digest_mismatch}} =
              BankingRiskAction.verify_evidence(tampered)
   end
+
+  test "evidence with unexpected top-level key is rejected", ctx do
+    result = BankingRiskAction.evaluate(ctx.action, ctx.governance_record)
+
+    tampered =
+      result
+      |> BankingRiskAction.export_evidence()
+      |> Map.put("hidden_policy", "fake")
+
+    assert {:error, %{status: :rejected, reason: :invalid_evidence_shape}} =
+             BankingRiskAction.verify_evidence(tampered)
+  end
+
+  test "unsupported action_type returns unsupported_action_type", ctx do
+    action = %{ctx.action | action_type: "wire_override"}
+
+    assert {:error, %{status: :rejected, stop_reason: :unsupported_action_type}} =
+             BankingRiskAction.evaluate(action, ctx.governance_record)
+  end
+
+  test "authorization_not_yet_valid is rejected", ctx do
+    record = %{ctx.governance_record | authorization_valid_from: ~U[2026-04-26 09:30:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_not_yet_valid}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "authorization_expired is rejected", ctx do
+    record = %{ctx.governance_record | authorization_valid_to: ~U[2026-04-26 08:50:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :authorization_expired}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "evidence_recorded_after_decision_time is rejected", ctx do
+    record = %{ctx.governance_record | evidence_observed_at: ~U[2026-04-26 09:03:00Z]}
+
+    assert {:error, %{status: :rejected, stop_reason: :evidence_recorded_after_decision_time}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
+
+  test "missing_decision_time_knowledge is rejected", ctx do
+    record = %{ctx.governance_record | decision_time_knowledge_present: false}
+
+    assert {:error, %{status: :rejected, stop_reason: :missing_decision_time_knowledge}} =
+             BankingRiskAction.evaluate(ctx.action, record)
+  end
 end


### PR DESCRIPTION
### Motivation
- Provide a small deterministic showcase that applies PythiaLabs' pre-execution, temporal-causal reasoning pattern to a banking/frontier-AI risk setting so reviewers can see how high-risk AI-enabled actions are gated before execution. 
- Reuse the existing Web3 treasury evidence/export/verification pattern to demonstrate stop reasons, chronological traces, and replayable evidence for audit without connecting to any real banking systems or implementing exploit logic. 

### Description
- Added the deterministic evaluator module `Pythia.Showcase.BankingRiskAction` (`lib/pythia/showcase/banking_risk_action.ex`) implementing stable checks (authorization times, evidence freshness, decision-time knowledge, operator approval), deterministic trace shape, evidence export, SHA-256 digest, and verification/tamper detection. 
- Added a runnable example `examples/banking_ai_risk_showcase.exs` that prints reviewer-facing scenarios A–H (accepted action, missing approval, stale evidence, unknown authorization at decision time, evidence export/digest/verification, and tamper rejection). 
- Added focused unit tests in `test/pythia/showcase/banking_risk_action_test.exs` covering accepted/rejected flows and evidence verification/tamper failure. 
- Added reviewer-facing expected output guide `docs/banking_ai_risk_showcase_expected_output.md`, updated `README.md` with a new Banking AI Risk Showcase section, and added an Unreleased entry in `CHANGELOG.md`. 

### Testing
- `mix format` completed successfully to ensure consistent formatting. 
- `mix deps.get` / dependency resolution was attempted but blocked by environment TLS/CA issues when contacting `repo.hex.pm`, preventing fetching Hex packages. 
- Because dependencies could not be fetched, `mix test` could not be executed (missing `rustler`, `jason`, `telemetry` etc.), so the newly added tests were not run in this environment. 
- `mix run examples/banking_ai_risk_showcase.exs` was also attempted but could not run for the same dependency-fetch limitation; the example is deterministic and runs locally once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef888fc638832dbc325e652057505a)