### PR TITLE
Reorganize README: prioritize action safety showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,28 @@
-# liminal-pythia — MVP
+# PythiaLabs
 
-PythiaLabs is a deterministic temporal-causal reasoning layer for agentic actions. It evaluates whether an action should proceed before execution, produces stable stop reasons, and exports replayable evidence traces for audit and review.
+Deterministic evidence gates for high-risk agentic actions.
 
-## Current focus
+PythiaLabs evaluates whether an AI/agent action should be allowed, blocked, or escalated under current evidence, authorization, environment, credential, and recovery context — producing replayable traces, stable stop reasons, and tamper-checkable evidence artifacts.
 
-- deterministic reasoning loops
-- agent action safety gates
-- bitemporal authorization reasoning
-- Web3 DAO treasury action review
-- evidence export, verification, and tamper detection
-- local deterministic demos for grant and reviewer evaluation
+## Why this matters
 
-## Main demo for reviewers
+AI agents are moving from text generation into real actions: infrastructure changes, financial decisions, governance actions, and treasury operations. Prompt instructions alone are not a reliable safety boundary. PythiaLabs explores deterministic action gates that make high-risk decisions reviewable, replayable, and auditable.
 
-Run:
+## Current showcases
+
+- **Agent Infrastructure Action Safety** — destructive infrastructure actions such as production volume deletion.
+- **Banking AI Risk** — high-risk financial/agentic actions with operator approval, freshness, and decision-time knowledge checks.
+- **Web3 Treasury Governance** — DAO treasury action review with quorum, timelock, temporal authorization, evidence export, and tamper rejection.
+
+## Reviewer quickstart
 
 ```bash
+mix deps.get
+mix test
+mix run examples/agent_infra_action_showcase.exs
+mix run examples/banking_ai_risk_showcase.exs
 mix run examples/web3_treasury_full_showcase.exs
 ```
-
-This demo shows:
-
-- accepted treasury action
-- rejected treasury action when quorum is not met
-- rejected treasury action when authorization was valid but unknown at decision time
-- evidence export
-- SHA-256 digest generation
-- evidence verification
-- tamper rejection
-- unsigned envelope verification
-- signed_demo envelope generation and verification
-
-Expected output guide: `docs/web3_treasury_full_showcase_expected_output.md`
 
 ## What PythiaLabs is not yet
 
@@ -44,163 +35,66 @@ PythiaLabs currently does not claim:
 - on-chain enforcement
 - production identity verification
 - persistent external storage
+- cloud-provider integration
+- IAM enforcement
+- backup management
+- regulatory compliance
+- cybersecurity protection
 
-**Mission**: Minimal HRM-style reasoning loop for LIMINAL: `propose → run → measure → refine` with transparent step traces, fast kernels, and safe isolation.
+## Agent Infrastructure Action Safety Showcase
 
-## Stack
-
-- Elixir/BEAM for orchestration
-- Rust NIF (via rustler) for fast kernels
-- Rust Port worker for sandboxed solvers (BFS maze)
-- JSON via `jason`
-- CI: GitHub Actions
-- License: Apache License 2.0
-
-Runtime note: canonical float encoding in evidence paths uses Erlang/OTP 25+ behavior (`:erlang.float_to_binary/2` with `[:short]`).
-
-## Values
-### Business Value
-- **Lower compute cost** by winning via refinement, not giant params
-- **Explainability** for clients/regulators (auditable traces)
-- **Easy integration** on top of GPT-5/LLMs with step control
-- **Edge/On‑prem friendly** footprint
-- **Reliability** thanks to BEAM supervision
-
-### Human Value
-- **Transparent reasoning** (no black box)
-- **Co‑thinking**: human can inspect/interrupt/refine
-- **Ethics & control**: limits, stop rules, visible logic
-- **Learning effect**: users adopt the refinement habit
-- **Accessibility**: good performance without huge hardware
-
-## Quickstart
-```bash
-mix deps.get
-mix compile
-
-# refinement demo (strings)
-mix run examples/lev_demo.exs
-
-# port worker build + demo (maze)
-cd workers/solver_port && cargo build --release && cd ../../
-mix run examples/port_demo.exs
-
-# benchmarks (NIF vs fallback)
-mix run benches/bench.exs
-```
-
-## Planner loop (concept)
-```
-state ← init(problem)
-repeat up to max_steps:
-  proposal ← propose(state)
-  candidate ← execute(proposal)
-  score ← measure(candidate)
-  if score ≤ threshold → stop
-  if no_improve ≥ limit → (hook) critic → stop (MVP)
-  state ← refine(state)
-return best
-```
-
-## Current MVP status
-
-PythiaLabs is currently an MVP focused on:
-
-- deterministic refinement loops
-- observable traces
-- stable stop reasons
-- Elixir/BEAM orchestration
-- Rust NIF / Rust Port worker integration
-- deterministic Agent Safety Showcase
-
-The Datomic/Neo4j/XTDB/EventStoreDB/TimescaleDB-style memory layers are not implemented yet.
-They are part of the architectural roadmap.
-
-## Roadmap: persistent reasoning memory
-
-Future versions may add persistent reasoning memory with two complementary layers:
-
-1. **Datomic-style append-only step log**  
-   Stores every reasoning step as an immutable event for replay, audit, debugging, and version comparison.
-
-2. **Neo4j-style hypothesis graph**  
-   Connects actions, constraints, proposals, failures, stop reasons, and successful paths.
-
-This would allow PythiaLabs to support replay, audit, recurring failure analysis, and cross-run reasoning patterns.
-
-This layer is not implemented in the current MVP.
-
-For details, see `docs/persistent_reasoning_memory.md`.
-
-For the broader five-layer roadmap, see `docs/temporal_causal_memory_stack.md`.
-
-For the Web3 application roadmap, see `docs/web3_consensus_reason_layer.md`.
-
-For the design principles behind these decisions, see `docs/design_principles.md`.
-
-For grant preparation materials, see:
-
-- `docs/grant_readiness.md`
-- `docs/threat_model_web3_treasury_reason_layer.md`
-- `docs/grant_one_pager_web3_treasury_reason_layer.md`
-- `docs/grant_application_summary.md`
-
-Additional roadmap items:
-
-- temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
-- critic triggers based on confidence, repeated failure classes, and trace patterns
-- multi-domain executors for QA, graph problems, puzzles, and agent actions
-- Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
-
-## Project trust and governance
-
-Project governance and trust materials:
-
-- `CONTRIBUTING.md`
-- `CODE_OF_CONDUCT.md`
-- `SECURITY.md`
-- `CHANGELOG.md`
-- `docs/license_strategy.md`
-- `docs/security_automation.md`
-
-These documents describe contribution expectations, security reporting, project maturity, release notes, and licensing strategy.
-
-The repository also includes a minimal GitHub Actions security workflow for secret scanning.
-
-## Agent Safety Showcase
-
-PythiaLabs includes a deterministic showcase for controlled agent actions.
-
-The demo shows two core outcomes:
-- a safe action proceeds when the required permission is present
-- an unsafe action is rejected when authorization is missing
-
-It also includes an invalid action example to show strict shape validation.
-The goal is to demonstrate a core PythiaLabs principle: agent actions should produce observable traces and stable stop reasons, not just outputs.
+PythiaLabs includes a deterministic local showcase for high-risk agent infrastructure actions.
+It demonstrates decision-time replay reasoning for destructive operations such as production database volume deletion.
 
 Run:
 
 ```bash
-mix run examples/agent_safety_showcase.exs
+mix run examples/agent_infra_action_showcase.exs
 ```
 
-## Bitemporal Authorization Showcase
+For expected reviewer-facing output, see: `docs/agent_infra_action_showcase_expected_output.md`
 
-PythiaLabs includes a deterministic showcase for temporal authorization reasoning.
+This is a deterministic local showcase only. It does not implement production infrastructure controls and does not claim cloud-provider integration, IAM enforcement, backup management, or cybersecurity protection.
+
+## Banking AI Risk Showcase
+
+PythiaLabs includes a deterministic banking-risk action showcase for AI-enabled financial workflows.
+It demonstrates how a proposed high-risk action can be accepted or rejected during deterministic decision-time replay based on operator approval, evidence freshness, temporal authorization, and decision-time knowledge.
+The showcase emits stable stop reasons and replayable evidence artifacts for audit and review.
 
 Run:
 
 ```bash
-mix run examples/bitemporal_authorization_showcase.exs
+mix run examples/banking_ai_risk_showcase.exs
 ```
 
-The demo shows how an agent action can be accepted or rejected based on:
+For expected reviewer-facing output, see: `docs/banking_ai_risk_showcase_expected_output.md`
 
-- whether the permission was valid at action_time
-- whether the system knew about the permission at decision_time
-- whether the permission was expired or scheduled for the future
+This is a deterministic local showcase for governance/audit reasoning. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
 
-This demonstrates the Temporal-Causal Memory Stack idea without requiring XTDB or any external database.
+## Full Web3 Treasury Showcase
+
+Run:
+
+```bash
+mix run examples/web3_treasury_full_showcase.exs
+```
+
+For expected reviewer-facing output, see: `docs/web3_treasury_full_showcase_expected_output.md`
+
+This single deterministic demo shows:
+
+- accepted and rejected treasury actions
+- chronological decision traces
+- evidence export
+- SHA-256 digest generation
+- evidence verification
+- tamper rejection
+- unsigned evidence envelope verification
+- signed_demo envelope generation
+- signed_demo verification
+
+The `signed_demo` flow is deterministic local demo logic only and is not production cryptography.
 
 ## Web3 Treasury Action Showcase
 
@@ -255,59 +149,161 @@ This `signed_demo` flow is a deterministic local demo only and is not production
 mix run examples/web3_treasury_signed_envelope_demo.exs
 ```
 
+## Agent Safety Showcase
 
-## Agent Infrastructure Action Safety Showcase
+PythiaLabs includes a deterministic showcase for controlled agent actions.
 
-PythiaLabs includes a deterministic local showcase for high-risk agent infrastructure actions.
-It demonstrates decision-time replay reasoning for destructive operations such as production database volume deletion.
+The demo shows two core outcomes:
+- a safe action proceeds when the required permission is present
+- an unsafe action is rejected when authorization is missing
 
-Run:
-
-```bash
-mix run examples/agent_infra_action_showcase.exs
-```
-
-For expected reviewer-facing output, see: `docs/agent_infra_action_showcase_expected_output.md`
-
-This is a deterministic local showcase only. It does not implement production infrastructure controls and does not claim cloud-provider integration, IAM enforcement, backup management, or cybersecurity protection.
-
-## Banking AI Risk Showcase
-
-PythiaLabs includes a deterministic banking-risk action showcase for AI-enabled financial workflows.
-It demonstrates how a proposed high-risk action can be accepted or rejected during deterministic decision-time replay based on operator approval, evidence freshness, temporal authorization, and decision-time knowledge.
-The showcase emits stable stop reasons and replayable evidence artifacts for audit and review.
+It also includes an invalid action example to show strict shape validation.
+The goal is to demonstrate a core PythiaLabs principle: agent actions should produce observable traces and stable stop reasons, not just outputs.
 
 Run:
 
 ```bash
-mix run examples/banking_ai_risk_showcase.exs
+mix run examples/agent_safety_showcase.exs
 ```
 
-For expected reviewer-facing output, see: `docs/banking_ai_risk_showcase_expected_output.md`
+## Bitemporal Authorization Showcase
 
-This is a deterministic local showcase for governance/audit reasoning. It does not claim production banking integration, regulatory compliance, or cybersecurity protection.
-
-
-## Full Web3 Treasury Showcase
+PythiaLabs includes a deterministic showcase for temporal authorization reasoning.
 
 Run:
 
 ```bash
-mix run examples/web3_treasury_full_showcase.exs
+mix run examples/bitemporal_authorization_showcase.exs
 ```
 
-For expected reviewer-facing output, see: `docs/web3_treasury_full_showcase_expected_output.md`
+The demo shows how an agent action can be accepted or rejected based on:
 
-This single deterministic demo shows:
+- whether the permission was valid at action_time
+- whether the system knew about the permission at decision_time
+- whether the permission was expired or scheduled for the future
 
-- accepted and rejected treasury actions
-- chronological decision traces
-- evidence export
-- SHA-256 digest generation
-- evidence verification
-- tamper rejection
-- unsigned evidence envelope verification
-- signed_demo envelope generation
-- signed_demo verification
+This demonstrates the Temporal-Causal Memory Stack idea without requiring XTDB or any external database.
 
-The `signed_demo` flow is deterministic local demo logic only and is not production cryptography.
+## Stack
+
+- Elixir/BEAM for orchestration
+- Rust NIF (via rustler) for fast kernels
+- Rust Port worker for sandboxed solvers (BFS maze)
+- JSON via `jason`
+- CI: GitHub Actions
+- License: Apache License 2.0
+
+Runtime note: canonical float encoding in evidence paths uses Erlang/OTP 25+ behavior (`:erlang.float_to_binary/2` with `[:short]`).
+
+## Current MVP status
+
+PythiaLabs is currently an MVP focused on:
+
+- deterministic refinement loops
+- observable traces
+- stable stop reasons
+- Elixir/BEAM orchestration
+- Rust NIF / Rust Port worker integration
+- deterministic Agent Safety Showcase
+
+The Datomic/Neo4j/XTDB/EventStoreDB/TimescaleDB-style memory layers are not implemented yet.
+They are part of the architectural roadmap.
+
+## Core MVP / legacy demos
+
+**Mission**: Minimal HRM-style reasoning loop for LIMINAL: `propose → run → measure → refine` with transparent step traces, fast kernels, and safe isolation.
+
+### Values
+#### Business Value
+- **Lower compute cost** by winning via refinement, not giant params
+- **Explainability** for clients/regulators (auditable traces)
+- **Easy integration** on top of GPT-5/LLMs with step control
+- **Edge/On‑prem friendly** footprint
+- **Reliability** thanks to BEAM supervision
+
+#### Human Value
+- **Transparent reasoning** (no black box)
+- **Co‑thinking**: human can inspect/interrupt/refine
+- **Ethics & control**: limits, stop rules, visible logic
+- **Learning effect**: users adopt the refinement habit
+- **Accessibility**: good performance without huge hardware
+
+### Legacy quickstart
+```bash
+mix deps.get
+mix compile
+
+# refinement demo (strings)
+mix run examples/lev_demo.exs
+
+# port worker build + demo (maze)
+cd workers/solver_port && cargo build --release && cd ../../
+mix run examples/port_demo.exs
+
+# benchmarks (NIF vs fallback)
+mix run benches/bench.exs
+```
+
+### Planner loop (concept)
+```
+state ← init(problem)
+repeat up to max_steps:
+  proposal ← propose(state)
+  candidate ← execute(proposal)
+  score ← measure(candidate)
+  if score ≤ threshold → stop
+  if no_improve ≥ limit → (hook) critic → stop (MVP)
+  state ← refine(state)
+return best
+```
+
+## Roadmap: persistent reasoning memory
+
+Future versions may add persistent reasoning memory with two complementary layers:
+
+1. **Datomic-style append-only step log**  
+   Stores every reasoning step as an immutable event for replay, audit, debugging, and version comparison.
+
+2. **Neo4j-style hypothesis graph**  
+   Connects actions, constraints, proposals, failures, stop reasons, and successful paths.
+
+This would allow PythiaLabs to support replay, audit, recurring failure analysis, and cross-run reasoning patterns.
+
+This layer is not implemented in the current MVP.
+
+For details, see `docs/persistent_reasoning_memory.md`.
+
+For the broader five-layer roadmap, see `docs/temporal_causal_memory_stack.md`.
+
+For the Web3 application roadmap, see `docs/web3_consensus_reason_layer.md`.
+
+For the design principles behind these decisions, see `docs/design_principles.md`.
+
+For grant preparation materials, see:
+
+- `docs/grant_readiness.md`
+- `docs/threat_model_web3_treasury_reason_layer.md`
+- `docs/grant_one_pager_web3_treasury_reason_layer.md`
+- `docs/grant_application_summary.md`
+
+Additional roadmap items:
+
+- temporal-causal memory stack for facts, relations, bitemporal validity, events, and metrics
+- critic triggers based on confidence, repeated failure classes, and trace patterns
+- multi-domain executors for QA, graph problems, puzzles, and agent actions
+- Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
+
+## Project trust and governance
+
+Project governance and trust materials:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `CHANGELOG.md`
+- `docs/license_strategy.md`
+- `docs/security_automation.md`
+
+These documents describe contribution expectations, security reporting, project maturity, release notes, and licensing strategy.
+
+The repository also includes a minimal GitHub Actions security workflow for secret scanning.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ PythiaLabs currently does not claim:
 - IAM enforcement
 - backup management
 - regulatory compliance
-- cybersecurity protection
+- production-grade cybersecurity protection
 
 ## Agent Infrastructure Action Safety Showcase
 
@@ -204,7 +204,10 @@ PythiaLabs is currently an MVP focused on:
 - stable stop reasons
 - Elixir/BEAM orchestration
 - Rust NIF / Rust Port worker integration
-- deterministic Agent Safety Showcase
+- deterministic evidence gates for high-risk agentic actions
+- Agent Infrastructure Action Safety Showcase
+- Banking AI Risk Showcase
+- Web3 Treasury Governance Showcase
 
 The Datomic/Neo4j/XTDB/EventStoreDB/TimescaleDB-style memory layers are not implemented yet.
 They are part of the architectural roadmap.


### PR DESCRIPTION
## Summary
Restructured the README to better reflect the current state of PythiaLabs and improve discoverability for reviewers. The documentation now leads with three concrete action safety showcases (Agent Infrastructure, Banking AI Risk, and Web3 Treasury) before diving into architectural details and roadmap items.

## Key changes

- **Simplified opening**: Changed title from "liminal-pythia — MVP" to "PythiaLabs" and condensed the value proposition into a single focused sentence about deterministic evidence gates
- **Reorganized showcase section**: Moved the three main showcases (Agent Infrastructure Action Safety, Banking AI Risk, and Web3 Treasury) to the top with dedicated sections, each including:
  - Clear description of what the showcase demonstrates
  - Quick-start command
  - Link to expected output documentation
  - Explicit disclaimer about what is/isn't implemented
- **Improved reviewer quickstart**: Added a simple 4-command quickstart at the top that runs all three showcases
- **Clarified scope**: Expanded the "What PythiaLabs is not yet" section with additional items (cloud-provider integration, IAM enforcement, backup management, regulatory compliance, cybersecurity protection)
- **Reorganized legacy content**: Moved original MVP mission, values, and legacy demos (lev_demo, port_demo, benchmarks) into a "Core MVP / legacy demos" section to preserve context while deprioritizing
- **Consolidated Web3 examples**: Grouped all Web3 Treasury showcase variations (action, trace export, evidence, verification, envelope, signed demo) into a single cohesive section with clear progression

## Notable details

- No source code changes; this is purely documentation restructuring
- Maintains all original content while improving information hierarchy
- Emphasizes practical, runnable examples over theoretical roadmap items
- Each showcase now includes explicit disclaimers about production readiness

https://claude.ai/code/session_01HoXB5eHMGLY6QgvyT8Phz1