### PR TITLE
docs: add positioning note on open agentic models and evidence gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Additional roadmap items:
 - multi-domain executors for QA, graph problems, puzzles, and agent actions
 - Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
+## Research / Positioning / Docs
+
+- Open agentic models need evidence gates: `docs/open_agentic_models_need_evidence_gates.md`
+
 ## Project trust and governance
 
 Project governance and trust materials:

--- a/docs/open_agentic_models_need_evidence_gates.md
+++ b/docs/open_agentic_models_need_evidence_gates.md
@@ -1,0 +1,43 @@
+# Open Agentic Models Need Open Evidence Gates
+
+## 1. Why this matters
+
+Recent releases of permissively licensed open agentic models (for example, Xiaomi's MIT-licensed MiMo-V2.5 family) signal a broader shift: strong long-context, tool-using, long-horizon capabilities are increasingly available in open ecosystems.
+
+As model capability becomes more accessible, safety work must also be accessible. Open safety infrastructure needs to keep pace with open execution capability.
+
+## 2. From output review to action review
+
+Traditional LLM evaluation often focuses on output quality: "Is the answer correct, useful, or aligned?" Agentic systems add a second question: "Should this action be allowed to execute under current evidence?"
+
+That changes the control point. In high-risk workflows, pre-execution action review becomes as important as post-hoc output review.
+
+## 3. Where pythiaLabs fits
+
+pythiaLabs focuses on deterministic pre-execution evidence gates for high-risk agentic actions.
+
+In this repository, that layer is represented by:
+
+- deterministic allow/block/escalate gate logic
+- stable stop reasons
+- replayable decision traces
+- tamper-checkable evidence artifacts
+
+The intent is to make action-level decisions inspectable and reproducible, not only model outputs.
+
+## 4. Future evaluation direction
+
+A practical next step for the ecosystem is to evaluate open agentic systems on action-governance properties in addition to task success, such as:
+
+- gate decision consistency under replay
+- evidence freshness and authorization checks at decision time
+- trace completeness for reviewer audit
+- tamper detection on evidence artifacts
+
+This complements model-centric benchmarks by adding execution-risk observability.
+
+## 5. Scope note
+
+This note uses MiMo as one external example of the open-agentic-model trend.
+
+It does **not** claim that pythiaLabs currently integrates with MiMo, has benchmarked MiMo, or has reached production readiness.


### PR DESCRIPTION
### Motivation

- Permissively licensed open agentic models (MiMo cited as an external example) indicate that long-context, tool-using, long-horizon execution capability is becoming more available in open ecosystems. 
- As agentic capability migrates from outputs to real actions, safety controls must shift from only reviewing final outputs to gating potentially high-risk actions before execution. 

### Description

- Add `docs/open_agentic_models_need_evidence_gates.md` containing a concise, technical positioning note with the requested five sections. 
- Document the shift from output review to pre-execution action review and list concrete properties to evaluate (replayable traces, decision consistency, evidence freshness, tamper detection). 
- Clarify where pythiaLabs fits by enumerating deterministic pre-execution gate primitives such as allow/block/escalate logic, stable stop reasons, replayable decision traces, and tamper-checkable evidence artifacts. 
- Add a README entry under a new `Research / Positioning / Docs` section linking to the new document and include an explicit scope note that MiMo is cited only as an external trend signal and that no integration, benchmarking, safety, or production-readiness claims are made. 

### Testing

- Verified the new file and README change via `git show` and inspected the file contents with `nl` to confirm the expected sections and wording were added successfully. 
- Confirmed the repository state with `git status --short` and completed a commit with `git commit`, both of which succeeded. 
- No unit or integration test changes were made and no test suite (`mix test`) was run as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b2cca404832d8c476ac2efb95129)