### PR TITLE
site: strengthen SEO (meta, OG/Twitter, FAQ JSON-LD)

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -36,10 +36,11 @@ async function main() {
   await mkdir(distDir, { recursive: true });
 
   const year = new Date().getFullYear();
+  const buildDate = new Date().toISOString();
   let total = 0;
 
   for (const id of localeOrder) {
-    const html = renderPage(id, year).replace("__INLINE_CSS__", minifiedCss);
+    const html = renderPage(id, year, buildDate).replace("__INLINE_CSS__", minifiedCss);
     const outDir = id === "en" ? distDir : path.join(distDir, id);
     if (id !== "en") await mkdir(outDir, { recursive: true });
     const outPath = path.join(outDir, "index.html");

--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -25,6 +25,7 @@ export const siteConfig = {
   pilotEmailSubject: "PythiaLabs pilot inquiry",
   xUrl: "https://x.com/lim746048",
   xHandle: "x.com/lim746048",
+  twitterSite: "@lim746048",
   telegramUrl: "https://t.me/Alexfox14",
   telegramHandle: "@Alexfox14",
   founderName: "Aleksei Safonov",

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -1,11 +1,16 @@
 export const locales = {
   en: {
     htmlLang: "en",
+    ogLocale: "en_US",
     langLabel: "EN",
     meta: {
       title: "Pre-execution safety gate for AI agents — PythiaLabs",
       description:
-        "PythiaLabs is the pre-execution safety gate for AI agents. Decides whether an agent's action should ALLOW, BLOCK, or ESCALATE — before it executes — with replayable evidence.",
+        "Open-source pre-execution gate for AI and agentic systems: ALLOW, BLOCK, or ESCALATE before tools run. Deterministic checks, replayable traces, audit-ready evidence — self-hosted Elixir library, Apache-2.0.",
+      keywords:
+        "AI agent safety, pre-execution gate, agentic AI, AI governance, ALLOW BLOCK ESCALATE, deterministic policy gate, audit trail, open source AI safety, Apache-2.0, Elixir agent guard, OPA RBAC complement, DevOps AI agents, fintech AI risk, Web3 treasury governance",
+      ogImageAlt:
+        "PythiaLabs — pre-execution safety gate for AI agents: verify actions before they execute",
     },
     nav: {
       problem: "Problem",
@@ -328,11 +333,16 @@ export const locales = {
 
   ru: {
     htmlLang: "ru",
+    ogLocale: "ru_RU",
     langLabel: "RU",
     meta: {
       title: "Pre-execution safety gate для AI-агентов — PythiaLabs",
       description:
-        "PythiaLabs — pre-execution safety gate для AI-агентов. Решает, должно ли действие агента быть ALLOW, BLOCK или ESCALATE до выполнения, с воспроизводимыми доказательствами.",
+        "Open-source шлюз до выполнения для AI и agentic-систем: ALLOW, BLOCK или ESCALATE до запуска tools. Детерминированные проверки, воспроизводимые трассы, артефакты для аудита — self-hosted Elixir-библиотека, Apache-2.0.",
+      keywords:
+        "безопасность AI-агентов, pre-execution gate, agentic AI, governance AI, ALLOW BLOCK ESCALATE, детерминированный policy gate, audit trail, open source AI safety, Apache-2.0, Elixir guard, OPA RBAC, DevOps агенты, финтех риск AI, Web3 treasury",
+      ogImageAlt:
+        "PythiaLabs — pre-execution safety gate для AI-агентов: проверка действий до выполнения",
     },
     nav: {
       problem: "Проблема",
@@ -655,11 +665,15 @@ export const locales = {
 
   zh: {
     htmlLang: "zh-Hans",
+    ogLocale: "zh_CN",
     langLabel: "中文",
     meta: {
       title: "面向 AI Agent 的执行前安全门控 — PythiaLabs",
       description:
-        "PythiaLabs 是面向 AI Agent 的执行前安全门控。在执行前判定行动应 ALLOW、BLOCK 或 ESCALATE，并产出可重放的证据。",
+        "面向 AI 与 agentic 系统的开源执行前门控：在工具运行前给出 ALLOW、BLOCK 或 ESCALATE。确定性检查、可重放轨迹、审计友好证据——自托管 Elixir 库，Apache-2.0。",
+      keywords:
+        "AI Agent 安全, 执行前门控, agentic AI, AI 治理, ALLOW BLOCK ESCALATE, 确定性策略门控, 审计轨迹, 开源 AI 安全, Apache-2.0, Elixir, OPA RBAC, DevOps Agent, 金融科技 AI 风险, Web3 金库治理",
+      ogImageAlt: "PythiaLabs — AI Agent 执行前安全门控：先验证再执行",
     },
     nav: {
       problem: "问题",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -89,10 +89,17 @@ function utm(url, campaign) {
   return `${url}${sep}utm_source=landing&utm_medium=cta&utm_campaign=${encodeURIComponent(campaign)}`;
 }
 
-function jsonLd(currentId, canonical) {
+function jsonLdGraph(currentId, canonical, buildDate) {
   const t = locales[currentId];
-  const data = {
-    "@context": "https://schema.org",
+  const base = siteConfig.canonicalOrigin.replace(/\/$/, "");
+  const publisher = {
+    "@type": "Organization",
+    name: "PythiaLabs",
+    url: `${base}/`,
+    sameAs: [siteConfig.repoUrl, siteConfig.xUrl],
+  };
+
+  const softwareApplication = {
     "@type": "SoftwareApplication",
     name: "PythiaLabs",
     applicationCategory: "DeveloperApplication",
@@ -102,22 +109,71 @@ function jsonLd(currentId, canonical) {
     inLanguage: t.htmlLang,
     license: `https://opensource.org/licenses/${siteConfig.license}`,
     codeRepository: siteConfig.repoUrl,
+    isAccessibleForFree: true,
+    dateModified: buildDate,
+    keywords: t.meta.keywords,
     author: {
       "@type": "Person",
       name: siteConfig.founderName,
     },
+    publisher,
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   };
-  return `<script type="application/ld+json">${JSON.stringify(data)}</script>`;
+
+  const webSite = {
+    "@type": "WebSite",
+    name: "PythiaLabs",
+    description: t.meta.description,
+    url: `${base}/`,
+    inLanguage: localeOrder.map((id) => locales[id].htmlLang),
+    publisher,
+    potentialAction: {
+      "@type": "ReadAction",
+      target: `${base}/`,
+    },
+  };
+
+  const faqPage = {
+    "@type": "FAQPage",
+    mainEntity: t.faq.items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+
+  const graphNodes = [softwareApplication, faqPage];
+  if (currentId === "en") {
+    graphNodes.push(webSite);
+  }
+
+  const graph = {
+    "@context": "https://schema.org",
+    "@graph": graphNodes,
+  };
+
+  return `<script type="application/ld+json">${JSON.stringify(graph)}</script>`;
 }
 
-export function renderPage(currentId, year) {
+export function renderPage(currentId, year, buildDate) {
   const t = locales[currentId];
   const hrefs = pathsFor(currentId);
   const canonical = canonicalFor(currentId);
   const ogImage = `${siteConfig.canonicalOrigin.replace(/\/$/, "")}${siteConfig.ogImagePath}`;
+  const ogLocale = t.ogLocale || t.htmlLang.replace("-", "_");
   const pilotHref = pilotMailto(siteConfig.pilotEmailSubject);
   const example = exampleDecisions[currentId] || exampleDecisions.en;
+
+  const ogAlternateLocales = localeOrder
+    .filter((id) => id !== currentId)
+    .map(
+      (id) =>
+        `<meta property="og:locale:alternate" content="${escape(locales[id].ogLocale || locales[id].htmlLang.replace("-", "_"))}" />`,
+    )
+    .join("\n    ");
 
   const langSwitcher = localeOrder
     .map((id) => {
@@ -172,6 +228,12 @@ export function renderPage(currentId, year) {
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <title>${escape(t.meta.title)}</title>
     <meta name="description" content="${escape(t.meta.description)}" />
+    <meta name="keywords" content="${escape(t.meta.keywords)}" />
+    <meta name="author" content="${escape(siteConfig.founderName)}" />
+    <meta name="application-name" content="PythiaLabs" />
+    <meta
+      name="audience"
+      content="Developers, security engineers, platform teams, AI product teams, compliance reviewers" />
     <meta name="color-scheme" content="dark light" />
     <meta name="robots" content="index, follow" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
@@ -179,16 +241,23 @@ export function renderPage(currentId, year) {
 
     <link rel="canonical" href="${canonical}" />
 
+    <meta property="og:site_name" content="PythiaLabs" />
     <meta property="og:title" content="${escape(t.meta.title)}" />
     <meta property="og:description" content="${escape(t.meta.description)}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="${canonical}" />
-    <meta property="og:locale" content="${t.htmlLang.replace("-", "_")}" />
+    <meta property="og:locale" content="${escape(ogLocale)}" />
+    ${ogAlternateLocales}
     <meta property="og:image" content="${ogImage}" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="${escape(t.meta.ogImageAlt)}" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="article:modified_time" content="${escape(buildDate)}" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="${escape(siteConfig.twitterSite)}" />
+    <meta name="twitter:title" content="${escape(t.meta.title)}" />
+    <meta name="twitter:description" content="${escape(t.meta.description)}" />
     <meta name="twitter:image" content="${ogImage}" />
+    <meta name="twitter:image:alt" content="${escape(t.meta.ogImageAlt)}" />
 
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='28'%3E%E2%97%87%3C/text%3E%3C/svg%3E" />
 
@@ -199,7 +268,7 @@ export function renderPage(currentId, year) {
 
     ${hreflangLinks}
 
-    ${jsonLd(currentId, canonical)}
+    ${jsonLdGraph(currentId, canonical, buildDate)}
 
     <style>__INLINE_CSS__</style>
   </head>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improves technical and social SEO for the static landing (EN / RU / ZH).

**Meta**

- Stronger `description` copy with target phrases (pre-execution gate, agentic AI, audit evidence, self-hosted Elixir, Apache-2.0).
- Per-locale `keywords` and `og:image` alt text.
- `author`, `application-name`, and `audience` meta for crawler context.

**Open Graph / Twitter**

- `og:site_name`, correct BCP 47 locales via `ogLocale` (`en_US`, `ru_RU`, `zh_CN`) and `og:locale:alternate` for the other languages.
- `og:image:alt`, `og:image:type`, `article:modified_time` (build ISO timestamp).
- Twitter `title`, `description`, `image:alt`, `site` from `siteConfig.twitterSite`.

**Structured data**

- Replaces single `SoftwareApplication` script with `@graph`: `SoftwareApplication` + `FAQPage` (all FAQ items), plus `WebSite` only on the English default URL to avoid duplicate site entities on `/ru/` and `/zh/`.
- Adds `publisher` / `Organization`, `dateModified`, `keywords`, `isAccessibleForFree`.

**Build**

- Passes `buildDate` from `build.mjs` into `renderPage` for JSON-LD and meta freshness.

Validated with `npm run build` under `site/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

