### PR TITLE
site: conversion patterns — stats, ICP, quickstart, mid-CTA, vs table

### DIFF
--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -30,4 +30,6 @@ export const siteConfig = {
   founderName: "Aleksei Safonov",
   license: "Apache-2.0",
   ogImagePath: "/og.svg",
+  showcaseScriptCount: 6,
+  testFileCount: 17,
 };

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -12,6 +12,8 @@ export const locales = {
       idea: "Big idea",
       solution: "How it works",
       integration: "Integration",
+      quickstart: "Quick start",
+      fit: "Who it's for",
       useCases: "Use cases",
       videos: "Videos",
       faq: "FAQ",
@@ -35,11 +37,54 @@ export const locales = {
       "No telemetry",
     ],
     cta: {
-      primary: "Watch the demo",
+      primary: "Join early access",
+      demo: "Watch the demo",
       secondary: "View GitHub repo",
-      tertiary: "Join early access",
       pilot: "Apply as pilot partner",
       contact: "Contact",
+    },
+    heroStats: {
+      ariaLabel: "Repository at a glance",
+      showcases: "deterministic local showcases",
+      tests: "Elixir test files for gates and evidence",
+      licenseLine: "License",
+      licenseValue: "Apache-2.0",
+      llmLine: "LLM calls in the gate",
+    },
+    ifYou: {
+      title: "If this sounds like your team, PythiaLabs is built for you",
+      items: [
+        "You run (or are about to run) agents that can change production, money, or governance — not just chat.",
+        "Post-hoc logs are not enough: you need a decision record before the tool fires.",
+        "RBAC and coarse policy are necessary but do not answer “should this exact action run right now, with this evidence?”",
+        "Reviewers and security want the same replayable artifact every time — not screenshots of a thread.",
+      ],
+    },
+    quickstart: {
+      title: "Get to a working gate in one sitting",
+      intro:
+        "No credit card. No SaaS account. Clone, test, run a showcase, then wire your orchestrator the same way.",
+      steps: [
+        {
+          name: "Clone and install deps",
+          desc: "`git clone` the repository, then `mix deps.get` (same toolchain as CI).",
+        },
+        {
+          name: "Prove the test suite",
+          desc: "Run `mix test` — this is the contract the gate is held to.",
+        },
+        {
+          name: "Run a showcase script",
+          desc: "Try `mix run examples/agent_infra_action_showcase.exs` (or banking / Web3 showcases) and compare stdout to `docs/*_expected_output.md`.",
+        },
+        {
+          name: "Call the evaluator before tools",
+          desc: "From your agent runner, pass a structured proposal plus decision-time evidence; block execution unless the outcome is ALLOW (or route ESCALATE per your policy).",
+        },
+      ],
+    },
+    midCta: {
+      line: "Watch the walkthrough, run the repo locally, or start a pilot — your stack, your infrastructure.",
     },
     videoBlock: {
       eyebrow: "Watch why this matters",
@@ -168,6 +213,25 @@ export const locales = {
         "Every decision has a stop reason, a trace, and a verifiable digest",
         "Reviewers get the same artifact every time, replay included",
       ],
+      vsTitle: "How this differs from nearby approaches",
+      vsItems: [
+        {
+          name: "Prompt-only guardrails",
+          desc: "Instructions to the model are not a boundary for high-risk tools. The gate is deterministic code with stable stop reasons and tests — not prompt text.",
+        },
+        {
+          name: "RBAC / coarse IAM alone",
+          desc: "Static roles don't encode “right now, with this evidence snapshot, under this risk.” The gate consumes decision-time context and freshness.",
+        },
+        {
+          name: "Policy engines such as OPA",
+          desc: "OPA answers authorization rules you express. PythiaLabs targets agent-action proposals plus replayable traces and digest exports for reviewers — complement, not duplicate.",
+        },
+        {
+          name: "Post-hoc monitoring",
+          desc: "Metrics after execution cannot undo a transfer, deletion, or governance vote. Pre-execution is the control point.",
+        },
+      ],
     },
     useCases: {
       title: "Where this becomes critical",
@@ -283,9 +347,9 @@ export const locales = {
       eyebrow: "For builders of high-risk AI agents",
       title: "Build AI agents that can be audited before they act",
       body: "The next generation of AI systems will not be judged only by how well they answer. They will be judged by whether their actions are safe, authorized, and explainable. PythiaLabs gives agentic AI a gate before execution.",
-      primary: "Watch the demo",
+      primary: "Join early access",
+      demo: "Watch the demo",
       secondary: "View GitHub repo",
-      tertiary: "Join early access",
       reassurance: "Apache-2.0 · Self-hostable · No vendor lock-in · No credit card",
     },
     closer: {
@@ -339,6 +403,8 @@ export const locales = {
       idea: "Идея",
       solution: "Как работает",
       integration: "Интеграция",
+      quickstart: "Быстрый старт",
+      fit: "Кому подходит",
       useCases: "Применение",
       videos: "Видео",
       faq: "FAQ",
@@ -362,11 +428,54 @@ export const locales = {
       "Без телеметрии",
     ],
     cta: {
-      primary: "Смотреть демо",
+      primary: "Запросить ранний доступ",
+      demo: "Смотреть демо",
       secondary: "Открыть GitHub",
-      tertiary: "Запросить ранний доступ",
       pilot: "Стать пилотным партнёром",
       contact: "Связаться",
+    },
+    heroStats: {
+      ariaLabel: "Сигналы репозитория",
+      showcases: "детерминированных локальных showcase",
+      tests: "файлов тестов для шлюзов и доказательств",
+      licenseLine: "Лицензия",
+      licenseValue: "Apache-2.0",
+      llmLine: "вызовов LLM в шлюзе",
+    },
+    ifYou: {
+      title: "Если это про вашу команду — PythiaLabs для вас",
+      items: [
+        "Вы запускаете (или собираетесь) агентов, которые трогают прод, деньги или governance — не только чат.",
+        "Постфактум логов мало: нужна запись решения до вызова tool.",
+        "RBAC и грубая политика нужны, но не отвечают: «должно ли выполниться именно это действие прямо сейчас с этими доказательствами?»",
+        "Security и ревьюерам нужен один и тот же воспроизводимый артефакт — не скриншот треда.",
+      ],
+    },
+    quickstart: {
+      title: "Рабочий шлюз за одну сессию",
+      intro:
+        "Без карты. Без SaaS-аккаунта. Клонируйте, прогоните тесты и showcase, затем подключите оркестратор так же.",
+      steps: [
+        {
+          name: "Клон и зависимости",
+          desc: "`git clone` репозитория, затем `mix deps.get` (как в CI).",
+        },
+        {
+          name: "Прогон тестов",
+          desc: "Выполните `mix test` — это контракт, которому соответствует шлюз.",
+        },
+        {
+          name: "Showcase-скрипт",
+          desc: "Запустите `mix run examples/agent_infra_action_showcase.exs` (или banking / Web3) и сверьте stdout с `docs/*_expected_output.md`.",
+        },
+        {
+          name: "Вызов до tools",
+          desc: "Из agent runner передайте структурированное предложение и evidence на момент решения; блокируйте исполнение, если исход не ALLOW (или обрабатывайте ESCALATE по своей политике).",
+        },
+      ],
+    },
+    midCta: {
+      line: "Посмотрите walkthrough, прогоните репозиторий локально или начните пилот — ваш стек, ваша инфраструктура.",
     },
     videoBlock: {
       eyebrow: "Почему это важно",
@@ -495,6 +604,25 @@ export const locales = {
         "У каждого решения есть stop-причина, трасса и проверяемый дайджест",
         "Ревьюеры каждый раз получают один и тот же артефакт, replay включён",
       ],
+      vsTitle: "Чем это отличается от близких подходов",
+      vsItems: [
+        {
+          name: "Только промпты и guardrails",
+          desc: "Инструкции модели — не граница для высокорисковых tools. Шлюз — детерминированный код со стабильными stop-причинами и тестами, а не текст промпта.",
+        },
+        {
+          name: "Только RBAC / грубый IAM",
+          desc: "Статические роли не кодируют «прямо сейчас, с этим снапшотом доказательств, при этом риске». Шлюз потребляет контекст на момент решения и свежесть evidence.",
+        },
+        {
+          name: "Policy engine вроде OPA",
+          desc: "OPA отвечает на выраженные вами правила авторизации. PythiaLabs — про предложения действий агента, воспроизводимые trace и экспорт дайджестов для ревью; это дополнение, не дубль.",
+        },
+        {
+          name: "Пост-мониторинг",
+          desc: "Метрики после исполнения не отменят перевод, удаление или голосование. Контрольная точка — до выполнения.",
+        },
+      ],
     },
     useCases: {
       title: "Где это становится критично",
@@ -610,9 +738,9 @@ export const locales = {
       eyebrow: "Для тех, кто строит AI-агентов с высоким риском",
       title: "Стройте AI-агентов, которых можно аудировать до их действий",
       body: "Следующее поколение AI-систем будут оценивать не только по тому, насколько хорошо они отвечают. Их будут оценивать по тому, безопасны ли, авторизованы ли и объяснимы ли их действия. PythiaLabs даёт agentic AI шлюз перед выполнением.",
-      primary: "Смотреть демо",
+      primary: "Запросить ранний доступ",
+      demo: "Смотреть демо",
       secondary: "Открыть GitHub",
-      tertiary: "Запросить ранний доступ",
       reassurance: "Apache-2.0 · Self-hosted · Без vendor lock-in · Без карточки",
     },
     closer: {
@@ -666,6 +794,8 @@ export const locales = {
       idea: "核心理念",
       solution: "工作原理",
       integration: "集成",
+      quickstart: "快速上手",
+      fit: "适合谁",
       useCases: "应用场景",
       videos: "视频",
       faq: "常见问题",
@@ -682,11 +812,53 @@ export const locales = {
     },
     trustStrip: ["100% 开源", "Apache-2.0", "确定性 — 门控路径中无 LLM 调用", "可自托管", "无遥测"],
     cta: {
-      primary: "观看演示",
+      primary: "申请早期访问",
+      demo: "观看演示",
       secondary: "查看 GitHub",
-      tertiary: "申请早期访问",
       pilot: "申请试点合作",
       contact: "联系",
+    },
+    heroStats: {
+      ariaLabel: "仓库一览",
+      showcases: "个确定性本地 showcase 脚本",
+      tests: "个 Ex 测试文件覆盖门控与证据",
+      licenseLine: "许可证",
+      licenseValue: "Apache-2.0",
+      llmLine: "门控路径中的 LLM 调用",
+    },
+    ifYou: {
+      title: "如果这就是你的团队，PythiaLabs 为你而建",
+      items: [
+        "你运行（或计划运行）能改动生产、资金或治理的 Agent——不仅是聊天。",
+        "事后日志不够：你需要在工具执行前就留下决策记录。",
+        "仅有 RBAC 与粗粒度策略不够回答「在当前证据下，这一具体操作此刻是否应执行？」",
+        "安全与审查需要每次都可重放的同一类产物——而不是线程截图。",
+      ],
+    },
+    quickstart: {
+      title: "一次上手就能跑通门控",
+      intro: "无需信用卡与 SaaS。克隆、测试、运行 showcase，再按同样方式接入编排器。",
+      steps: [
+        {
+          name: "克隆并安装依赖",
+          desc: "`git clone` 仓库后执行 `mix deps.get`（与 CI 相同工具链）。",
+        },
+        {
+          name: "跑通测试",
+          desc: "运行 `mix test`——门控需遵守的契约。",
+        },
+        {
+          name: "运行 showcase",
+          desc: "执行 `mix run examples/agent_infra_action_showcase.exs`（或 banking / Web3 showcase），将标准输出与 `docs/*_expected_output.md` 对照。",
+        },
+        {
+          name: "在工具前调用评估器",
+          desc: "在 Agent runner 中传入结构化提案与决策时证据；若结果不是 ALLOW（或按策略处理 ESCALATE）则阻止执行。",
+        },
+      ],
+    },
+    midCta: {
+      line: "观看讲解视频、在本地运行仓库，或启动试点对话——你的栈，你的基础设施。",
     },
     videoBlock: {
       eyebrow: "为什么这件事重要",
@@ -801,6 +973,25 @@ export const locales = {
         "每个决策都有停止原因、轨迹与可校验摘要",
         "审查者每次拿到的是同样的产物，含重放",
       ],
+      vsTitle: "与常见方案的区别",
+      vsItems: [
+        {
+          name: "仅靠提示词与护栏",
+          desc: "对高风险工具而言，模型指令不是边界。门控是可测试的确定性代码与稳定停止原因——不是提示文本。",
+        },
+        {
+          name: "仅有 RBAC / 粗粒度 IAM",
+          desc: "静态角色无法表达「此刻、在此证据快照、在此风险下」。门控消费决策时上下文与证据新鲜度。",
+        },
+        {
+          name: "诸如 OPA 的策略引擎",
+          desc: "OPA 回答你编写的授权规则。PythiaLabs 聚焦 Agent 行动提案、可重放轨迹与审阅用摘要导出——互补而非重复。",
+        },
+        {
+          name: "事后监控",
+          desc: "执行后的指标无法撤销转账、删除或治理投票。控制点在执行之前。",
+        },
+      ],
     },
     useCases: {
       title: "关键场景",
@@ -911,9 +1102,9 @@ export const locales = {
       eyebrow: "为构建高风险 AI Agent 的团队",
       title: "构建可在行动前被审计的 AI Agent",
       body: "下一代 AI 系统不会只以回答得多好被评判，更会以行动是否安全、被授权、可解释来评判。PythiaLabs 为 agentic AI 提供执行前的门控。",
-      primary: "观看演示",
+      primary: "申请早期访问",
+      demo: "观看演示",
       secondary: "查看 GitHub",
-      tertiary: "申请早期访问",
       reassurance: "Apache-2.0 · 可自托管 · 无供应商锁定 · 无需信用卡",
     },
     closer: {

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -216,6 +216,8 @@ export function renderPage(currentId, year) {
           <a href="#idea">${escape(t.nav.idea)}</a>
           <a href="#solution">${escape(t.nav.solution)}</a>
           <a href="#integration">${escape(t.nav.integration)}</a>
+          <a href="#quickstart">${escape(t.nav.quickstart)}</a>
+          <a href="#if-you">${escape(t.nav.fit)}</a>
           <a href="#use-cases">${escape(t.nav.useCases)}</a>
           <a href="#videos">${escape(t.nav.videos)}</a>
           <a href="#faq">${escape(t.nav.faq)}</a>
@@ -234,9 +236,9 @@ export function renderPage(currentId, year) {
           <p class="hero-text">${escape(t.hero.body)}</p>
           <p class="hero-tagline">${escape(t.hero.tagline)}</p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="${utm(siteConfig.demoUrl, "hero_demo")}" rel="noopener noreferrer">${escape(t.cta.primary)}</a>
-            <a class="btn btn-secondary" href="${utm(siteConfig.repoUrl, "hero_github")}" rel="noopener noreferrer">${escape(t.cta.secondary)}</a>
-            <a class="btn btn-ghost" href="${pilotHref}" rel="noopener noreferrer">${escape(t.cta.tertiary)}</a>
+            <a class="btn btn-primary" href="${pilotHref}" rel="noopener noreferrer">${escape(t.cta.primary)}</a>
+            <a class="btn btn-secondary" href="${utm(siteConfig.demoUrl, "hero_demo")}" rel="noopener noreferrer">${escape(t.cta.demo)}</a>
+            <a class="btn btn-ghost" href="${utm(siteConfig.repoUrl, "hero_github")}" rel="noopener noreferrer">${escape(t.cta.secondary)}</a>
           </div>
           <p class="hero-badges">
             <a href="${siteConfig.repoUrl}/stargazers" class="badge-link">
@@ -246,6 +248,22 @@ export function renderPage(currentId, year) {
               <img src="https://img.shields.io/github/license/${siteConfig.repoSlug}?style=flat-square&color=0b0d10" alt="License" loading="lazy" decoding="async" width="100" height="20" />
             </a>
           </p>
+          <div class="hero-stats" role="region" aria-label="${escape(t.heroStats.ariaLabel)}">
+            <div class="stat"><span class="stat-value">${siteConfig.showcaseScriptCount}</span><span class="stat-label">${escape(t.heroStats.showcases)}</span></div>
+            <div class="stat rule" aria-hidden="true"></div>
+            <div class="stat"><span class="stat-value">${siteConfig.testFileCount}</span><span class="stat-label">${escape(t.heroStats.tests)}</span></div>
+            <div class="stat rule" aria-hidden="true"></div>
+            <div class="stat"><span class="stat-value stat-value--license">${escape(t.heroStats.licenseValue)}</span><span class="stat-label">${escape(t.heroStats.licenseLine)}</span></div>
+            <div class="stat rule" aria-hidden="true"></div>
+            <div class="stat"><span class="stat-value">0</span><span class="stat-label">${escape(t.heroStats.llmLine)}</span></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="if-you" class="section section-if-you">
+        <div class="container">
+          <h2>${escape(t.ifYou.title)}</h2>
+          <ul class="if-you-list">${t.ifYou.items.map((s) => `<li>${escape(s)}</li>`).join("")}</ul>
         </div>
       </section>
 
@@ -368,6 +386,19 @@ export function renderPage(currentId, year) {
         </div>
       </section>
 
+      <section id="quickstart" class="section section-alt">
+        <div class="container">
+          <h2>${escape(t.quickstart.title)}</h2>
+          <p>${escape(t.quickstart.intro)}</p>
+          <ol class="step-list quickstart-list">${t.quickstart.steps
+            .map(
+              (s, i) =>
+                `<li class="step"><div class="step-num" aria-hidden="true">${i + 1}</div><div class="step-body"><h3>${escape(s.name)}</h3><p>${escape(s.desc)}</p></div></li>`,
+            )
+            .join("")}</ol>
+        </div>
+      </section>
+
       <section id="value" class="section">
         <div class="container">
           <h2>${escape(t.valueStack.title)}</h2>
@@ -381,6 +412,17 @@ export function renderPage(currentId, year) {
         <div class="container">
           <h2>${escape(t.useCases.title)}</h2>
           <div class="card-grid">${useCaseCards}</div>
+        </div>
+      </section>
+
+      <section class="section mid-cta" aria-label="Mid-page calls to action">
+        <div class="container mid-cta-inner">
+          <p class="mid-cta-line">${escape(t.midCta.line)}</p>
+          <div class="cta-row cta-row--center">
+            <a class="btn btn-primary" href="${pilotHref}" rel="noopener noreferrer">${escape(t.cta.primary)}</a>
+            <a class="btn btn-secondary" href="${utm(siteConfig.demoUrl, "mid_demo")}" rel="noopener noreferrer">${escape(t.cta.demo)}</a>
+            <a class="btn btn-ghost" href="${utm(siteConfig.repoUrl, "mid_github")}" rel="noopener noreferrer">${escape(t.cta.secondary)}</a>
+          </div>
         </div>
       </section>
 
@@ -422,6 +464,13 @@ export function renderPage(currentId, year) {
               <ul>${t.comparison.withItems.map((s) => `<li>${escape(s)}</li>`).join("")}</ul>
             </div>
           </div>
+          <h3 class="comparison-vs-title">${escape(t.comparison.vsTitle)}</h3>
+          <div class="card-grid comparison-vs-grid">${t.comparison.vsItems
+            .map(
+              (item) =>
+                `<article class="card"><h4>${escape(item.name)}</h4><p>${escape(item.desc)}</p></article>`,
+            )
+            .join("")}</div>
         </div>
       </section>
 
@@ -476,9 +525,9 @@ export function renderPage(currentId, year) {
           <h2>${escape(t.finalCta.title)}</h2>
           <p>${escape(t.finalCta.body)}</p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="${utm(siteConfig.demoUrl, "final_demo")}" rel="noopener noreferrer">${escape(t.finalCta.primary)}</a>
-            <a class="btn btn-secondary" href="${utm(siteConfig.repoUrl, "final_github")}" rel="noopener noreferrer">${escape(t.finalCta.secondary)}</a>
-            <a class="btn btn-ghost" href="${pilotHref}" rel="noopener noreferrer">${escape(t.finalCta.tertiary)}</a>
+            <a class="btn btn-primary" href="${pilotHref}" rel="noopener noreferrer">${escape(t.finalCta.primary)}</a>
+            <a class="btn btn-secondary" href="${utm(siteConfig.demoUrl, "final_demo")}" rel="noopener noreferrer">${escape(t.finalCta.demo)}</a>
+            <a class="btn btn-ghost" href="${utm(siteConfig.repoUrl, "final_github")}" rel="noopener noreferrer">${escape(t.finalCta.secondary)}</a>
           </div>
           <p class="cta-reassurance">${escape(t.finalCta.reassurance)}</p>
         </div>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -633,6 +633,134 @@ blockquote {
   border-radius: 4px;
 }
 
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 0.5rem 1.25rem;
+  margin: 1.75rem 0 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(22, 27, 34, 0.5);
+  max-width: 100%;
+}
+
+.hero-stats .stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 5.5rem;
+}
+
+.hero-stats .stat.rule {
+  width: 1px;
+  min-width: 0;
+  align-self: stretch;
+  background: var(--border);
+  margin: 0 0.25rem;
+}
+
+.stat-value {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 1.35rem;
+  line-height: 1.2;
+  color: var(--accent-strong);
+}
+
+.stat-value--license {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.stat-label {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+  max-width: 11rem;
+}
+
+.section-if-you {
+  padding: 2rem 0;
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+}
+
+.section-if-you h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.35rem, 2.5vw, 1.75rem);
+}
+
+.if-you-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.if-you-list li {
+  margin: 0;
+  padding: 0 0 0 1.35rem;
+  position: relative;
+}
+
+.if-you-list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--allow);
+  font-weight: 700;
+}
+
+.mid-cta {
+  padding: 2.25rem 0;
+  border-block: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(78, 166, 255, 0.06) 0%, transparent 100%);
+}
+
+.mid-cta-inner {
+  text-align: center;
+}
+
+.mid-cta-line {
+  margin: 0 0 1.25rem;
+  font-size: 1.05rem;
+  max-width: 42rem;
+  margin-left: auto;
+  margin-right: auto;
+  color: var(--text-muted);
+}
+
+.cta-row--center {
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.comparison-vs-title {
+  margin: 2rem 0 1rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.comparison-vs-grid .card h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.comparison-vs-grid .card p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.quickstart-list {
+  margin-top: 1.25rem;
+}
+
 /* Example decision */
 .example-decision {
   border-bottom: 1px solid var(--border);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adapts high-conversion patterns from consumer SaaS homepages (e.g. prominent stats, ICP section, repeatable CTAs, simple onboarding steps) while keeping an honest technical voice for an open-source MVP.

**Hero**

- Primary CTA is **Join early access** (email); demo and GitHub are secondary.
- **Stats strip**: number of `examples/*_showcase.exs` scripts, `test/**/*_test.exs` count from config, license label, and **0 LLM** in the gate. Update `siteConfig.showcaseScriptCount` / `testFileCount` if the repo tree changes.

**New / updated sections**

- **Who it's for** (`#if-you`): parallel “if this is you…” bullets for infra / governance / audit teams.
- **Quick start** (`#quickstart`): clone → `mix test` → showcase → wire orchestrator before tools.
- **Mid-page CTA** after use cases: same three actions again.
- **Comparison**: adds “vs prompts-only, RBAC-only, OPA, post-hoc monitoring” in a small card grid under the existing before/after columns.

**Nav**

- Adds **Quick start** and **Who it's for** links.

**Checks**

- `validateLocales`, `npm run format`, `npm run build` under `site/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

