### PR TITLE
site: Matrix Oracle quote — understand the choice (before tools run)

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -211,7 +211,7 @@ export const locales = {
       oracleEyebrow: "Why this name fits",
       oracleQuote:
         "You didn't come here to make the choice. You're here to try to understand why you made it.",
-      oracleSource: "The Oracle, The Matrix Reloaded (2003)",
+      oracleSource: "The Oracle, The Matrix",
       oracleBridge:
         'When an agent acts, the risk is that the "why" only appears after the damage. PythiaLabs makes the why legible first: stable stop reasons and a replayable trace before the tool runs — so humans can understand the choice while it can still be stopped.',
     },
@@ -544,7 +544,7 @@ export const locales = {
       oracleEyebrow: "Почему это созвучно названию",
       oracleQuote:
         "Ты пришёл не затем, чтобы сделать выбор. Ты пришёл, чтобы понять, почему ты его сделал.",
-      oracleSource: "Оракул, «Матрица: Перезагрузка» (2003)",
+      oracleSource: "Оракул, «Матрица»",
       oracleBridge:
         "Когда действует агент, опасность в том, что «почему» всплывает уже после последствий. PythiaLabs делает «почему» читаемым заранее: стабильные stop-причины и воспроизводимый trace до вызова tool — чтобы человек понимал выбор, пока его ещё можно остановить.",
     },
@@ -850,7 +850,7 @@ export const locales = {
       pullQuote: "强大的 AI Agent 不只是要会推理，更应受到可校验行动权限的约束。",
       oracleEyebrow: "与名字的共鸣",
       oracleQuote: "你不是来这里做选择的——你是来试图理解自己为何做出这个选择。",
-      oracleSource: "先知，《黑客帝国：重装上阵》（2003）",
+      oracleSource: "先知，《黑客帝国》",
       oracleBridge:
         "当 Agent 真正行动时，风险在于「为何」往往在后果之后才浮现。PythiaLabs 让「为何」在工具执行前就可读：稳定的停止原因与可重放轨迹——在人类仍能叫停时理解这次选择。",
     },

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -208,6 +208,12 @@ export const locales = {
       body: "The AI industry is moving fast toward autonomous agents. PythiaLabs is built around a simple idea:",
       pullQuote:
         "A powerful AI agent should not only reason. It should be constrained by verifiable action permissions.",
+      oracleEyebrow: "Why this name fits",
+      oracleQuote:
+        "You didn't come here to make the choice. You're here to try to understand why you made it.",
+      oracleSource: "The Oracle, The Matrix Reloaded (2003)",
+      oracleBridge:
+        'When an agent acts, the risk is that the "why" only appears after the damage. PythiaLabs makes the why legible first: stable stop reasons and a replayable trace before the tool runs — so humans can understand the choice while it can still be stopped.',
     },
     founderVideosBlock: {
       eyebrow: "From the founder",
@@ -535,6 +541,12 @@ export const locales = {
       body: "AI-индустрия быстро движется к автономным агентам. PythiaLabs построен вокруг простой идеи:",
       pullQuote:
         "Сильный AI-агент должен не только рассуждать. Он должен быть ограничен проверяемыми правами на действие.",
+      oracleEyebrow: "Почему это созвучно названию",
+      oracleQuote:
+        "Ты пришёл не затем, чтобы сделать выбор. Ты пришёл, чтобы понять, почему ты его сделал.",
+      oracleSource: "Оракул, «Матрица: Перезагрузка» (2003)",
+      oracleBridge:
+        "Когда действует агент, опасность в том, что «почему» всплывает уже после последствий. PythiaLabs делает «почему» читаемым заранее: стабильные stop-причины и воспроизводимый trace до вызова tool — чтобы человек понимал выбор, пока его ещё можно остановить.",
     },
     founderVideosBlock: {
       eyebrow: "От основателя",
@@ -836,6 +848,11 @@ export const locales = {
       title: "没有可校验行动权限的自主性，不是智能，而是风险",
       body: "AI 行业正快速走向自主代理。PythiaLabs 构建在一个简单理念之上：",
       pullQuote: "强大的 AI Agent 不只是要会推理，更应受到可校验行动权限的约束。",
+      oracleEyebrow: "与名字的共鸣",
+      oracleQuote: "你不是来这里做选择的——你是来试图理解自己为何做出这个选择。",
+      oracleSource: "先知，《黑客帝国：重装上阵》（2003）",
+      oracleBridge:
+        "当 Agent 真正行动时，风险在于「为何」往往在后果之后才浮现。PythiaLabs 让「为何」在工具执行前就可读：稳定的停止原因与可重放轨迹——在人类仍能叫停时理解这次选择。",
     },
     founderVideosBlock: {
       eyebrow: "来自创始人",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -431,6 +431,14 @@ export function renderPage(currentId, year) {
           <h2>${escape(t.authority.title)}</h2>
           <p>${escape(t.authority.body)}</p>
           <blockquote class="big-quote">${escape(t.authority.pullQuote)}</blockquote>
+          <aside class="oracle-quote" aria-labelledby="oracle-quote-label">
+            <p class="oracle-quote-eyebrow" id="oracle-quote-label">${escape(t.authority.oracleEyebrow)}</p>
+            <blockquote class="oracle-quote-body">
+              <p>${escape(t.authority.oracleQuote)}</p>
+              <cite class="oracle-quote-source">${escape(t.authority.oracleSource)}</cite>
+            </blockquote>
+            <p class="oracle-quote-bridge">${escape(t.authority.oracleBridge)}</p>
+          </aside>
         </div>
       </section>
 

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1110,6 +1110,52 @@ blockquote {
   color: var(--text);
 }
 
+.oracle-quote {
+  margin: 2rem 0 0;
+  padding: 1.35rem 1.5rem;
+  max-width: 820px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(22, 27, 34, 0.55);
+}
+
+.oracle-quote-eyebrow {
+  margin: 0 0 0.65rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.oracle-quote-body {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.oracle-quote-body p {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.15rem, 2vw, 1.35rem);
+  line-height: 1.45;
+  font-style: italic;
+  color: var(--text);
+}
+
+.oracle-quote-source {
+  display: block;
+  font-size: 0.88rem;
+  font-style: normal;
+  color: var(--text-muted);
+}
+
+.oracle-quote-bridge {
+  margin: 1rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
 /* Not / negation list (Big Idea, Positioning) */
 .not-list {
   list-style: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds audience-minded framing next to the existing authority section, using the Oracle line from *The Matrix* about understanding *why* a choice was made — then explicitly ties that to pre-execution artifacts (stop reasons + replayable trace before tools run).

- New copy keys under `authority`: `oracleEyebrow`, `oracleQuote`, `oracleSource`, `oracleBridge` for EN / RU / ZH
- Attribution shortened to **The Matrix** (not Reloaded-by-title) per maintainer preference
- Renders as a bordered aside under the main pull quote; `cite` for attribution; `aria-labelledby` on the aside

Built with `npm run build` under `site/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

