### PR TITLE
site: quickstart steps render monospace commands as <code>

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -492,7 +492,7 @@ export const locales = {
       steps: [
         {
           name: "Клон и зависимости",
-          desc: "`git clone` репозитория, затем `mix deps.get` (как в CI).",
+          desc: "Сделайте `git clone` репозитория, затем `mix deps.get` (как в CI).",
         },
         {
           name: "Прогон тестов",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -8,6 +8,20 @@ const escape = (s) =>
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
 
+/** Interprets `…` spans as inline <code> (safe for HTML). */
+const inlineCodeToHtml = (s) => {
+  const parts = String(s).split(/`([^`]*)`/g);
+  let html = "";
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 0) {
+      html += escape(parts[i]);
+    } else {
+      html += `<code class="inline-code">${escape(parts[i])}</code>`;
+    }
+  }
+  return html;
+};
+
 const li = (s) => `<li>${escape(s)}</li>`;
 
 const ARTIFACT_JSON = `{
@@ -203,7 +217,7 @@ export function renderPage(currentId, year, buildDate) {
   const mechanismSteps = t.solution.steps
     .map(
       (s, i) =>
-        `<li class="step"><div class="step-num" aria-hidden="true">${i + 1}</div><div class="step-body"><h3>${escape(s.name)}</h3><p>${escape(s.desc)}</p></div></li>`,
+        `<li class="step"><div class="step-num" aria-hidden="true">${i + 1}</div><div class="step-body"><h3>${escape(s.name)}</h3><p>${inlineCodeToHtml(s.desc)}</p></div></li>`,
     )
     .join("");
 
@@ -481,7 +495,7 @@ export function renderPage(currentId, year, buildDate) {
           <ol class="step-list quickstart-list">${t.quickstart.steps
             .map(
               (s, i) =>
-                `<li class="step"><div class="step-num" aria-hidden="true">${i + 1}</div><div class="step-body"><h3>${escape(s.name)}</h3><p>${escape(s.desc)}</p></div></li>`,
+                `<li class="step"><div class="step-num" aria-hidden="true">${i + 1}</div><div class="step-body"><h3>${escape(s.name)}</h3><p>${inlineCodeToHtml(s.desc)}</p></div></li>`,
             )
             .join("")}</ol>
         </div>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1405,6 +1405,17 @@ blockquote {
   line-height: 1.5;
 }
 
+.step-body .inline-code,
+.quickstart-list .inline-code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: rgba(126, 196, 255, 0.1);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.06em 0.35em;
+  color: var(--text);
+}
+
 /* Video block — core message pull */
 .core-message {
   margin: 1.25rem 0 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Interprets `` `…` `` spans in mechanism and quickstart step descriptions as semantic `<code class="inline-code">` so commands show in monospace instead of raw backticks.
- Adds light styling for inline code inside step bodies.
- Russian quickstart step 1: wording adjusted to "Сделайте `git clone` репозитория…" for natural grammar with inline code.

## Testing

- `npm run format` and `npm run build` in `site/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

