### PR TITLE
site: monospace commands in integration note, FAQ, artifact details

### DIFF
--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -468,7 +468,7 @@ export function renderPage(currentId, year, buildDate) {
           <p>${escape(t.artifact.introPlain)}</p>
           <details class="artifact-technical">
             <summary>${escape(t.artifact.technicalSummary)}</summary>
-            <p>${escape(t.artifact.introTechnical)}</p>
+            <p>${inlineCodeToHtml(t.artifact.introTechnical)}</p>
           </details>
           <pre class="code-block" aria-label="Example evidence artifact JSON"><code>${escape(ARTIFACT_JSON)}</code></pre>
         </div>
@@ -481,10 +481,10 @@ export function renderPage(currentId, year, buildDate) {
           <div class="card-grid">${t.integration.items
             .map(
               (item) =>
-                `<article class="card"><h3>${escape(item.name)}</h3><p>${escape(item.desc)}</p></article>`,
+                `<article class="card"><h3>${escape(item.name)}</h3><p>${inlineCodeToHtml(item.desc)}</p></article>`,
             )
             .join("")}</div>
-          <p class="integration-repo-note">${escape(t.integration.repoNote)}</p>
+          <p class="integration-repo-note">${inlineCodeToHtml(t.integration.repoNote)}</p>
         </div>
       </section>
 
@@ -622,7 +622,7 @@ export function renderPage(currentId, year, buildDate) {
             ${t.faq.items
               .map(
                 (item) =>
-                  `<details class="faq-item"><summary>${escape(item.q)}</summary><p>${escape(item.a)}</p></details>`,
+                  `<details class="faq-item"><summary>${escape(item.q)}</summary><p>${inlineCodeToHtml(item.a)}</p></details>`,
               )
               .join("")}
           </div>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1406,7 +1406,11 @@ blockquote {
 }
 
 .step-body .inline-code,
-.quickstart-list .inline-code {
+.quickstart-list .inline-code,
+.card .inline-code,
+.integration-repo-note .inline-code,
+.faq-item .inline-code,
+.artifact-technical .inline-code {
   font-family: var(--mono);
   font-size: 0.9em;
   background: rgba(126, 196, 255, 0.1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the same `` `…` `` → `<code class="inline-code">` rendering used for quickstart steps to:

- Integration card descriptions and the reviewer quickstart `repoNote` paragraph (fixes raw backticks in the DOM).
- FAQ answers (integration how-to and similar strings with commands).
- The artifact `<details>` technical paragraph (`pythia.canonical_export.v1`).

Extends `.inline-code` styles to cards, integration note, FAQ, and artifact technical blocks.

## Testing

- `npm run format` and `npm run build` in `site/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

