### PR TITLE
site: disable automatic translation on root html (translate=no)

### DIFF
--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -234,7 +234,7 @@ export function renderPage(currentId, year, buildDate) {
     .join("");
 
   return `<!doctype html>
-<html lang="${t.htmlLang}">
+<html lang="${t.htmlLang}" translate="no">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chrome and other browsers can “translate” the page and inject nested `<font>` nodes around text and even inside elements like step numbers. That breaks the layout around `<code>` snippets and litters the DOM (as seen in quickstart step 3).

## Change

Add `translate="no"` on the root `<html>` element. The site already ships dedicated locale URLs (`/`, `/ru/`, `/zh/`) with full translations, so automatic page translation is redundant and harmful to the markup.

## Testing

- `npm run format` and `npm run build` in `site/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

