### PR TITLE
feat: MCP stdio server + mix pythia.eval_json for infra gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tmp/
 node_modules/
 site/dist/
 site/node_modules/
+
+integrations/mcp/node_modules/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ mix run examples/banking_ai_risk_showcase.exs
 mix run examples/web3_treasury_full_showcase.exs
 ```
 
+## Cursor / IDE bridge (MCP)
+
+A minimal **stdio MCP server** lives in [`integrations/mcp/`](integrations/mcp/). It exposes tools that call `mix pythia.eval_json` locally so Cursor (or any MCP host) can run the **agent infrastructure** gate on a JSON proposal.
+
+```bash
+# Same schema as the MCP tool `pythia_evaluate_agent_infra` (see integrations/mcp/README.md)
+echo '{"gate":"agent_infra_action","action":{...},"safety_context":{...}}' | mix pythia.eval_json
+```
+
+Setup steps and `mcp.json` snippet: [`integrations/mcp/README.md`](integrations/mcp/README.md).
+
 ## What PythiaLabs is not yet
 
 PythiaLabs currently does not claim:

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -1,0 +1,85 @@
+# PythiaLabs MCP (Cursor & compatible hosts)
+
+stdio MCP server that exposes **`pythia_evaluate_agent_infra`** — it shells to `mix pythia.eval_json` in this repository so the deterministic infrastructure gate runs locally (no hosted service).
+
+## Prerequisites
+
+- Elixir / Mix on `PATH` (same as reviewer quickstart: `mix deps.get`, `mix compile`)
+- Node.js 18+ (for this thin MCP adapter)
+
+## Install (Cursor)
+
+1. Clone PythiaLabs and run `mix deps.get` once at the repo root.
+2. In Cursor: **Settings → MCP → Add server** (or edit `~/.cursor/mcp.json`), e.g.:
+
+```json
+{
+  "mcpServers": {
+    "pythialabs": {
+      "command": "node",
+      "args": ["/absolute/path/to/pythiaLabs/integrations/mcp/server.mjs"],
+      "env": {}
+    }
+  }
+}
+```
+
+If the repo is not next to `integrations/mcp` relative to the script, set:
+
+```json
+"env": {
+  "PYTHIA_REPO_ROOT": "/absolute/path/to/pythiaLabs"
+}
+```
+
+3. Restart Cursor (or reload MCP). You should see tools **`pythia_evaluate_agent_infra`** and **`pythia_mcp_info`**.
+
+## Tool: `pythia_evaluate_agent_infra`
+
+Pass **`input_json`** — a single JSON string matching the schema consumed by `mix pythia.eval_json`:
+
+- **`gate`**: `"agent_infra_action"`
+- **`action`**: infrastructure action map (string keys), including ISO-8601 `action_time` and `decision_time`
+- **`safety_context`**: safety context map (booleans + string fields as in `examples/agent_infra_action_showcase.exs`)
+
+### Example `input_json` (accept path from showcase)
+
+```json
+{
+  "gate": "agent_infra_action",
+  "action": {
+    "action_id": "infra_act_001",
+    "action_type": "volume_delete",
+    "actor_id": "agent_ops_7",
+    "resource_id": "db_volume_primary",
+    "resource_type": "database_volume",
+    "target_environment": "production",
+    "action_time": "2026-04-27T12:00:00Z",
+    "decision_time": "2026-04-27T12:00:09Z"
+  },
+  "safety_context": {
+    "credential_scope": "scoped_operator",
+    "explicit_user_approval_present": true,
+    "environment_scope_verified": true,
+    "documentation_verified": true,
+    "dry_run_completed": true,
+    "backup_isolation": "off_target",
+    "decision_time_knowledge_present": true
+  }
+}
+```
+
+Response maps **`outcome`** to **`ALLOW`** when the gate accepts, **`BLOCK`** when it rejects (deterministic showcase semantics). See stdout JSON for `export`, `evidence`, and `stop_reason`.
+
+## CLI without MCP
+
+```bash
+echo '{"gate":"agent_infra_action", ... }' | mix pythia.eval_json
+# or
+mix pythia.eval_json --file proposal.json
+```
+
+## Limitations (MVP)
+
+- One gate id: **`agent_infra_action`**. Banking / Web3 showcases can be wired the same way later.
+- Requires local Mix + compiled project; MCP is a bridge, not a remote API.

--- a/integrations/mcp/package.json
+++ b/integrations/mcp/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pythialabs-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP stdio server that bridges Cursor to mix pythia.eval_json",
+  "type": "module",
+  "bin": {
+    "pythialabs-mcp": "./server.mjs"
+  },
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/integrations/mcp/server.mjs
+++ b/integrations/mcp/server.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Minimal MCP server (stdio) — forwards tool calls to `mix pythia.eval_json`.
+ *
+ * Env:
+ *   PYTHIA_REPO_ROOT — absolute path to PythiaLabs clone (default: parent of integrations/mcp)
+ */
+
+import { spawn } from "node:child_process";
+import * as readline from "node:readline";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultRoot = path.resolve(__dirname, "..", "..");
+const repoRoot = process.env.PYTHIA_REPO_ROOT
+  ? path.resolve(process.env.PYTHIA_REPO_ROOT)
+  : defaultRoot;
+
+const SERVER_INFO = {
+  name: "pythialabs",
+  version: "0.1.0",
+};
+
+const TOOLS = [
+  {
+    name: "pythia_evaluate_agent_infra",
+    description:
+      "Run the deterministic PythiaLabs agent infrastructure gate (ALLOW/BLOCK style outcome). Input: JSON with gate, action, safety_context per repo docs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        input_json: {
+          type: "string",
+          description:
+            'Full JSON body for mix pythia.eval_json, e.g. {"gate":"agent_infra_action","action":{...},"safety_context":{...}}',
+        },
+      },
+      required: ["input_json"],
+    },
+  },
+  {
+    name: "pythia_mcp_info",
+    description: "Return PythiaLabs repo root used by this MCP server and supported tools.",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+let messageId = 0;
+function nextId() {
+  messageId += 1;
+  return messageId;
+}
+
+function send(msg) {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+function runMixEvalJson(jsonBody) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("mix", ["pythia.eval_json"], {
+      cwd: repoRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (c) => (out += c));
+    child.stderr.on("data", (c) => (err += c));
+    child.on("error", reject);
+    child.stdin.write(jsonBody);
+    child.stdin.end();
+    child.on("close", (code) => {
+      resolve({ code, out: out.trim(), err: err.trim() });
+    });
+  });
+}
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+for await (const line of rl) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    continue;
+  }
+
+  const { method, params, id } = msg;
+
+  if (method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      },
+    });
+    continue;
+  }
+
+  if (method === "notifications/initialized" || method === "initialized") {
+    continue;
+  }
+
+  if (method === "tools/list") {
+    send({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+    continue;
+  }
+
+  if (method === "tools/call") {
+    const name = params?.name;
+    const args = params?.arguments ?? {};
+
+    if (name === "pythia_mcp_info") {
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  server: SERVER_INFO.name,
+                  version: SERVER_INFO.version,
+                  repoRoot,
+                  mixTask: "mix pythia.eval_json",
+                  docs: "integrations/mcp/README.md",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        },
+      });
+      continue;
+    }
+
+    if (name === "pythia_evaluate_agent_infra") {
+      const input = args.input_json;
+      if (typeof input !== "string" || !input.trim()) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32602, message: "input_json must be a non-empty string" },
+        });
+        continue;
+      }
+
+      try {
+        const { code, out, err } = await runMixEvalJson(input);
+        const payload = {
+          exitCode: code,
+          stdout: out,
+          stderr: err || undefined,
+        };
+        let pretty = out;
+        try {
+          pretty = JSON.stringify(JSON.parse(out), null, 2);
+        } catch {
+          /* keep raw */
+        }
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: pretty }],
+            structuredContent: payload,
+            isError: code !== 0,
+          },
+        });
+      } catch (e) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32603,
+            message: e?.message ?? String(e),
+          },
+        });
+      }
+      continue;
+    }
+
+    send({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: `Unknown tool: ${name}` },
+    });
+    continue;
+  }
+
+  if (method === "ping") {
+    send({ jsonrpc: "2.0", id, result: {} });
+    continue;
+  }
+
+  if (id !== undefined && id !== null) {
+    send({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: `Method not found: ${method}` },
+    });
+  }
+}

--- a/lib/mix/tasks/pythia.eval_json.ex
+++ b/lib/mix/tasks/pythia.eval_json.ex
@@ -1,0 +1,52 @@
+defmodule Mix.Tasks.Pythia.EvalJson do
+  use Mix.Task
+
+  @shortdoc "Run AgentInfraAction gate on JSON (stdin or --file path)"
+
+  @moduledoc """
+  Reads one JSON object and prints the evaluation result as JSON on stdout.
+
+  ## Examples
+
+      echo '{"gate":"agent_infra_action",...}' | mix pythia.eval_json
+
+      mix pythia.eval_json --file proposal.json
+
+  See `Pythia.Mcp.JsonEvaluator` for the input schema.
+  """
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, _, _} =
+      OptionParser.parse(argv,
+        strict: [file: :string],
+        aliases: [f: :file]
+      )
+
+    Mix.Task.run("compile")
+
+    input =
+      case Keyword.get(opts, :file) do
+        nil -> IO.read(:stdio)
+        path -> File.read!(path)
+      end
+
+    input = String.trim(input)
+
+    case input do
+      "" ->
+        IO.puts(Jason.encode!(%{ok: false, error: "empty_input"}))
+        System.halt(2)
+
+      body ->
+        case Pythia.Mcp.JsonEvaluator.run(body) do
+          {:ok, resp} ->
+            IO.puts(Jason.encode!(resp))
+
+          {:error, err} ->
+            IO.puts(Jason.encode!(err))
+            System.halt(1)
+        end
+    end
+  end
+end

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -144,7 +144,17 @@ defmodule Pythia.Mcp.JsonEvaluator do
   end
 
   defp get_str(raw, key, field) do
-    case Map.get(raw, key) || Map.get(raw, field) do
+    val =
+      cond do
+        Map.has_key?(raw, key) -> Map.fetch!(raw, key)
+        Map.has_key?(raw, field) -> Map.fetch!(raw, field)
+        true -> nil
+      end
+
+    case val do
+      nil ->
+        {:error, %{error: "missing_field", field: key}}
+
       v when is_binary(v) ->
         if String.trim(v) != "" do
           {:ok, v}
@@ -152,16 +162,20 @@ defmodule Pythia.Mcp.JsonEvaluator do
           {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
         end
 
-      nil ->
-        {:error, %{error: "missing_field", field: key}}
-
       _ ->
         {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
     end
   end
 
   defp get_bool(raw, key, field) do
-    case Map.get(raw, key) || Map.get(raw, field) do
+    val =
+      cond do
+        Map.has_key?(raw, key) -> Map.fetch!(raw, key)
+        Map.has_key?(raw, field) -> Map.fetch!(raw, field)
+        true -> nil
+      end
+
+    case val do
       true -> {:ok, true}
       false -> {:ok, false}
       nil -> {:error, %{error: "missing_field", field: key}}
@@ -170,13 +184,18 @@ defmodule Pythia.Mcp.JsonEvaluator do
   end
 
   defp fetch_iso_datetime(raw, key, field) do
-    v = Map.get(raw, key) || Map.get(raw, field)
+    val =
+      cond do
+        Map.has_key?(raw, key) -> Map.fetch!(raw, key)
+        Map.has_key?(raw, field) -> Map.fetch!(raw, field)
+        true -> nil
+      end
 
     cond do
-      is_binary(v) ->
-        case DateTime.from_iso8601(v) do
+      is_binary(val) ->
+        case DateTime.from_iso8601(val) do
           {:ok, dt, _} -> {:ok, dt}
-          {:error, _} -> {:error, %{error: "invalid_datetime", field: key, value: v}}
+          {:error, _} -> {:error, %{error: "invalid_datetime", field: key, value: val}}
         end
 
       true ->

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -138,9 +138,18 @@ defmodule Pythia.Mcp.JsonEvaluator do
 
   defp get_str(raw, key, field) do
     case Map.get(raw, key) || Map.get(raw, field) do
-      v when is_binary(v) and String.trim(v) != "" -> {:ok, v}
-      nil -> {:error, %{error: "missing_field", field: key}}
-      _ -> {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
+      v when is_binary(v) ->
+        if String.trim(v) != "" do
+          {:ok, v}
+        else
+          {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
+        end
+
+      nil ->
+        {:error, %{error: "missing_field", field: key}}
+
+      _ ->
+        {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
     end
   end
 

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -40,14 +40,20 @@ defmodule Pythia.Mcp.JsonEvaluator do
         end
 
       nil ->
-        {:error, %{error: "missing_gate", message: "required field \"gate\" (e.g. \"agent_infra_action\")"}}
+        {:error,
+         %{
+           error: "missing_gate",
+           message: "required field \"gate\" (e.g. \"agent_infra_action\")"
+         }}
 
       other ->
-        {:error, %{error: "unknown_gate", gate: other, message: "supported: [\"agent_infra_action\"]"}}
+        {:error,
+         %{error: "unknown_gate", gate: other, message: "supported: [\"agent_infra_action\"]"}}
     end
   end
 
-  defp evaluate_decoded(_), do: {:error, %{error: "invalid_body", message: "JSON root must be an object"}}
+  defp evaluate_decoded(_),
+    do: {:error, %{error: "invalid_body", message: "JSON root must be an object"}}
 
   defp build_response({:ok, payload}, evidence) do
     %{
@@ -100,6 +106,7 @@ defmodule Pythia.Mcp.JsonEvaluator do
 
   defp decode_safety_context(raw) when is_map(raw) do
     strings = [:credential_scope, :backup_isolation]
+
     bools = [
       :explicit_user_approval_present,
       :environment_scope_verified,

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -1,0 +1,170 @@
+defmodule Pythia.Mcp.JsonEvaluator do
+  @moduledoc """
+  JSON bridge for IDE / MCP clients: decodes a proposal + safety context,
+  runs `Pythia.Showcase.AgentInfraAction.evaluate/2`, returns JSON-friendly maps.
+
+  Input is a JSON object with string keys. Required top-level key `"gate"`.
+  Currently supported: `"agent_infra_action"` (matches the infrastructure showcase gate).
+  """
+
+  alias Pythia.Showcase.AgentInfraAction
+
+  @doc """
+  Parses `json_string` and returns `{:ok, response_map}` or `{:error, error_map}`.
+  Both maps are safe to pass to `Jason.encode!/1`.
+  """
+  @spec run(String.t()) :: {:ok, map()} | {:error, map()}
+  def run(json_string) when is_binary(json_string) do
+    with {:ok, decoded} <- Jason.decode(json_string),
+         {:ok, response} <- evaluate_decoded(decoded) do
+      {:ok, response}
+    else
+      {:error, %Jason.DecodeError{} = e} ->
+        {:error, %{ok: false, error: "invalid_json", message: Exception.message(e)}}
+
+      {:error, reason} when is_map(reason) ->
+        {:error, Map.put(reason, :ok, false)}
+    end
+  end
+
+  defp evaluate_decoded(decoded) when is_map(decoded) do
+    gate = Map.get(decoded, "gate")
+
+    case gate do
+      "agent_infra_action" ->
+        with {:ok, action} <- decode_action(Map.get(decoded, "action", %{})),
+             {:ok, ctx} <- decode_safety_context(Map.get(decoded, "safety_context", %{})) do
+          raw = AgentInfraAction.evaluate(action, ctx)
+          evidence = AgentInfraAction.export_evidence(raw)
+          {:ok, build_response(raw, evidence)}
+        end
+
+      nil ->
+        {:error, %{error: "missing_gate", message: "required field \"gate\" (e.g. \"agent_infra_action\")"}}
+
+      other ->
+        {:error, %{error: "unknown_gate", gate: other, message: "supported: [\"agent_infra_action\"]"}}
+    end
+  end
+
+  defp evaluate_decoded(_), do: {:error, %{error: "invalid_body", message: "JSON root must be an object"}}
+
+  defp build_response({:ok, payload}, evidence) do
+    %{
+      ok: true,
+      outcome: "ALLOW",
+      status: "accepted",
+      stop_reason: format_stop_reason(payload[:stop_reason]),
+      export: AgentInfraAction.export_result({:ok, payload}),
+      evidence: evidence
+    }
+  end
+
+  defp build_response({:error, payload}, evidence) do
+    %{
+      ok: true,
+      outcome: "BLOCK",
+      status: "rejected",
+      stop_reason: format_stop_reason(payload[:stop_reason]),
+      export: AgentInfraAction.export_result({:error, payload}),
+      evidence: evidence
+    }
+  end
+
+  defp format_stop_reason(nil), do: nil
+  defp format_stop_reason(atom) when is_atom(atom), do: Atom.to_string(atom)
+  defp format_stop_reason(other), do: to_string(other)
+
+  defp decode_action(raw) when is_map(raw) do
+    required = [
+      :action_id,
+      :action_type,
+      :actor_id,
+      :resource_id,
+      :resource_type,
+      :target_environment,
+      :action_time,
+      :decision_time
+    ]
+
+    with {:ok, fields} <- fetch_required_string(raw, required -- [:action_time, :decision_time]),
+         {:ok, action_time} <- fetch_iso_datetime(raw, "action_time", :action_time),
+         {:ok, decision_time} <- fetch_iso_datetime(raw, "decision_time", :decision_time) do
+      {:ok,
+       Map.merge(fields, %{
+         action_time: action_time,
+         decision_time: decision_time
+       })}
+    end
+  end
+
+  defp decode_safety_context(raw) when is_map(raw) do
+    strings = [:credential_scope, :backup_isolation]
+    bools = [
+      :explicit_user_approval_present,
+      :environment_scope_verified,
+      :documentation_verified,
+      :dry_run_completed,
+      :decision_time_knowledge_present
+    ]
+
+    with {:ok, str} <- fetch_required_string(raw, strings),
+         {:ok, bo} <- fetch_required_bool(raw, bools) do
+      {:ok, Map.merge(str, bo)}
+    end
+  end
+
+  defp fetch_required_string(raw, fields) do
+    Enum.reduce_while(fields, {:ok, %{}}, fn field, {:ok, acc} ->
+      key = Atom.to_string(field)
+
+      case get_str(raw, key, field) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, field, value)}}
+        {:error, e} -> {:halt, {:error, e}}
+      end
+    end)
+  end
+
+  defp fetch_required_bool(raw, fields) do
+    Enum.reduce_while(fields, {:ok, %{}}, fn field, {:ok, acc} ->
+      key = Atom.to_string(field)
+
+      case get_bool(raw, key, field) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, field, value)}}
+        {:error, e} -> {:halt, {:error, e}}
+      end
+    end)
+  end
+
+  defp get_str(raw, key, field) do
+    case Map.get(raw, key) || Map.get(raw, field) do
+      v when is_binary(v) and String.trim(v) != "" -> {:ok, v}
+      nil -> {:error, %{error: "missing_field", field: key}}
+      _ -> {:error, %{error: "invalid_field", field: key, expected: "non-empty string"}}
+    end
+  end
+
+  defp get_bool(raw, key, field) do
+    case Map.get(raw, key) || Map.get(raw, field) do
+      true -> {:ok, true}
+      false -> {:ok, false}
+      nil -> {:error, %{error: "missing_field", field: key}}
+      _ -> {:error, %{error: "invalid_field", field: key, expected: "boolean"}}
+    end
+  end
+
+  defp fetch_iso_datetime(raw, key, field) do
+    v = Map.get(raw, key) || Map.get(raw, field)
+
+    cond do
+      is_binary(v) ->
+        case DateTime.from_iso8601(v) do
+          {:ok, dt, _} -> {:ok, dt}
+          {:error, _} -> {:error, %{error: "invalid_datetime", field: key, value: v}}
+        end
+
+      true ->
+        {:error, %{error: "missing_or_invalid_field", field: key, expected: "ISO-8601 string"}}
+    end
+  end
+end

--- a/test/mcp/json_evaluator_test.exs
+++ b/test/mcp/json_evaluator_test.exs
@@ -52,4 +52,15 @@ defmodule Pythia.Mcp.JsonEvaluatorTest do
     assert err.ok == false
     assert err.error == "missing_gate"
   end
+
+  test "explicit false booleans are read correctly (not treated as missing)" do
+    ctx =
+      @accept_body["safety_context"]
+      |> Map.put("explicit_user_approval_present", false)
+
+    body = Map.put(@accept_body, "safety_context", ctx)
+    json = Jason.encode!(body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "BLOCK"
+  end
 end

--- a/test/mcp/json_evaluator_test.exs
+++ b/test/mcp/json_evaluator_test.exs
@@ -1,0 +1,55 @@
+defmodule Pythia.Mcp.JsonEvaluatorTest do
+  use ExUnit.Case, async: true
+
+  alias Pythia.Mcp.JsonEvaluator
+
+  @accept_body %{
+    "gate" => "agent_infra_action",
+    "action" => %{
+      "action_id" => "infra_act_001",
+      "action_type" => "volume_delete",
+      "actor_id" => "agent_ops_7",
+      "resource_id" => "db_volume_primary",
+      "resource_type" => "database_volume",
+      "target_environment" => "production",
+      "action_time" => "2026-04-27T12:00:00Z",
+      "decision_time" => "2026-04-27T12:00:09Z"
+    },
+    "safety_context" => %{
+      "credential_scope" => "scoped_operator",
+      "explicit_user_approval_present" => true,
+      "environment_scope_verified" => true,
+      "documentation_verified" => true,
+      "dry_run_completed" => true,
+      "backup_isolation" => "off_target",
+      "decision_time_knowledge_present" => true
+    }
+  }
+
+  test "accept path maps to ALLOW and includes evidence" do
+    json = Jason.encode!(@accept_body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "ALLOW"
+    assert resp.status == "accepted"
+    assert resp.ok == true
+    assert is_map(resp.evidence)
+    assert resp.evidence["artifact_type"] == "pythia.agent_infra_action.decision_trace.v1"
+  end
+
+  test "reject path maps to BLOCK on missing approval" do
+    ctx = Map.put(@accept_body["safety_context"], "explicit_user_approval_present", false)
+    body = Map.put(@accept_body, "safety_context", ctx)
+    json = Jason.encode!(body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "BLOCK"
+    assert resp.status == "rejected"
+    assert resp.stop_reason == "destructive_action_requires_explicit_approval"
+  end
+
+  test "missing gate returns error" do
+    json = Jason.encode!(Map.delete(@accept_body, "gate"))
+    assert {:error, err} = JsonEvaluator.run(json)
+    assert err.ok == false
+    assert err.error == "missing_gate"
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- **`Pythia.Mcp.JsonEvaluator`** — accepts JSON (`gate`, `action`, `safety_context`) for `agent_infra_action`, returns JSON with `outcome` (`ALLOW` / `BLOCK`), `export`, and `evidence` (same export path as showcases).
- **`mix pythia.eval_json`** — stdin or `--file`; prints one JSON line for IDE piping.
- **`integrations/mcp/`** — minimal Node stdio MCP server calling `mix pythia.eval_json` (`pythia_evaluate_agent_infra`, `pythia_mcp_info`).
- **README** — short “Cursor / IDE bridge” section linking to `integrations/mcp/README.md`.
- **Tests** — `test/mcp/json_evaluator_test.exs`.

## Why

Delivers the “го” MVP: Cursor can list tools and run the real deterministic gate locally without a hosted API.

## Notes for reviewers

- MCP `structuredContent.isError` is true when Mix exits non-zero (validation / gate errors print JSON to stdout with exit 1).
- `PYTHIA_REPO_ROOT` env if `server.mjs` is not under `integrations/mcp` of the clone.

## Testing

- CI: `mix test` (includes new evaluator tests).
- Local: `node --check integrations/mcp/server.mjs` (syntax).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

