### PR TITLE
fix(site): quickstart step cards — wrap long commands

### DIFF
--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1372,10 +1372,16 @@ blockquote {
 .step {
   display: flex;
   gap: 0.9rem;
+  min-width: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.1rem 1.25rem;
+}
+
+.step-body {
+  min-width: 0;
+  flex: 1;
 }
 
 .step-num {
@@ -1403,6 +1409,7 @@ blockquote {
   color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .step-body .inline-code,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Russian (and other) quickstart step that lists `mix run examples/...` and `docs/*_expected_output.md` could overflow horizontally inside the flex-based `.step` cards because flex items default to `min-width: auto`, which blocks shrinking below the longest unbreakable token.

## Changes

- Set `min-width: 0` on `.step` and `.step-body` so flex children can shrink within the CSS grid.
- Set `flex: 1` on `.step-body` so copy uses remaining width beside the step number.
- Add `overflow-wrap: anywhere` on `.step-body p` so long paths and commands break inside the card instead of spilling out.

## Testing

Not run (CSS-only; Node/site build not executed in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

