### PR TITLE
fix(site): integration cards wrap long canonical_export copy

### DIFF
--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -338,6 +338,13 @@ blockquote {
   margin-top: 1.5rem;
 }
 
+/* Let grid tracks shrink so long copy wraps instead of widening the row */
+.card-grid > *,
+.two-col > *,
+.step-list > * {
+  min-width: 0;
+}
+
 .card {
   min-width: 0;
   background: var(--surface);
@@ -1409,6 +1416,7 @@ blockquote {
 .step-body h3 {
   margin: 0 0 0.35rem;
   font-size: 1rem;
+  overflow-wrap: anywhere;
 }
 
 .step-body p {
@@ -1432,6 +1440,9 @@ blockquote {
   border-radius: 4px;
   padding: 0.06em 0.35em;
   color: var(--text);
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Video block — core message pull */

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -339,6 +339,7 @@ blockquote {
 }
 
 .card {
+  min-width: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -349,6 +350,12 @@ blockquote {
   margin: 0 0 0.75rem;
   font-size: 1.05rem;
   color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.card p,
+.card li {
+  overflow-wrap: anywhere;
 }
 
 .card ul {
@@ -1372,10 +1379,16 @@ blockquote {
 .step {
   display: flex;
   gap: 0.9rem;
+  min-width: 0;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.1rem 1.25rem;
+}
+
+.step-body {
+  min-width: 0;
+  flex: 1;
 }
 
 .step-num {
@@ -1403,6 +1416,7 @@ blockquote {
   color: var(--text-muted);
   font-size: 0.95rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .step-body .inline-code,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integration cards (including the RU string with `pythia.canonical_export.v1`) and quickstart `.step` cards still overflowed on GitHub Pages: inline `<code class="inline-code">` defaults to non-wrapping behavior, and grid track minimums can still prevent shrinking unless applied to **direct grid children**.

## Changes

- `min-width: 0` on direct children of `.card-grid`, `.two-col`, and `.step-list`.
- `overflow-wrap: anywhere` on `.step-body h3`.
- On `.inline-code`: `white-space: normal`, `overflow-wrap: anywhere`, `word-break: break-word` so long paths and identifiers break **inside** the pill, not only on surrounding text.

## Testing

Not run (CSS-only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

