### PR TITLE
feat: MCP/JSON eval for banking_risk_action and web3_treasury_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ mix run examples/web3_treasury_full_showcase.exs
 
 ## Cursor / IDE bridge (MCP)
 
-A minimal **stdio MCP server** lives in [`integrations/mcp/`](integrations/mcp/). It exposes tools that call `mix pythia.eval_json` locally so Cursor (or any MCP host) can run the **agent infrastructure** gate on a JSON proposal.
+A minimal **stdio MCP server** in [`integrations/mcp/`](integrations/mcp/) calls `mix pythia.eval_json` locally so Cursor (or any MCP host) can run deterministic gates (`agent_infra_action`, `banking_risk_action`, `web3_treasury_action`) from JSON.
 
 ```bash
-# Same schema as the MCP tool `pythia_evaluate_agent_infra` (see integrations/mcp/README.md)
+# Any supported gate — see integrations/mcp/README.md
 echo '{"gate":"agent_infra_action","action":{...},"safety_context":{...}}' | mix pythia.eval_json
 ```
 

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -1,6 +1,6 @@
 # PythiaLabs MCP (Cursor & compatible hosts)
 
-stdio MCP server that exposes **`pythia_evaluate_agent_infra`** — it shells to `mix pythia.eval_json` in this repository so the deterministic infrastructure gate runs locally (no hosted service).
+stdio MCP server that forwards tool calls to `mix pythia.eval_json` in this repository so deterministic showcase gates run locally (no hosted service).
 
 ## Prerequisites
 
@@ -32,17 +32,23 @@ If the repo is not next to `integrations/mcp` relative to the script, set:
 }
 ```
 
-3. Restart Cursor (or reload MCP). You should see tools **`pythia_evaluate_agent_infra`** and **`pythia_mcp_info`**.
+3. Restart Cursor (or reload MCP). Tools: **`pythia_evaluate`** (main), **`pythia_evaluate_agent_infra`** (alias), **`pythia_mcp_info`**.
 
-## Tool: `pythia_evaluate_agent_infra`
+## Tool: `pythia_evaluate`
 
-Pass **`input_json`** — a single JSON string matching the schema consumed by `mix pythia.eval_json`:
+Pass **`input_json`** — one JSON object (string) for `mix pythia.eval_json`.
 
-- **`gate`**: `"agent_infra_action"`
-- **`action`**: infrastructure action map (string keys), including ISO-8601 `action_time` and `decision_time`
-- **`safety_context`**: safety context map (booleans + string fields as in `examples/agent_infra_action_showcase.exs`)
+### `gate` values
 
-### Example `input_json` (accept path from showcase)
+| `gate` | Second map | Matches showcase |
+|--------|------------|------------------|
+| `agent_infra_action` | `safety_context` | `examples/agent_infra_action_showcase.exs` |
+| `banking_risk_action` | `governance` (or `governance_record`) | `examples/banking_ai_risk_showcase.exs` |
+| `web3_treasury_action` | `governance` (or `governance_record`) | `examples/web3_treasury_action_showcase.exs` |
+
+Use **string keys** and **ISO-8601** datetimes. For Web3, `amount` must be an integer (whole-number floats accepted).
+
+### Example: agent infrastructure (accept path)
 
 ```json
 {
@@ -69,17 +75,74 @@ Pass **`input_json`** — a single JSON string matching the schema consumed by `
 }
 ```
 
-Response maps **`outcome`** to **`ALLOW`** when the gate accepts, **`BLOCK`** when it rejects (deterministic showcase semantics). See stdout JSON for `export`, `evidence`, and `stop_reason`.
+### Example: banking risk
+
+```json
+{
+  "gate": "banking_risk_action",
+  "action": {
+    "action_id": "bank_act_001",
+    "action_type": "fraud_response",
+    "operator_id": "risk_operator_7",
+    "account_id": "acct_demo_01",
+    "action_time": "2026-04-26T09:00:00Z",
+    "decision_time": "2026-04-26T09:01:00Z"
+  },
+  "governance": {
+    "authorization_valid_from": "2026-04-26T08:30:00Z",
+    "authorization_valid_to": "2026-04-26T10:30:00Z",
+    "authorization_recorded_at": "2026-04-26T08:45:00Z",
+    "evidence_observed_at": "2026-04-26T08:55:00Z",
+    "evidence_valid_until": "2026-04-26T09:10:00Z",
+    "decision_time_knowledge_present": true,
+    "operator_approval_present": true
+  }
+}
+```
+
+### Example: Web3 treasury
+
+```json
+{
+  "gate": "web3_treasury_action",
+  "action": {
+    "action_id": "dao_act_001",
+    "action_type": "treasury_transfer",
+    "actor": "agent_alpha",
+    "dao_id": "dao_pythia",
+    "proposal_id": "prop_001",
+    "amount": 10000,
+    "asset": "USDC",
+    "recipient": "0xRecipient",
+    "required_permission": "treasury.transfer",
+    "action_time": "2026-04-25T12:00:00Z",
+    "decision_time": "2026-04-25T12:01:00Z"
+  },
+  "governance": {
+    "proposal_id": "prop_001",
+    "permission": "treasury.transfer",
+    "quorum_met": true,
+    "voting_closed_at": "2026-04-25T11:00:00Z",
+    "timelock_until": "2026-04-25T11:30:00Z",
+    "authorization_valid_from": "2026-04-25T11:30:00Z",
+    "authorization_valid_to": "2026-04-25T13:00:00Z",
+    "authorization_recorded_at": "2026-04-25T11:45:00Z",
+    "transfer_expires_at": "2026-04-25T13:00:00Z"
+  }
+}
+```
+
+Response: **`outcome`** **`ALLOW`** or **`BLOCK`**, plus `export`, `evidence`, `stop_reason` (showcase semantics).
 
 ## CLI without MCP
 
 ```bash
 echo '{"gate":"agent_infra_action", ... }' | mix pythia.eval_json
-# or
+echo '{"gate":"banking_risk_action", ... }' | mix pythia.eval_json
 mix pythia.eval_json --file proposal.json
 ```
 
 ## Limitations (MVP)
 
-- One gate id: **`agent_infra_action`**. Banking / Web3 showcases can be wired the same way later.
-- Requires local Mix + compiled project; MCP is a bridge, not a remote API.
+- Deterministic local showcases only; MCP is a bridge, not a remote API.
+- Field decoding is strict JSON (no silent coercion beyond whole-number floats for `amount`).

--- a/integrations/mcp/server.mjs
+++ b/integrations/mcp/server.mjs
@@ -19,14 +19,30 @@ const repoRoot = process.env.PYTHIA_REPO_ROOT
 
 const SERVER_INFO = {
   name: "pythialabs",
-  version: "0.1.0",
+  version: "0.2.0",
 };
 
 const TOOLS = [
   {
+    name: "pythia_evaluate",
+    description:
+      "Run a deterministic PythiaLabs gate (ALLOW/BLOCK). input_json: {\"gate\":\"agent_infra_action\"|\"banking_risk_action\"|\"web3_treasury_action\", \"action\":{...}, plus safety_context or governance}. See integrations/mcp/README.md.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        input_json: {
+          type: "string",
+          description:
+            'JSON string for mix pythia.eval_json (gate + action + safety_context or governance)',
+        },
+      },
+      required: ["input_json"],
+    },
+  },
+  {
     name: "pythia_evaluate_agent_infra",
     description:
-      "Run the deterministic PythiaLabs agent infrastructure gate (ALLOW/BLOCK style outcome). Input: JSON with gate, action, safety_context per repo docs.",
+      "Alias: same as pythia_evaluate — supports all gates via input_json; name kept for backward compatibility.",
     inputSchema: {
       type: "object",
       properties: {
@@ -140,7 +156,7 @@ for await (const line of rl) {
       continue;
     }
 
-    if (name === "pythia_evaluate_agent_infra") {
+    if (name === "pythia_evaluate" || name === "pythia_evaluate_agent_infra") {
       const input = args.input_json;
       if (typeof input !== "string" || !input.trim()) {
         send({

--- a/lib/mix/tasks/pythia.eval_json.ex
+++ b/lib/mix/tasks/pythia.eval_json.ex
@@ -1,18 +1,20 @@
 defmodule Mix.Tasks.Pythia.EvalJson do
   use Mix.Task
 
-  @shortdoc "Run AgentInfraAction gate on JSON (stdin or --file path)"
+  @shortdoc "Run deterministic showcase gate on JSON (stdin or --file)"
 
   @moduledoc """
   Reads one JSON object and prints the evaluation result as JSON on stdout.
 
+  **`gate`** selects the showcase: `"agent_infra_action"`, `"banking_risk_action"`, or
+  `"web3_treasury_action"`. See `Pythia.Mcp.JsonEvaluator` for field layout per gate.
+
   ## Examples
 
       echo '{"gate":"agent_infra_action",...}' | mix pythia.eval_json
+      echo '{"gate":"banking_risk_action","action":{...},"governance":{...}}' | mix pythia.eval_json
 
       mix pythia.eval_json --file proposal.json
-
-  See `Pythia.Mcp.JsonEvaluator` for the input schema.
   """
 
   @impl Mix.Task

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -68,8 +68,7 @@ defmodule Pythia.Mcp.JsonEvaluator do
         {:error,
          %{
            error: "missing_gate",
-           message:
-             "required field \"gate\" (one of: #{Enum.join(@supported_gates, ", ")})"
+           message: "required field \"gate\" (one of: #{Enum.join(@supported_gates, ", ")})"
          }}
 
       other ->

--- a/lib/pythia/mcp/json_evaluator.ex
+++ b/lib/pythia/mcp/json_evaluator.ex
@@ -1,13 +1,22 @@
 defmodule Pythia.Mcp.JsonEvaluator do
   @moduledoc """
-  JSON bridge for IDE / MCP clients: decodes a proposal + safety context,
-  runs `Pythia.Showcase.AgentInfraAction.evaluate/2`, returns JSON-friendly maps.
+  JSON bridge for IDE / MCP clients: decodes a proposal plus context maps,
+  runs the matching deterministic showcase gate, returns JSON-friendly maps.
 
-  Input is a JSON object with string keys. Required top-level key `"gate"`.
-  Currently supported: `"agent_infra_action"` (matches the infrastructure showcase gate).
+  Input uses string keys. Required top-level key `"gate"`:
+
+  - `"agent_infra_action"` — requires `"action"` and `"safety_context"` (see infra showcase).
+  - `"banking_risk_action"` — requires `"action"` and `"governance"` (see banking showcase).
+  - `"web3_treasury_action"` — requires `"action"` and `"governance"` (see treasury showcase).
   """
 
-  alias Pythia.Showcase.AgentInfraAction
+  alias Pythia.Showcase.{
+    AgentInfraAction,
+    BankingRiskAction,
+    Web3TreasuryAction
+  }
+
+  @supported_gates ~w(agent_infra_action banking_risk_action web3_treasury_action)
 
   @doc """
   Parses `json_string` and returns `{:ok, response_map}` or `{:error, error_map}`.
@@ -32,47 +41,76 @@ defmodule Pythia.Mcp.JsonEvaluator do
 
     case gate do
       "agent_infra_action" ->
-        with {:ok, action} <- decode_action(Map.get(decoded, "action", %{})),
+        with {:ok, action} <- decode_infra_action(Map.get(decoded, "action", %{})),
              {:ok, ctx} <- decode_safety_context(Map.get(decoded, "safety_context", %{})) do
           raw = AgentInfraAction.evaluate(action, ctx)
           evidence = AgentInfraAction.export_evidence(raw)
-          {:ok, build_response(raw, evidence)}
+          {:ok, build_response(AgentInfraAction, raw, evidence)}
+        end
+
+      "banking_risk_action" ->
+        with {:ok, action} <- decode_banking_action(Map.get(decoded, "action", %{})),
+             {:ok, gov} <- decode_banking_governance(get_governance(decoded)) do
+          raw = BankingRiskAction.evaluate(action, gov)
+          evidence = BankingRiskAction.export_evidence(raw)
+          {:ok, build_response(BankingRiskAction, raw, evidence)}
+        end
+
+      "web3_treasury_action" ->
+        with {:ok, action} <- decode_web3_action(Map.get(decoded, "action", %{})),
+             {:ok, gov} <- decode_web3_governance(get_governance(decoded)) do
+          raw = Web3TreasuryAction.evaluate(action, gov)
+          evidence = Web3TreasuryAction.export_evidence(raw)
+          {:ok, build_response(Web3TreasuryAction, raw, evidence)}
         end
 
       nil ->
         {:error,
          %{
            error: "missing_gate",
-           message: "required field \"gate\" (e.g. \"agent_infra_action\")"
+           message:
+             "required field \"gate\" (one of: #{Enum.join(@supported_gates, ", ")})"
          }}
 
       other ->
         {:error,
-         %{error: "unknown_gate", gate: other, message: "supported: [\"agent_infra_action\"]"}}
+         %{
+           error: "unknown_gate",
+           gate: other,
+           message: "supported: #{inspect(@supported_gates)}"
+         }}
     end
   end
 
   defp evaluate_decoded(_),
     do: {:error, %{error: "invalid_body", message: "JSON root must be an object"}}
 
-  defp build_response({:ok, payload}, evidence) do
+  defp get_governance(decoded) do
+    cond do
+      Map.has_key?(decoded, "governance") -> Map.get(decoded, "governance") || %{}
+      Map.has_key?(decoded, "governance_record") -> Map.get(decoded, "governance_record") || %{}
+      true -> %{}
+    end
+  end
+
+  defp build_response(mod, {:ok, payload}, evidence) do
     %{
       ok: true,
       outcome: "ALLOW",
       status: "accepted",
       stop_reason: format_stop_reason(payload[:stop_reason]),
-      export: AgentInfraAction.export_result({:ok, payload}),
+      export: mod.export_result({:ok, payload}),
       evidence: evidence
     }
   end
 
-  defp build_response({:error, payload}, evidence) do
+  defp build_response(mod, {:error, payload}, evidence) do
     %{
       ok: true,
       outcome: "BLOCK",
       status: "rejected",
       stop_reason: format_stop_reason(payload[:stop_reason]),
-      export: AgentInfraAction.export_result({:error, payload}),
+      export: mod.export_result({:error, payload}),
       evidence: evidence
     }
   end
@@ -81,7 +119,7 @@ defmodule Pythia.Mcp.JsonEvaluator do
   defp format_stop_reason(atom) when is_atom(atom), do: Atom.to_string(atom)
   defp format_stop_reason(other), do: to_string(other)
 
-  defp decode_action(raw) when is_map(raw) do
+  defp decode_infra_action(raw) when is_map(raw) do
     required = [
       :action_id,
       :action_type,
@@ -101,6 +139,81 @@ defmodule Pythia.Mcp.JsonEvaluator do
          action_time: action_time,
          decision_time: decision_time
        })}
+    end
+  end
+
+  defp decode_banking_action(raw) when is_map(raw) do
+    strings = [:action_id, :action_type, :operator_id, :account_id]
+
+    with {:ok, fields} <- fetch_required_string(raw, strings),
+         {:ok, action_time} <- fetch_iso_datetime(raw, "action_time", :action_time),
+         {:ok, decision_time} <- fetch_iso_datetime(raw, "decision_time", :decision_time) do
+      {:ok,
+       Map.merge(fields, %{
+         action_time: action_time,
+         decision_time: decision_time
+       })}
+    end
+  end
+
+  defp decode_banking_governance(raw) when is_map(raw) do
+    datetimes = [
+      :authorization_valid_from,
+      :authorization_valid_to,
+      :authorization_recorded_at,
+      :evidence_observed_at,
+      :evidence_valid_until
+    ]
+
+    bools = [:decision_time_knowledge_present, :operator_approval_present]
+
+    with {:ok, dt} <- fetch_iso_datetimes(raw, datetimes),
+         {:ok, bo} <- fetch_required_bool(raw, bools) do
+      {:ok, Map.merge(dt, bo)}
+    end
+  end
+
+  defp decode_web3_action(raw) when is_map(raw) do
+    strings = [
+      :action_id,
+      :action_type,
+      :actor,
+      :dao_id,
+      :proposal_id,
+      :asset,
+      :recipient,
+      :required_permission
+    ]
+
+    with {:ok, fields} <- fetch_required_string(raw, strings),
+         {:ok, amount} <- get_int(raw, "amount", :amount),
+         {:ok, action_time} <- fetch_iso_datetime(raw, "action_time", :action_time),
+         {:ok, decision_time} <- fetch_iso_datetime(raw, "decision_time", :decision_time) do
+      {:ok,
+       Map.merge(fields, %{
+         amount: amount,
+         action_time: action_time,
+         decision_time: decision_time
+       })}
+    end
+  end
+
+  defp decode_web3_governance(raw) when is_map(raw) do
+    strings = [:proposal_id, :permission]
+
+    datetimes = [
+      :voting_closed_at,
+      :timelock_until,
+      :authorization_valid_from,
+      :authorization_valid_to,
+      :authorization_recorded_at,
+      :transfer_expires_at
+    ]
+
+    with {:ok, str} <- fetch_required_string(raw, strings),
+         {:ok, quorum_met} <- get_bool(raw, "quorum_met", :quorum_met),
+         {:ok, dt} <- fetch_iso_datetimes(raw, datetimes) do
+      {:ok, Map.merge(str, Map.put(dt, :quorum_met, quorum_met))}
     end
   end
 
@@ -180,6 +293,33 @@ defmodule Pythia.Mcp.JsonEvaluator do
       false -> {:ok, false}
       nil -> {:error, %{error: "missing_field", field: key}}
       _ -> {:error, %{error: "invalid_field", field: key, expected: "boolean"}}
+    end
+  end
+
+  defp fetch_iso_datetimes(raw, fields) do
+    Enum.reduce_while(fields, {:ok, %{}}, fn field, {:ok, acc} ->
+      key = Atom.to_string(field)
+
+      case fetch_iso_datetime(raw, key, field) do
+        {:ok, dt} -> {:cont, {:ok, Map.put(acc, field, dt)}}
+        {:error, e} -> {:halt, {:error, e}}
+      end
+    end)
+  end
+
+  defp get_int(raw, key, field) do
+    val =
+      cond do
+        Map.has_key?(raw, key) -> Map.fetch!(raw, key)
+        Map.has_key?(raw, field) -> Map.fetch!(raw, field)
+        true -> nil
+      end
+
+    case val do
+      nil -> {:error, %{error: "missing_field", field: key}}
+      v when is_integer(v) -> {:ok, v}
+      v when is_float(v) and trunc(v) == v -> {:ok, trunc(v)}
+      _ -> {:error, %{error: "invalid_field", field: key, expected: "integer"}}
     end
   end
 

--- a/test/mcp/json_evaluator_test.exs
+++ b/test/mcp/json_evaluator_test.exs
@@ -26,6 +26,99 @@ defmodule Pythia.Mcp.JsonEvaluatorTest do
     }
   }
 
+  @banking_body %{
+    "gate" => "banking_risk_action",
+    "action" => %{
+      "action_id" => "bank_act_001",
+      "action_type" => "fraud_response",
+      "operator_id" => "risk_operator_7",
+      "account_id" => "acct_demo_01",
+      "action_time" => "2026-04-26T09:00:00Z",
+      "decision_time" => "2026-04-26T09:01:00Z"
+    },
+    "governance" => %{
+      "authorization_valid_from" => "2026-04-26T08:30:00Z",
+      "authorization_valid_to" => "2026-04-26T10:30:00Z",
+      "authorization_recorded_at" => "2026-04-26T08:45:00Z",
+      "evidence_observed_at" => "2026-04-26T08:55:00Z",
+      "evidence_valid_until" => "2026-04-26T09:10:00Z",
+      "decision_time_knowledge_present" => true,
+      "operator_approval_present" => true
+    }
+  }
+
+  @web3_body %{
+    "gate" => "web3_treasury_action",
+    "action" => %{
+      "action_id" => "dao_act_001",
+      "action_type" => "treasury_transfer",
+      "actor" => "agent_alpha",
+      "dao_id" => "dao_pythia",
+      "proposal_id" => "prop_001",
+      "amount" => 10_000,
+      "asset" => "USDC",
+      "recipient" => "0xRecipient",
+      "required_permission" => "treasury.transfer",
+      "action_time" => "2026-04-25T12:00:00Z",
+      "decision_time" => "2026-04-25T12:01:00Z"
+    },
+    "governance" => %{
+      "proposal_id" => "prop_001",
+      "permission" => "treasury.transfer",
+      "quorum_met" => true,
+      "voting_closed_at" => "2026-04-25T11:00:00Z",
+      "timelock_until" => "2026-04-25T11:30:00Z",
+      "authorization_valid_from" => "2026-04-25T11:30:00Z",
+      "authorization_valid_to" => "2026-04-25T13:00:00Z",
+      "authorization_recorded_at" => "2026-04-25T11:45:00Z",
+      "transfer_expires_at" => "2026-04-25T13:00:00Z"
+    }
+  }
+
+  test "banking gate ACCEPT and artifact type" do
+    json = Jason.encode!(@banking_body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "ALLOW"
+    assert resp.evidence["artifact_type"] == "pythia.banking_risk_action.decision_trace.v1"
+  end
+
+  test "banking gate BLOCK on missing operator approval" do
+    gov = Map.put(@banking_body["governance"], "operator_approval_present", false)
+    body = Map.put(@banking_body, "governance", gov)
+    json = Jason.encode!(body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "BLOCK"
+    assert resp.stop_reason == "missing_operator_approval"
+  end
+
+  test "banking accepts governance_record alias key" do
+    body =
+      @banking_body
+      |> Map.delete("governance")
+      |> Map.put("governance_record", @banking_body["governance"])
+
+    json = Jason.encode!(body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "ALLOW"
+  end
+
+  test "web3 treasury gate ACCEPT and artifact type" do
+    json = Jason.encode!(@web3_body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "ALLOW"
+    assert resp.stop_reason == "treasury_transfer_accepted"
+    assert resp.evidence["artifact_type"] == "pythia.web3_treasury_action.decision_trace.v1"
+  end
+
+  test "web3 treasury gate BLOCK on quorum false" do
+    gov = Map.put(@web3_body["governance"], "quorum_met", false)
+    body = Map.put(@web3_body, "governance", gov)
+    json = Jason.encode!(body)
+    assert {:ok, resp} = JsonEvaluator.run(json)
+    assert resp.outcome == "BLOCK"
+    assert resp.stop_reason == "quorum_not_met"
+  end
+
   test "accept path maps to ALLOW and includes evidence" do
     json = Jason.encode!(@accept_body)
     assert {:ok, resp} = JsonEvaluator.run(json)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `Pythia.Mcp.JsonEvaluator` and `mix pythia.eval_json` with two more showcase gates:

- **`banking_risk_action`** — `action` + `governance` (or `governance_record`), aligned with `examples/banking_ai_risk_showcase.exs`.
- **`web3_treasury_action`** — `action` + `governance`, aligned with `examples/web3_treasury_action_showcase.exs` (including integer `amount`; whole-number floats accepted).

`build_response` now delegates `export_result` / evidence to the module that ran the gate. `get_governance` uses `Map.has_key?` so an explicit empty `governance` object is not replaced by a stray `governance_record` key.

## MCP

- New tool **`pythia_evaluate`**; **`pythia_evaluate_agent_infra`** remains as an alias calling the same handler.
- Server version **0.2.0**; README documents all three gates with examples.

## Testing

- Added ExUnit cases for banking (accept, block, alias key) and web3 (accept, quorum block).
- CI: `mix test`, `mix format --check-formatted`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee3fd924-1031-4d05-8cbb-e2571b7a1aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

