### PR TITLE
fix(site): reviewer quickstart callout under integration cards

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -202,8 +202,9 @@ export const locales = {
           desc: "Evaluator outputs are canonicalized (see `pythia.canonical_export.v1` in the repository) and hashed with SHA-256. Tests pin expected digests for accepted snapshots and reject tampered payloads — that is the concrete meaning of “same inputs, same digest.”",
         },
       ],
+      repoNoteTitle: "Reviewer quickstart",
       repoNote:
-        "Reviewer quickstart: clone the repo, run `mix test`, then `mix run examples/agent_infra_action_showcase.exs` (and the banking / Web3 showcases). Expected reviewer-facing output lives under `docs/*_expected_output.md`.",
+        "Clone the repo, run `mix test`, then `mix run examples/agent_infra_action_showcase.exs` (and the banking / Web3 showcases). Expected reviewer-facing output lives under `docs/*_expected_output.md`.",
     },
     valueStack: {
       title: "Stop dangerous agent actions before they happen",
@@ -621,8 +622,9 @@ export const locales = {
           desc: "Выходы evaluators канонизируются (см. `pythia.canonical_export.v1` в репозитории) и хешируются SHA-256. Тесты закрепляют ожидаемые дайджесты для принятых снапшотов и отклоняют подменённые payload'ы — это конкретный смысл формулировки «те же входы → тот же дайджест».",
         },
       ],
+      repoNoteTitle: "Быстрый старт для ревьюеров",
       repoNote:
-        "Быстрый старт для ревьюеров: клонировать репозиторий, выполнить `mix test`, затем `mix run examples/agent_infra_action_showcase.exs` (и banking / Web3 showcase). Ожидаемый вывод для ревью — в `docs/*_expected_output.md`.",
+        "Клонируйте репозиторий, выполните `mix test`, затем `mix run examples/agent_infra_action_showcase.exs` (и banking / Web3 showcase). Ожидаемый вывод для ревью — в `docs/*_expected_output.md`.",
     },
     valueStack: {
       title: "Останавливайте опасные действия агентов до того, как они произойдут",
@@ -1017,8 +1019,9 @@ export const locales = {
           desc: "评估器输出经规范化（见仓库中的 `pythia.canonical_export.v1`）并以 SHA-256 哈希。测试为接受态快照固定预期摘要并拒绝被篡改的 payload——这就是“相同输入 → 相同摘要”的具体含义。",
         },
       ],
+      repoNoteTitle: "审阅者快速上手",
       repoNote:
-        "审阅者快速上手：克隆仓库，运行 `mix test`，再执行 `mix run examples/agent_infra_action_showcase.exs`（以及 banking / Web3 showcase）。面向审阅的预期输出见 `docs/*_expected_output.md`。",
+        "克隆仓库，运行 `mix test`，再执行 `mix run examples/agent_infra_action_showcase.exs`（以及 banking / Web3 showcase）。面向审阅的预期输出见 `docs/*_expected_output.md`。",
     },
     valueStack: {
       title: "在危险的 Agent 行动发生之前阻止它",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -484,7 +484,14 @@ export function renderPage(currentId, year, buildDate) {
                 `<article class="card"><h3>${escape(item.name)}</h3><p>${inlineCodeToHtml(item.desc)}</p></article>`,
             )
             .join("")}</div>
-          <p class="integration-repo-note">${inlineCodeToHtml(t.integration.repoNote)}</p>
+          <aside
+            class="integration-repo-callout"
+            aria-labelledby="integration-repo-note-heading">
+            <h3 id="integration-repo-note-heading" class="integration-repo-callout-title">
+              ${escape(t.integration.repoNoteTitle)}
+            </h3>
+            <p class="integration-repo-callout-body">${inlineCodeToHtml(t.integration.repoNote)}</p>
+          </aside>
         </div>
       </section>
 

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1018,8 +1018,26 @@ blockquote {
   letter-spacing: 0.05em;
 }
 
-.integration-repo-note {
+.integration-repo-callout {
   margin: 1.75rem 0 0;
+  padding: 1.15rem 1.35rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  border-left: 3px solid var(--accent);
+}
+
+.integration-repo-callout-title {
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--text);
+}
+
+.integration-repo-callout-body {
+  margin: 0;
   font-size: 0.95rem;
   line-height: 1.55;
   color: var(--text-muted);
@@ -1408,7 +1426,7 @@ blockquote {
 .step-body .inline-code,
 .quickstart-list .inline-code,
 .card .inline-code,
-.integration-repo-note .inline-code,
+.integration-repo-callout-body .inline-code,
 .faq-item .inline-code,
 .artifact-technical .inline-code {
   font-family: var(--mono);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The integration section ends with a long `repoNote` paragraph right after the last card (“Воспроизводимый дайджест…”). It read like a stray continuation of that card or an odd second line, not a separate “how to verify” block.

## Changes

- Add `integration.repoNoteTitle` (EN/RU/ZH) and wrap the note in an `<aside>` callout with a visible heading and card-style chrome (border / accent stripe).
- Retype RU `repoNote` with imperative verbs and remove redundant repetition of the title in the body.
- Replace `.integration-repo-note` styles with `.integration-repo-callout*`; keep `.inline-code` styling for the new body class.

## Testing

- `node site/build.mjs` (locale validation + build) succeeds locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

