### PR TITLE
feat(site): hero outcome + quickstart jump + not-a-fit section

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -33,6 +33,9 @@ export const locales = {
         "The gate returns ALLOW, BLOCK, or ESCALATE before your agent runs destructive tools — deterministic, replayable, on your infrastructure.",
       body: "Code, infra, banking, governance: when agents act, PythiaLabs evaluates the proposal and evidence first, not the chat transcript.",
       tagline: "Verify before execute. Evidence your reviewers can replay.",
+      outcomeLine:
+        "In one sitting: clone the repo, run `mix test`, run a showcase, and compare stdout to the golden outputs in `docs/` — a replayable decision record you can show to security.",
+      startHereLabel: "New here? Start with Quick start",
       starsAlt: "GitHub stars",
     },
     trustStrip: [
@@ -64,6 +67,14 @@ export const locales = {
         "Post-hoc logs are not enough: you need a decision record before the tool fires.",
         "RBAC and coarse policy are necessary but do not answer “should this exact action run right now, with this evidence?”",
         "Reviewers and security want the same replayable artifact every time — not screenshots of a thread.",
+      ],
+    },
+    ifNotYou: {
+      title: "Probably not a fit (yet) if:",
+      items: [
+        "You want a hosted control plane or a black-box SaaS that blocks actions without wiring the library into your stack.",
+        "You are not ready to model proposed actions and decision-time evidence as structured inputs to an evaluator.",
+        "You only need chat moderation or prompt filters — not a pre-execution gate before real tools run.",
       ],
     },
     quickstart: {
@@ -452,6 +463,9 @@ export const locales = {
         "Шлюз возвращает ALLOW, BLOCK или ESCALATE до того, как агент запустит разрушительные tools — детерминированно, воспроизводимо, на вашей инфре.",
       body: "Код, инфра, банки, governance: когда агент действует, PythiaLabs сначала оценивает предложение и доказательства, а не расшифровку чата.",
       tagline: "Проверка до исполнения. Доказательства, которые ревьюер может перепроиграть.",
+      outcomeLine:
+        "За одну сессию: клонируйте репозиторий, выполните `mix test`, запустите showcase и сравните stdout с эталонами в `docs/` — воспроизводимую запись решения можно показать security.",
+      startHereLabel: "Новичок здесь? Начните с «Быстрого старта»",
       starsAlt: "Звёзды на GitHub",
     },
     trustStrip: [
@@ -483,6 +497,14 @@ export const locales = {
         "Постфактум логов мало: нужна запись решения до вызова tool.",
         "RBAC и грубая политика нужны, но не отвечают: «должно ли выполниться именно это действие прямо сейчас с этими доказательствами?»",
         "Security и ревьюерам нужен один и тот же воспроизводимый артефакт — не скриншот треда.",
+      ],
+    },
+    ifNotYou: {
+      title: "Скорее всего не ваш вариант (пока), если:",
+      items: [
+        "Нужен hosted control plane или «чёрный ящик» SaaS, который режет действия без встраивания библиотеки в ваш стек.",
+        "Вы не готовы описывать предложения действий и decision-time evidence как структурированные входы evaluator'а.",
+        "Нужна только модерация чата или фильтры промптов — а не шлюз до выполнения реальных tools.",
       ],
     },
     quickstart: {
@@ -870,6 +892,9 @@ export const locales = {
         "在 Agent 运行破坏性工具之前，门控先返回 ALLOW、BLOCK 或 ESCALATE——确定性、可重放，跑在你自己的基础设施上。",
       body: "代码、基础设施、银行、治理：当 Agent 要行动时，PythiaLabs 先评估提案与证据，而不是聊天记录本身。",
       tagline: "先验证再执行。审阅者可重放的证据。",
+      outcomeLine:
+        "用一晚上就够：克隆仓库、运行 `mix test`、执行 showcase，并将标准输出与 `docs/` 中的预期输出对照——这是可给安全团队看的、可重放的决策记录。",
+      startHereLabel: "第一次来？从「快速上手」开始",
       starsAlt: "GitHub 星标",
     },
     trustStrip: ["100% 开源", "Apache-2.0", "确定性 — 门控路径中无 LLM 调用", "可自托管", "无遥测"],
@@ -895,6 +920,14 @@ export const locales = {
         "事后日志不够：你需要在工具执行前就留下决策记录。",
         "仅有 RBAC 与粗粒度策略不够回答「在当前证据下，这一具体操作此刻是否应执行？」",
         "安全与审查需要每次都可重放的同一类产物——而不是线程截图。",
+      ],
+    },
+    ifNotYou: {
+      title: "可能暂时不适合你，如果：",
+      items: [
+        "你期望的是托管控制面或无需把库接入栈内的黑盒 SaaS。",
+        "你还没准备好把拟议行动与决策时证据建模成评估器的结构化输入。",
+        "你只想做对话审核或提示过滤——而不是在真实工具执行前加一道门控。",
       ],
     },
     quickstart: {

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -318,12 +318,16 @@ export function renderPage(currentId, year, buildDate) {
           <h1 class="hero-headline">${escape(t.hero.headline)}</h1>
           <p class="hero-subtitle">${escape(t.hero.subtitle)}</p>
           <p class="hero-text">${escape(t.hero.body)}</p>
+          <p class="hero-outcome-line">${inlineCodeToHtml(t.hero.outcomeLine)}</p>
           <p class="hero-tagline">${escape(t.hero.tagline)}</p>
           <div class="cta-row">
             <a class="btn btn-primary" href="${pilotHref}" rel="noopener noreferrer">${escape(t.cta.primary)}</a>
             <a class="btn btn-secondary" href="${utm(siteConfig.demoUrl, "hero_demo")}" rel="noopener noreferrer">${escape(t.cta.demo)}</a>
             <a class="btn btn-ghost" href="${utm(siteConfig.repoUrl, "hero_github")}" rel="noopener noreferrer">${escape(t.cta.secondary)}</a>
           </div>
+          <p class="hero-start-here">
+            <a href="#quickstart">${escape(t.hero.startHereLabel)} →</a>
+          </p>
           <p class="hero-badges">
             <a href="${siteConfig.repoUrl}/stargazers" class="badge-link">
               <img src="https://img.shields.io/github/stars/${siteConfig.repoSlug}?style=flat-square&label=stars&color=0b0d10" alt="${escape(t.hero.starsAlt)}" loading="lazy" decoding="async" width="90" height="20" />
@@ -348,6 +352,13 @@ export function renderPage(currentId, year, buildDate) {
         <div class="container">
           <h2>${escape(t.ifYou.title)}</h2>
           <ul class="if-you-list">${t.ifYou.items.map((s) => `<li>${escape(s)}</li>`).join("")}</ul>
+        </div>
+      </section>
+
+      <section id="if-not-you" class="section section-if-not-you" aria-labelledby="if-not-you-title">
+        <div class="container">
+          <h2 id="if-not-you-title">${escape(t.ifNotYou.title)}</h2>
+          <ul class="not-list">${t.ifNotYou.items.map((s) => `<li><span class="not-mark" aria-hidden="true">✕</span>${escape(s)}</li>`).join("")}</ul>
         </div>
       </section>
 

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -228,6 +228,29 @@ a:focus {
   margin: 0 0 0.75rem;
 }
 
+.hero-outcome-line {
+  font-size: 1.02rem;
+  max-width: 720px;
+  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.hero-start-here {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+}
+
+.hero-start-here a {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.hero-start-here a:hover,
+.hero-start-here a:focus {
+  color: var(--accent-strong);
+}
+
 .hero-support {
   color: var(--text-muted);
   max-width: 680px;
@@ -714,6 +737,16 @@ blockquote {
   left: 0;
   color: var(--allow);
   font-weight: 700;
+}
+
+.section-if-not-you {
+  padding: 2rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-if-not-you h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.35rem, 2.5vw, 1.75rem);
 }
 
 .mid-cta {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the recommended funnel-style clarity for a technical OSS audience: concrete “what you get in one sitting” copy, a visible path to Quick start, and an honest “not a fit” section.

## Changes

- **Hero**: `hero.outcomeLine` (EN/RU/ZH) with inline code for commands/paths; placed after body copy, before the tagline.
- **Hero**: `hero.startHereLabel` + link to `#quickstart` under the primary CTA row.
- **New section** `#if-not-you` after “if you”: `ifNotYou.title` + bullet list reusing `.not-list` styling.
- **CSS**: `.hero-outcome-line`, `.hero-start-here`, `.section-if-not-you`.

## Testing

- `node site/build.mjs` (locale validation + static build) passes.

## Notes

- `ifNotYou` is intentionally not linked from the header nav to avoid clutter; scroll order keeps it next to “who it’s for.”
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf531f3c-8554-4af5-ab22-6f3bd11d06e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

