### PR TITLE
site: localize demo iframe title for RU/ZH a11y

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -100,6 +100,7 @@ export const locales = {
       coreLabel: "Core message",
       core: "The future of agent safety is not after-the-fact debugging. It is pre-execution control.",
       fallback: "Watch on YouTube",
+      iframeTitle: "PythiaLabs demo video",
     },
     problem: {
       title: "The dangerous gap in agentic AI",
@@ -536,6 +537,7 @@ export const locales = {
       coreLabel: "Главный тезис",
       core: "Будущее agent safety — не пост-фактум дебаг. Это контроль до выполнения.",
       fallback: "Смотреть на YouTube",
+      iframeTitle: "Видео-демо PythiaLabs",
     },
     problem: {
       title: "Опасный разрыв в agentic AI",
@@ -964,6 +966,7 @@ export const locales = {
       coreLabel: "核心信息",
       core: "Agent 安全的未来不是事后调试，而是执行前的控制。",
       fallback: "在 YouTube 观看",
+      iframeTitle: "PythiaLabs 演示视频",
     },
     problem: {
       title: "Agentic AI 中的危险缺口",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -407,7 +407,7 @@ export function renderPage(currentId, year, buildDate) {
           <div class="video-frame">
             <iframe
               src="${siteConfig.demoEmbedUrl}"
-              title="PythiaLabs demo"
+              title="${escape(t.videoBlock.iframeTitle)}"
               loading="lazy"
               allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowfullscreen


### PR DESCRIPTION
## Summary

Reviewed the live site at https://safal207.github.io/pythiaLabs/ across all three locales (EN/RU/ZH).

The hero demo `<iframe title="PythiaLabs demo">` was hardcoded in English in `site/src/render.mjs`, so RU and ZH visitors using a screen reader heard the embedded YouTube demo announced in English while the rest of the page is properly localized.

## Changes

- `site/src/i18n.mjs`: add `videoBlock.iframeTitle` to all three locales:
  - EN: `"PythiaLabs demo video"`
  - RU: `"Видео-демо PythiaLabs"`
  - ZH: `"PythiaLabs 演示视频"`
- `site/src/render.mjs`: wire the iframe `title` attribute through `escape(t.videoBlock.iframeTitle)` instead of a hardcoded string.

## Verification

`node site/build.mjs` passes (locale validation + static build); resulting HTML across the three locales:

- `dist/index.html` → `title="PythiaLabs demo video"`
- `dist/ru/index.html` → `title="Видео-демо PythiaLabs"`
- `dist/zh/index.html` → `title="PythiaLabs 演示视频"`

No CSS or copy changes; minimal diff (+4 / -1).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_