### PR TITLE
site: hero MCP-ready badge linking to #cursor-ide

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -38,6 +38,7 @@ export const locales = {
         "In one sitting: clone the repo, run `mix test`, run a showcase, and compare stdout to the golden outputs in `docs/` — a replayable decision record you can show to security.",
       startHereLabel: "New here? Start with Quick start",
       starsAlt: "GitHub stars",
+      mcpBadgeAlt: "MCP-ready: Cursor & IDE bridge",
     },
     trustStrip: [
       "100% open-source",
@@ -487,6 +488,7 @@ export const locales = {
         "За одну сессию: клонируйте репозиторий, выполните `mix test`, запустите showcase и сравните stdout с эталонами в `docs/` — воспроизводимую запись решения можно показать security.",
       startHereLabel: "Новичок здесь? Начните с «Быстрого старта»",
       starsAlt: "Звёзды на GitHub",
+      mcpBadgeAlt: "MCP-ready: мост в Cursor и IDE",
     },
     trustStrip: [
       "100% open-source",
@@ -935,6 +937,7 @@ export const locales = {
         "用一晚上就够：克隆仓库、运行 `mix test`、执行 showcase，并将标准输出与 `docs/` 中的预期输出对照——这是可给安全团队看的、可重放的决策记录。",
       startHereLabel: "第一次来？从「快速上手」开始",
       starsAlt: "GitHub 星标",
+      mcpBadgeAlt: "支持 MCP：连接 Cursor 与 IDE",
     },
     trustStrip: ["100% 开源", "Apache-2.0", "确定性 — 门控路径中无 LLM 调用", "可自托管", "无遥测"],
     cta: {

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -336,6 +336,9 @@ export function renderPage(currentId, year, buildDate) {
             <a href="${siteConfig.repoUrl}/blob/main/LICENSE" class="badge-link">
               <img src="https://img.shields.io/github/license/${siteConfig.repoSlug}?style=flat-square&color=0b0d10" alt="License" loading="lazy" decoding="async" width="100" height="20" />
             </a>
+            <a href="#cursor-ide" class="badge-link">
+              <img src="https://img.shields.io/badge/MCP-ready-7cc4ff?style=flat-square&color=0b0d10" alt="${escape(t.hero.mcpBadgeAlt)}" loading="lazy" decoding="async" width="92" height="20" />
+            </a>
           </p>
           <div class="hero-stats" role="region" aria-label="${escape(t.heroStats.ariaLabel)}">
             <div class="stat"><span class="stat-value">${siteConfig.showcaseScriptCount}</span><span class="stat-label">${escape(t.heroStats.showcases)}</span></div>


### PR DESCRIPTION
## Summary

Adds a third hero badge — `MCP ready` — next to the existing GitHub stars and License badges, linking to the in-page `#cursor-ide` section that was introduced in #68. Reinforces the funnel from hero → Cursor / IDE block without nav clutter.

## Changes

- `site/src/i18n.mjs`: new `hero.mcpBadgeAlt` for EN / RU / ZH (used as the image `alt`).
- `site/src/render.mjs`: third `<a class="badge-link" href="#cursor-ide">` in `.hero-badges`, with a static shields.io badge `MCP-ready` in the same flat-square style as the other two.

No new CSS — reuses the existing `.badge-link` rule. CSP already allows `img-src https://img.shields.io`.

## Verification

`node site/build.mjs` succeeds; the badge anchor appears on all three locale pages:

```
dist/index.html:    href="#cursor-ide" class="badge-link"
dist/ru/index.html: href="#cursor-ide" class="badge-link"
dist/zh/index.html: href="#cursor-ide" class="badge-link"
```

Diff: +6 / -0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_