### PR TITLE
site: concrete-stakes line in hero

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -39,6 +39,8 @@ export const locales = {
       startHereLabel: "New here? Start with Quick start",
       starsAlt: "GitHub stars",
       mcpBadgeAlt: "MCP-ready: Cursor & IDE bridge",
+      stakesLine:
+        "When an agent gets it wrong, it isn't a bad chat answer — it's a wiped database, a transfer you can't claw back, a deploy that breaks production at 3 a.m.",
     },
     trustStrip: [
       "100% open-source",
@@ -489,6 +491,8 @@ export const locales = {
       startHereLabel: "Новичок здесь? Начните с «Быстрого старта»",
       starsAlt: "Звёзды на GitHub",
       mcpBadgeAlt: "MCP-ready: мост в Cursor и IDE",
+      stakesLine:
+        "Когда агент ошибается, это не плохой ответ в чате — это снесённая база, перевод, который не вернуть, и упавший прод в три ночи.",
     },
     trustStrip: [
       "100% open-source",
@@ -938,6 +942,7 @@ export const locales = {
       startHereLabel: "第一次来？从「快速上手」开始",
       starsAlt: "GitHub 星标",
       mcpBadgeAlt: "支持 MCP：连接 Cursor 与 IDE",
+      stakesLine: "Agent 出错时，不只是聊天里答错一句——而是被清空的数据库、追不回的转账，以及凌晨三点崩掉的生产环境。",
     },
     trustStrip: ["100% 开源", "Apache-2.0", "确定性 — 门控路径中无 LLM 调用", "可自托管", "无遥测"],
     cta: {

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -318,6 +318,7 @@ export function renderPage(currentId, year, buildDate) {
           <p class="eyebrow">${escape(t.hero.eyebrow)}</p>
           <h1 class="hero-headline">${escape(t.hero.headline)}</h1>
           <p class="hero-subtitle">${escape(t.hero.subtitle)}</p>
+          <p class="hero-stakes">${escape(t.hero.stakesLine)}</p>
           <p class="hero-text">${escape(t.hero.body)}</p>
           <p class="hero-outcome-line">${inlineCodeToHtml(t.hero.outcomeLine)}</p>
           <p class="hero-tagline">${escape(t.hero.tagline)}</p>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -228,6 +228,18 @@ a:focus {
   margin: 0 0 0.75rem;
 }
 
+.hero-stakes {
+  font-size: 1.08rem;
+  max-width: 720px;
+  margin: 0 0 1rem;
+  padding: 0.85rem 1rem 0.85rem 1.1rem;
+  border-left: 3px solid var(--block);
+  background: #f851491a;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--text);
+  line-height: 1.55;
+}
+
 .hero-outcome-line {
   font-size: 1.02rem;
   max-width: 720px;


### PR DESCRIPTION
## Summary

The hero subtitle says "before your agent runs destructive tools" — accurate but abstract. Adds one concrete-consequences line right under the subtitle so the cost of getting it wrong lands in the first three seconds: deleted database, irreversible transfer, broken deploy.

Kept it factual (a list of three concrete failure modes) rather than apocalyptic, since the audience is technical and reacts badly to fear-marketing.

## Changes

- `site/src/i18n.mjs`: new `hero.stakesLine` for EN / RU / ZH.
- `site/src/render.mjs`: `<p class="hero-stakes">` between `.hero-subtitle` and `.hero-text`.
- `site/src/styles.css`: `.hero-stakes` — left-accent stripe in `--block` red, subtle red tint, same max-width as the rest of the hero copy.

## Copy

- **EN:** *When an agent gets it wrong, it isn't a bad chat answer — it's a wiped database, a transfer you can't claw back, a deploy that breaks production at 3 a.m.*
- **RU:** *Когда агент ошибается, это не плохой ответ в чате — это снесённая база, перевод, который не вернуть, и упавший прод в три ночи.*
- **ZH:** *Agent 出错时，不只是聊天里答错一句——而是被清空的数据库、追不回的转账，以及凌晨三点崩掉的生产环境。*

## Verification

`node site/build.mjs` succeeds; `class="hero-stakes"` present with the localized line in all three locales.

Diff: +18 / -0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_