### PR TITLE
feat(cli): bin/pythia wrapper around mix pythia.eval_json

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ A minimal **stdio MCP server** in [`integrations/mcp/`](integrations/mcp/) calls
 echo '{"gate":"agent_infra_action","action":{...},"safety_context":{...}}' | mix pythia.eval_json
 ```
 
+For users who do not want to remember the `mix` invocation, a thin wrapper at
+[`bin/pythia`](bin/pythia) exposes the same gate as `pythia eval`:
+
+```bash
+# Stdin (auto-locates the repo from the script path)
+echo '{"gate":"agent_infra_action", ...}' | ./bin/pythia eval
+
+# Or from a file
+./bin/pythia eval --file proposal.json
+
+# Help and supported gates
+./bin/pythia --help
+```
+
+Set `PYTHIA_REPO_ROOT` if you symlink the script into your `$PATH` from outside
+the repository.
+
 Setup steps and `mcp.json` snippet: [`integrations/mcp/README.md`](integrations/mcp/README.md).
 
 ## What PythiaLabs is not yet

--- a/bin/pythia
+++ b/bin/pythia
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Thin CLI wrapper around `mix pythia.eval_json`.
+#
+# Usage:
+#   pythia eval [--file path.json | -f path.json]    # reads stdin if no --file
+#   pythia --help
+#
+# Repo location is resolved as:
+#   $PYTHIA_REPO_ROOT  (if set)  →  the repo containing this script
+#
+# Output: a single JSON line on stdout. Exit codes match `mix pythia.eval_json`
+# (0 ok, 1 evaluator error, 2 empty input).
+
+set -euo pipefail
+
+print_usage() {
+  cat <<'USAGE'
+pythia — deterministic pre-execution gate (CLI wrapper)
+
+Usage:
+  pythia eval [--file PATH | -f PATH]
+      Evaluate one JSON proposal. Reads from stdin if --file is omitted.
+      Prints a single JSON line on stdout.
+
+  pythia --help | -h
+      Show this help.
+
+Environment:
+  PYTHIA_REPO_ROOT  Override repo root (defaults to the repo containing
+                    this script).
+
+Examples:
+  echo '{"gate":"agent_infra_action", ...}' | pythia eval
+  pythia eval --file proposal.json
+
+Gates: agent_infra_action, banking_risk_action, web3_treasury_action.
+See integrations/mcp/README.md for full request/response shapes.
+USAGE
+}
+
+resolve_repo_root() {
+  if [[ -n "${PYTHIA_REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$PYTHIA_REPO_ROOT"
+    return
+  fi
+  local script_path
+  script_path=$(readlink -f "$0" 2>/dev/null || python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$0")
+  dirname "$(dirname "$script_path")"
+}
+
+cmd_eval() {
+  local file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --file|-f)
+        [[ $# -ge 2 ]] || { echo "pythia: --file needs a path" >&2; exit 64; }
+        file=$2
+        shift 2
+        ;;
+      -h|--help)
+        print_usage
+        return 0
+        ;;
+      *)
+        echo "pythia: unknown argument: $1" >&2
+        echo "Try: pythia --help" >&2
+        exit 64
+        ;;
+    esac
+  done
+
+  local root
+  root=$(resolve_repo_root)
+  if [[ ! -f "$root/mix.exs" ]]; then
+    echo "pythia: no mix.exs found at '$root' — set PYTHIA_REPO_ROOT" >&2
+    exit 66
+  fi
+
+  if [[ -n "$file" ]]; then
+    (cd "$root" && exec mix pythia.eval_json --file "$file")
+  else
+    (cd "$root" && exec mix pythia.eval_json)
+  fi
+}
+
+main() {
+  if [[ $# -eq 0 ]]; then
+    print_usage
+    exit 0
+  fi
+  case "$1" in
+    eval)
+      shift
+      cmd_eval "$@"
+      ;;
+    -h|--help|help)
+      print_usage
+      ;;
+    *)
+      echo "pythia: unknown command: $1" >&2
+      echo "Try: pythia --help" >&2
+      exit 64
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Removes the requirement to remember `mix pythia.eval_json` for the most common path. Users (and the MCP server) can now call:

```
pythia eval --file proposal.json
echo '{...}' | pythia eval
```

The wrapper is a thin POSIX bash script — no new runtime dependency, no behaviour change in the gate itself.

## Changes

- `bin/pythia` (new, executable):
  - Subcommands: `eval`, `--help` / `-h` / `help`.
  - `eval` accepts `--file` / `-f`; otherwise reads stdin.
  - Repo root resolved via `PYTHIA_REPO_ROOT` first, then the script's own location (so symlinking into `$PATH` works).
  - Errors out clearly if `mix.exs` is not at the resolved root.
  - Exits with the same codes as `mix pythia.eval_json` (0 ok, 1 evaluator error, 2 empty input).
- `README.md`: short section under "Cursor / IDE bridge (MCP)" showing both stdin and `--file` usage and the `PYTHIA_REPO_ROOT` env var.

## Verification

With a stub `mix` on `$PATH`:

```
$ echo '{"gate":"x"}' | ./bin/pythia eval
MIX_CALLED args=pythia.eval_json
MIX_CWD=/home/user/pythiaLabs
{"gate":"x"}

$ ./bin/pythia eval --file /tmp/p.json
MIX_CALLED args=pythia.eval_json --file /tmp/p.json
MIX_CWD=/home/user/pythiaLabs

$ PYTHIA_REPO_ROOT=/tmp ./bin/pythia eval
pythia: no mix.exs found at '/tmp' — set PYTHIA_REPO_ROOT

$ ./bin/pythia eval --bogus
pythia: unknown argument: --bogus
Try: pythia --help
```

Help output renders for `pythia`, `pythia --help`, `pythia -h`, `pythia eval -h`.

## Notes

- Intentionally not bundled with the MCP server — that path stays on `mix` directly to avoid a second moving part. A future change can switch the server to call `bin/pythia` once this stabilises.
- The wrapper is a leaf node: no logic, only argument shaping. All real changes still happen in `Pythia.Mcp.JsonEvaluator`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_