### PR TITLE
feat(mcp): pythia_describe_gate + pythia_list_gates tools (v0.3.0)

### DIFF
--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -32,7 +32,15 @@ If the repo is not next to `integrations/mcp` relative to the script, set:
 }
 ```
 
-3. Restart Cursor (or reload MCP). Tools: **`pythia_evaluate`** (main), **`pythia_evaluate_agent_infra`** (alias), **`pythia_mcp_info`**.
+3. Restart Cursor (or reload MCP). Tools:
+
+   | Tool                            | Purpose                                                          |
+   | ------------------------------- | ---------------------------------------------------------------- |
+   | `pythia_evaluate`               | Run a gate (`input_json` → ALLOW/BLOCK + evidence).              |
+   | `pythia_evaluate_agent_infra`   | Backward-compat alias of `pythia_evaluate`.                      |
+   | `pythia_describe_gate`          | Return the JSON Schema for a gate so the agent can self-correct. |
+   | `pythia_list_gates`             | List supported gate ids.                                         |
+   | `pythia_mcp_info`               | Server version, repo root, supported gates, schemas dir.         |
 
 ## Tool: `pythia_evaluate`
 

--- a/integrations/mcp/package.json
+++ b/integrations/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pythialabs-mcp",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "description": "MCP stdio server that bridges Cursor to mix pythia.eval_json",
   "type": "module",

--- a/integrations/mcp/server.mjs
+++ b/integrations/mcp/server.mjs
@@ -7,6 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import * as readline from "node:readline";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,9 +18,15 @@ const repoRoot = process.env.PYTHIA_REPO_ROOT
   ? path.resolve(process.env.PYTHIA_REPO_ROOT)
   : defaultRoot;
 
+const SUPPORTED_GATES = [
+  "agent_infra_action",
+  "banking_risk_action",
+  "web3_treasury_action",
+];
+
 const SERVER_INFO = {
   name: "pythialabs",
-  version: "0.2.0",
+  version: "0.3.0",
 };
 
 const TOOLS = [
@@ -56,11 +63,38 @@ const TOOLS = [
     },
   },
   {
+    name: "pythia_describe_gate",
+    description:
+      "Return the JSON Schema (draft-07) for one PythiaLabs gate so the agent can compose a valid input_json before calling pythia_evaluate. Schema files live in schemas/mcp/.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        gate: {
+          type: "string",
+          enum: SUPPORTED_GATES,
+          description: "Gate id to describe.",
+        },
+      },
+      required: ["gate"],
+    },
+  },
+  {
+    name: "pythia_list_gates",
+    description: "List supported gate ids served by this MCP server.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
     name: "pythia_mcp_info",
     description: "Return PythiaLabs repo root used by this MCP server and supported tools.",
     inputSchema: { type: "object", properties: {} },
   },
 ];
+
+async function loadGateSchema(gate) {
+  const file = path.join(repoRoot, "schemas", "mcp", `${gate}.schema.json`);
+  const raw = await readFile(file, "utf8");
+  return { file, schema: JSON.parse(raw) };
+}
 
 let messageId = 0;
 function nextId() {
@@ -130,6 +164,52 @@ for await (const line of rl) {
     const name = params?.name;
     const args = params?.arguments ?? {};
 
+    if (name === "pythia_list_gates") {
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          content: [{ type: "text", text: JSON.stringify(SUPPORTED_GATES, null, 2) }],
+          structuredContent: { gates: SUPPORTED_GATES },
+        },
+      });
+      continue;
+    }
+
+    if (name === "pythia_describe_gate") {
+      const gate = args.gate;
+      if (!SUPPORTED_GATES.includes(gate)) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32602,
+            message: `unknown gate: ${gate} (supported: ${SUPPORTED_GATES.join(", ")})`,
+          },
+        });
+        continue;
+      }
+
+      try {
+        const { file, schema } = await loadGateSchema(gate);
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: JSON.stringify(schema, null, 2) }],
+            structuredContent: { gate, file: path.relative(repoRoot, file), schema },
+          },
+        });
+      } catch (e) {
+        send({
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32603, message: `failed to load schema for ${gate}: ${e?.message ?? e}` },
+        });
+      }
+      continue;
+    }
+
     if (name === "pythia_mcp_info") {
       send({
         jsonrpc: "2.0",
@@ -144,6 +224,8 @@ for await (const line of rl) {
                   version: SERVER_INFO.version,
                   repoRoot,
                   mixTask: "mix pythia.eval_json",
+                  supportedGates: SUPPORTED_GATES,
+                  schemasDir: "schemas/mcp",
                   docs: "integrations/mcp/README.md",
                 },
                 null,


### PR DESCRIPTION
## Summary

Closes the loop between the JSON Schemas added in #73 and the MCP server: the
agent in Cursor can now ask the server "what fields does this gate take?" and
get the schema back without leaving the chat. This means an LLM that calls
`pythia_evaluate` and gets a `missing_field` error can immediately call
`pythia_describe_gate` and self-correct, instead of asking the user.

## Changes

- `integrations/mcp/server.mjs`:
  - new tool **`pythia_describe_gate`** — input `{gate: enum}`, returns the
    schema as both pretty text and `structuredContent` (`{gate, file, schema}`);
  - new tool **`pythia_list_gates`** — zero-arg, returns the three gate ids;
  - `pythia_mcp_info` now also reports `supportedGates` and `schemasDir`;
  - `SUPPORTED_GATES` constant shared with the new handlers;
  - `loadGateSchema(gate)` helper reads `schemas/mcp/<gate>.schema.json` from
    `repoRoot`;
  - `serverInfo.version` bumped to **0.3.0**.
- `integrations/mcp/package.json`: version → 0.3.0.
- `integrations/mcp/README.md`: replaced the inline tool list with a small
  table covering all five tools.

## Verification

End-to-end stdio round-trip with a synthetic JSON-RPC stream:

```
initialize           → serverInfo.version = "0.3.0"
tools/list           → 5 tools
pythia_list_gates    → ["agent_infra_action","banking_risk_action","web3_treasury_action"]
pythia_describe_gate gate=banking_risk_action  → full schema in content + structuredContent
pythia_describe_gate gate=bogus               → JSON-RPC error -32602 with supported list
pythia_mcp_info       → includes supportedGates + schemasDir
```

`node --check integrations/mcp/server.mjs` passes.

## Notes

- Schemas are read at call time, not at startup, so editing `schemas/mcp/*.json`
  takes effect on the next tool call without restarting the server.
- The Elixir evaluator is untouched; runtime per-field errors remain the source
  of truth. The new tools only expose existing schema files via JSON-RPC.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_