### PR TITLE
site: surface pythia_describe_gate in cursor-ide section

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -229,6 +229,7 @@ export const locales = {
       items: [
         "Add the stdio MCP server from `integrations/mcp/` (Node + local Mix).",
         "Tool `pythia_evaluate`: pass JSON with `gate`, `action`, and `safety_context` or `governance`.",
+        "Tool `pythia_describe_gate`: the agent fetches the gate's JSON Schema mid-chat and fixes its own payload — no copy-paste from README.",
         "Same JSON works from the CLI — copy examples from the README.",
       ],
       docsCta: "MCP setup & JSON examples →",
@@ -681,6 +682,7 @@ export const locales = {
       items: [
         "stdio MCP из `integrations/mcp/` (Node + локальный Mix).",
         "Инструмент `pythia_evaluate`: JSON с `gate`, `action` и `safety_context` или `governance`.",
+        "Инструмент `pythia_describe_gate`: агент сам получает JSON Schema нужного gate и поправляет свой payload — без копипаста из README.",
         "Тот же JSON из CLI — примеры в README репозитория.",
       ],
       docsCta: "Установка MCP и примеры JSON →",
@@ -1109,6 +1111,7 @@ export const locales = {
       items: [
         "从 `integrations/mcp/` 启动 stdio MCP（Node + 本地 Mix）。",
         "工具 `pythia_evaluate`：传入含 `gate`、`action` 以及 `safety_context` 或 `governance` 的 JSON。",
+        "工具 `pythia_describe_gate`：Agent 在对话中直接获取 gate 的 JSON Schema 并自行修正 payload，无需从 README 复制粘贴。",
         "同一 JSON 也可通过 CLI 运行 — 示例见 README。",
       ],
       docsCta: "MCP 配置与 JSON 示例 →",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -514,8 +514,8 @@ export function renderPage(currentId, year, buildDate) {
       <section id="cursor-ide" class="section section-alt section-ide-bridge" aria-labelledby="cursor-ide-title">
         <div class="container">
           <h2 id="cursor-ide-title">${escape(t.ideBridge.title)}</h2>
-          <p>${escape(t.ideBridge.intro)}</p>
-          <ul class="ide-bridge-list">${t.ideBridge.items.map((line) => `<li>${escape(line)}</li>`).join("")}</ul>
+          <p>${inlineCodeToHtml(t.ideBridge.intro)}</p>
+          <ul class="ide-bridge-list">${t.ideBridge.items.map((line) => `<li>${inlineCodeToHtml(line)}</li>`).join("")}</ul>
           <p class="ide-bridge-cta">
             <a class="btn btn-secondary" href="${utm(`${siteConfig.repoUrl}/blob/main/${siteConfig.mcpReadmePath}`, "ide_mcp_docs")}" rel="noopener noreferrer">${escape(t.ideBridge.docsCta)}</a>
           </p>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1518,7 +1518,8 @@ blockquote {
 .card .inline-code,
 .integration-repo-callout-body .inline-code,
 .faq-item .inline-code,
-.artifact-technical .inline-code {
+.artifact-technical .inline-code,
+.section-ide-bridge .inline-code {
   font-family: var(--mono);
   font-size: 0.9em;
   background: rgba(126, 196, 255, 0.1);


### PR DESCRIPTION
## Summary

The MCP server got a `pythia_describe_gate` tool in #74 (and `pythia_list_gates`); the landing still talked only about `pythia_evaluate`. Adds a fourth bullet in the **Cursor & IDE** section so visitors see the new self-correction story without having to dig into the README.

## Changes

- `site/src/i18n.mjs`: new bullet in `ideBridge.items` (EN / RU / ZH):
  - **EN:** *Tool `pythia_describe_gate`: the agent fetches the gate's JSON Schema mid-chat and fixes its own payload — no copy-paste from README.*
  - **RU:** *Инструмент `pythia_describe_gate`: агент сам получает JSON Schema нужного gate и поправляет свой payload — без копипаста из README.*
  - **ZH:** *工具 `pythia_describe_gate`：Agent 在对话中直接获取 gate 的 JSON Schema 并自行修正 payload，无需从 README 复制粘贴。*
- `site/src/render.mjs`: switched the `ideBridge` intro and bullet items from `escape()` to `inlineCodeToHtml()` so backticks render as proper `<code>` (was a pre-existing inconsistency — backticks were displaying literally next to `pythia_evaluate` etc.).
- `site/src/styles.css`: added `.section-ide-bridge .inline-code` to the existing inline-code selector list so the new `<code>` pills get the same chrome as elsewhere on the page.

No new section, no nav changes, no copy beyond one bullet per locale.

## Verification

`node site/build.mjs` succeeds; `pythia_describe_gate` appears exactly once on each of `dist/index.html`, `dist/ru/index.html`, `dist/zh/index.html` (inside the new bullet).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_