### PR TITLE
ci(mcp): smoke test for server.mjs round-trip + GitHub Actions job

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,0 +1,33 @@
+name: MCP
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "integrations/mcp/**"
+      - "schemas/mcp/**"
+      - ".github/workflows/mcp.yml"
+  pull_request:
+    paths:
+      - "integrations/mcp/**"
+      - "schemas/mcp/**"
+      - ".github/workflows/mcp.yml"
+
+jobs:
+  smoke:
+    name: server.mjs smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Syntax check (server + smoke)
+        run: |
+          node --check integrations/mcp/server.mjs
+          node --check integrations/mcp/smoke.mjs
+
+      - name: Run MCP smoke test
+        run: node integrations/mcp/smoke.mjs

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -150,6 +150,21 @@ echo '{"gate":"banking_risk_action", ... }' | mix pythia.eval_json
 mix pythia.eval_json --file proposal.json
 ```
 
+## Smoke test
+
+A standalone Node script drives the server through stdio with a stub `mix` on
+`$PATH`, so it runs without any Elixir installed. Useful as a fast regression
+check when changing `server.mjs`:
+
+```bash
+node integrations/mcp/smoke.mjs
+# or
+npm --prefix integrations/mcp run smoke
+```
+
+The same script runs in CI on PRs that touch `integrations/mcp/**` or
+`schemas/mcp/**` (see `.github/workflows/mcp.yml`).
+
 ## Limitations (MVP)
 
 - Deterministic local showcases only; MCP is a bridge, not a remote API.

--- a/integrations/mcp/package.json
+++ b/integrations/mcp/package.json
@@ -8,7 +8,8 @@
     "pythialabs-mcp": "./server.mjs"
   },
   "scripts": {
-    "start": "node server.mjs"
+    "start": "node server.mjs",
+    "smoke": "node smoke.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/integrations/mcp/smoke.mjs
+++ b/integrations/mcp/smoke.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for the PythiaLabs MCP stdio server.
+ *
+ * Spawns server.mjs once, drives it through JSON-RPC over stdio:
+ *  - initialize
+ *  - tools/list
+ *  - pythia_list_gates
+ *  - pythia_describe_gate (valid + invalid)
+ *  - pythia_evaluate (against a fake `mix` on $PATH)
+ *  - pythia_mcp_info
+ *
+ * No Elixir runtime needed: a tiny stub `mix` is dropped into a temp dir and
+ * prepended to $PATH so the evaluate path can be exercised end-to-end.
+ *
+ * Exits 0 on success, 1 on any assertion failure.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+let failures = 0;
+function assert(cond, msg) {
+  if (cond) {
+    process.stdout.write(`  ok    ${msg}\n`);
+  } else {
+    failures += 1;
+    process.stdout.write(`  FAIL  ${msg}\n`);
+  }
+}
+
+function setupStubMix() {
+  const dir = mkdtempSync(path.join(tmpdir(), "pythia-mcp-smoke-"));
+  // Stub `mix` that echoes a deterministic JSON line regardless of stdin —
+  // good enough for the evaluate-path round-trip.
+  const stub = `#!/usr/bin/env bash
+cat >/dev/null
+echo '{"ok":true,"outcome":"ALLOW","status":"accepted","stop_reason":null}'
+`;
+  const stubPath = path.join(dir, "mix");
+  writeFileSync(stubPath, stub);
+  chmodSync(stubPath, 0o755);
+  return dir;
+}
+
+function spawnServer(envOverrides) {
+  const child = spawn(process.execPath, [path.join(__dirname, "server.mjs")], {
+    cwd: repoRoot,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...envOverrides },
+  });
+  child.stderr.on("data", (c) => process.stderr.write(`[server] ${c}`));
+  return child;
+}
+
+function rpcDriver(child) {
+  // Buffer stdout into newline-delimited JSON messages and resolve pending
+  // requests by id. The server emits one JSON object per line.
+  const pending = new Map();
+  let buf = "";
+  child.stdout.on("data", (chunk) => {
+    buf += chunk.toString();
+    let idx;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const r = pending.get(msg.id);
+      if (r) {
+        pending.delete(msg.id);
+        r(msg);
+      }
+    }
+  });
+
+  let nextId = 1;
+  function call(method, params) {
+    const id = nextId++;
+    const req = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve) => {
+      pending.set(id, resolve);
+      child.stdin.write(JSON.stringify(req) + "\n");
+    });
+  }
+  return { call };
+}
+
+async function main() {
+  const stubDir = setupStubMix();
+  const child = spawnServer({
+    PATH: `${stubDir}:${process.env.PATH ?? ""}`,
+    PYTHIA_REPO_ROOT: repoRoot,
+  });
+  const { call } = rpcDriver(child);
+
+  process.stdout.write("MCP smoke test:\n");
+
+  const init = await call("initialize", {});
+  assert(init?.result?.serverInfo?.name === "pythialabs", "initialize returns server name");
+  assert(typeof init?.result?.serverInfo?.version === "string", "initialize returns version");
+
+  const tools = await call("tools/list", {});
+  const names = (tools?.result?.tools ?? []).map((t) => t.name);
+  assert(names.includes("pythia_evaluate"), "tools/list contains pythia_evaluate");
+  assert(names.includes("pythia_describe_gate"), "tools/list contains pythia_describe_gate");
+  assert(names.includes("pythia_list_gates"), "tools/list contains pythia_list_gates");
+  assert(names.includes("pythia_mcp_info"), "tools/list contains pythia_mcp_info");
+
+  const list = await call("tools/call", { name: "pythia_list_gates", arguments: {} });
+  const listed = list?.result?.structuredContent?.gates ?? [];
+  assert(
+    listed.length === 3 &&
+      listed.includes("agent_infra_action") &&
+      listed.includes("banking_risk_action") &&
+      listed.includes("web3_treasury_action"),
+    "pythia_list_gates returns the three gate ids",
+  );
+
+  const describe = await call("tools/call", {
+    name: "pythia_describe_gate",
+    arguments: { gate: "banking_risk_action" },
+  });
+  const schema = describe?.result?.structuredContent?.schema;
+  assert(schema?.properties?.gate?.const === "banking_risk_action", "describe_gate returns matching schema");
+  assert(Array.isArray(schema?.properties?.action?.required), "schema has action.required list");
+
+  const describeBad = await call("tools/call", {
+    name: "pythia_describe_gate",
+    arguments: { gate: "totally_unknown_gate" },
+  });
+  assert(describeBad?.error?.code === -32602, "describe_gate rejects unknown gate with -32602");
+
+  const evalCall = await call("tools/call", {
+    name: "pythia_evaluate",
+    arguments: { input_json: '{"gate":"agent_infra_action"}' },
+  });
+  const evalStruct = evalCall?.result?.structuredContent;
+  assert(evalStruct?.exitCode === 0, "evaluate exits 0 against stub mix");
+  assert(typeof evalStruct?.stdout === "string" && evalStruct.stdout.includes("ALLOW"), "evaluate forwards stub stdout");
+
+  const info = await call("tools/call", { name: "pythia_mcp_info", arguments: {} });
+  const infoText = info?.result?.content?.[0]?.text ?? "";
+  assert(infoText.includes("supportedGates"), "pythia_mcp_info reports supportedGates");
+  assert(infoText.includes("schemasDir"), "pythia_mcp_info reports schemasDir");
+
+  child.stdin.end();
+  child.kill();
+
+  if (failures > 0) {
+    process.stdout.write(`\nFAILED: ${failures} assertion(s) failed.\n`);
+    process.exit(1);
+  }
+  process.stdout.write("\nOK: all assertions passed.\n");
+  process.exit(0);
+}
+
+main().catch((e) => {
+  process.stderr.write(`smoke test crashed: ${e?.stack ?? e}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

A regression in `integrations/mcp/server.mjs` is currently invisible until somebody manually runs Cursor — the main `CI` workflow doesn't exercise the MCP server at all. This PR adds a fast, Elixir-free smoke test that drives the server through stdio JSON-RPC and runs in its own GitHub Actions job on PRs that touch the MCP server or the gate schemas.

## Changes

- `integrations/mcp/smoke.mjs` (new, executable): spawns `server.mjs` once, sends a sequence of JSON-RPC messages, asserts on the responses. Uses a temp-dir stub `mix` prepended to `$PATH` so the `pythia_evaluate` path can be exercised without Elixir installed. Asserts cover:
  - `initialize` returns `serverInfo.name = "pythialabs"` and a version string.
  - `tools/list` includes `pythia_evaluate`, `pythia_describe_gate`, `pythia_list_gates`, `pythia_mcp_info`.
  - `pythia_list_gates` → the three gate ids.
  - `pythia_describe_gate banking_risk_action` → schema with matching `gate.const` and an `action.required` array.
  - `pythia_describe_gate totally_unknown_gate` → JSON-RPC `-32602`.
  - `pythia_evaluate` round-trip → `exitCode 0`, stdout forwarded.
  - `pythia_mcp_info` content includes `supportedGates` and `schemasDir`.
- `.github/workflows/mcp.yml` (new): single `smoke` job on Node 20, gated by paths (`integrations/mcp/**`, `schemas/mcp/**`, the workflow itself). Runs `node --check` on both files and then `node integrations/mcp/smoke.mjs`.
- `integrations/mcp/package.json`: new `smoke` script (`npm run smoke`).
- `integrations/mcp/README.md`: short section explaining how to run the smoke test locally and pointing at the workflow.

## Verification

Local run on Node 24 (this branch):

```
$ node integrations/mcp/smoke.mjs
MCP smoke test:
  ok    initialize returns server name
  ok    initialize returns version
  ok    tools/list contains pythia_evaluate
  ok    tools/list contains pythia_describe_gate
  ok    tools/list contains pythia_list_gates
  ok    tools/list contains pythia_mcp_info
  ok    pythia_list_gates returns the three gate ids
  ok    describe_gate returns matching schema
  ok    schema has action.required list
  ok    describe_gate rejects unknown gate with -32602
  ok    evaluate exits 0 against stub mix
  ok    evaluate forwards stub stdout
  ok    pythia_mcp_info reports supportedGates
  ok    pythia_mcp_info reports schemasDir

OK: all assertions passed.
```

`node --check integrations/mcp/server.mjs` and `node --check integrations/mcp/smoke.mjs` both pass.

## Notes

- The workflow is intentionally separate from the heavy `CI` job (Elixir + Rust); typical PRs touching `server.mjs` will get feedback in seconds instead of minutes.
- The stub `mix` returns a deterministic ALLOW JSON line regardless of input, so the test asserts on the round-trip plumbing only — not on evaluator behaviour, which is already covered by `Pythia.Mcp.JsonEvaluatorTest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECP5wKYnEFrYpiscN1BRYE)_