### PR TITLE
chore(site): nudge Pages redeploy

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -9,7 +9,7 @@ import { renderPage } from "./src/render.mjs";
 import { renderRobots, renderSitemap } from "./src/sitemap.mjs";
 import { downloadAssets } from "./src/download_assets.mjs";
 
-// lightningcss browser version encoding: major << 16 | minor << 8 | patch
+// lightningcss browser version encoding: major << 16 | minor << 8 | patch.
 const browserVersion = (major, minor = 0, patch = 0) => (major << 16) | (minor << 8) | patch;
 
 const buildCssFixes = `


### PR DESCRIPTION
## Summary

Trivial no-op change inside `site/` (a single trailing period in a comment in `site/build.mjs`) to retrigger the `Deploy landing page to GitHub Pages` workflow, which is `paths`-filtered to `site/**`.

Background: `e7ad157` (paid-review section) is on `main` but the live site at https://safal207.github.io/pythiaLabs/ does not yet show `#paid-review`, `#downloads`, or `#support`. This PR forces a fresh Pages build/deploy without otherwise touching the site.

If `workflow_dispatch` is preferred, this PR can be closed without merging.

## Test plan

- [x] `npm run build` succeeds (3 pages + 4 downloads).
- [ ] After merge, the Pages workflow run for the resulting commit completes green.
- [ ] `https://safal207.github.io/pythiaLabs/?v=<sha>#paid-review` resolves and renders the paid-review section.
- [ ] `#downloads` and `#support` also visible.
- [ ] `https://safal207.github.io/pythiaLabs/downloads/sample-evidence-artifact.json` returns the JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UdK8T1LppXVx5C6ZDR22P)_