### PR TITLE
Add 5-minute local PythiaLabs demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: demo
+
+demo:
+	mix run examples/paid_review_demo.exs

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ mix run examples/banking_ai_risk_showcase.exs
 mix run examples/web3_treasury_full_showcase.exs
 ```
 
+## Paid review demo (recordable in ~30 seconds)
+
+Run:
+
+```bash
+make demo
+```
+
+This deterministic local demo shows a risky proposed Web3 treasury transfer of 25,000 USDC, runs evidence checks, returns an `ESCALATE` decision with a stable stop reason, and writes a JSON artifact to `examples/output/paid_review_demo_artifact.json`.
+
+For expected reviewer-facing output, see `examples/paid_review_demo_expected_output.md`.
+
 ## Cursor / IDE bridge (MCP)
 
 A minimal **stdio MCP server** in [`integrations/mcp/`](integrations/mcp/) calls `mix pythia.eval_json` locally so Cursor (or any MCP host) can run deterministic gates (`agent_infra_action`, `banking_risk_action`, `web3_treasury_action`) from JSON.

--- a/examples/output/paid_review_demo_artifact.json
+++ b/examples/output/paid_review_demo_artifact.json
@@ -1,0 +1,35 @@
+{
+  "schema": "pythia.demo.artifact.v1",
+  "artifact_id": "artifact_paid_review_demo_001",
+  "trace_id": "trace_paid_review_demo_001",
+  "proposed_action": {
+    "action_id": "transfer_25000_usdc",
+    "action_type": "web3_treasury_transfer",
+    "amount": 25000,
+    "asset": "USDC",
+    "recipient": "0xA11owListedRecipient",
+    "requested_by": "agent_treasury_alpha"
+  },
+  "decision_time_evidence": {
+    "authorization": true,
+    "wallet_allowlist": true,
+    "quorum_approval": false,
+    "policy_freshness_seconds": 5400,
+    "policy_freshness_ttl_seconds": 1800,
+    "action_risk": "high_value_low_reversibility"
+  },
+  "checks": [
+    {"name": "authorization", "status": "PASS"},
+    {"name": "wallet_allowlist", "status": "PASS"},
+    {"name": "quorum_approval", "status": "FAIL"},
+    {"name": "policy_freshness", "status": "FAIL"},
+    {"name": "action_risk", "status": "REVIEW"}
+  ],
+  "outcome": "ESCALATE",
+  "execution_allowed": false,
+  "stop_reason": "missing_quorum_approval_and_stale_policy_state",
+  "digest": {
+    "algorithm": "sha256",
+    "value": "deterministic_demo_digest_placeholder"
+  }
+}

--- a/examples/paid_review_demo.exs
+++ b/examples/paid_review_demo.exs
@@ -1,0 +1,95 @@
+alias Jason
+
+input_path = "examples/paid_review_demo_input.json"
+artifact_path = "examples/output/paid_review_demo_artifact.json"
+
+input =
+  input_path
+  |> File.read!()
+  |> Jason.decode!()
+
+proposed_action = input["proposed_action"]
+evidence_context = input["evidence_context"]
+expected_decision = input["expected_decision"]
+trace_id = input["trace_id"]
+
+authorization_ok? = evidence_context["authorization"] == true
+wallet_allowlist_ok? = evidence_context["wallet_allowlist"] == true
+quorum_approval_ok? = evidence_context["quorum_approval"] == true
+
+policy_freshness_ok? =
+  evidence_context["policy_freshness_seconds"] <= evidence_context["policy_freshness_ttl_seconds"]
+
+action_risk = evidence_context["action_risk"]
+
+decision =
+  cond do
+    not authorization_ok? or not wallet_allowlist_ok? -> "BLOCK"
+    not quorum_approval_ok? or not policy_freshness_ok? -> "ESCALATE"
+    action_risk == "high_value_low_reversibility" -> "ESCALATE"
+    true -> "ALLOW"
+  end
+
+stop_reason =
+  cond do
+    decision == "BLOCK" -> "authorization_or_wallet_allowlist_failed"
+    not quorum_approval_ok? and not policy_freshness_ok? ->
+      "missing_quorum_approval_and_stale_policy_state"
+
+    not quorum_approval_ok? -> "missing_quorum_approval"
+    not policy_freshness_ok? -> "stale_policy_state"
+    decision == "ESCALATE" -> "high_value_low_reversibility_action"
+    true -> "approved_under_current_evidence"
+  end
+
+execution_allowed = decision == "ALLOW"
+
+checks = [
+  %{name: "authorization", status: if(authorization_ok?, do: "PASS", else: "FAIL")},
+  %{name: "wallet_allowlist", status: if(wallet_allowlist_ok?, do: "PASS", else: "FAIL")},
+  %{name: "quorum_approval", status: if(quorum_approval_ok?, do: "PASS", else: "FAIL")},
+  %{name: "policy_freshness", status: if(policy_freshness_ok?, do: "PASS", else: "FAIL")},
+  %{name: "action_risk", status: if(action_risk == "high_value_low_reversibility", do: "REVIEW", else: "PASS")}
+]
+
+artifact = %{
+  schema: "pythia.demo.artifact.v1",
+  artifact_id: "artifact_paid_review_demo_001",
+  trace_id: trace_id,
+  proposed_action: proposed_action,
+  decision_time_evidence: evidence_context,
+  checks: checks,
+  outcome: decision,
+  execution_allowed: execution_allowed,
+  stop_reason: stop_reason,
+  digest: %{
+    algorithm: "sha256",
+    value: "deterministic_demo_digest_placeholder"
+  }
+}
+
+File.mkdir_p!(Path.dirname(artifact_path))
+File.write!(artifact_path, Jason.encode!(artifact, pretty: true) <> "\n")
+
+check_line = fn name, status ->
+  dots = String.duplicate(".", max(1, 20 - String.length(name)))
+  "  #{name} #{dots} #{status}"
+end
+
+IO.puts("PythiaLabs Demo: Web3 treasury action\n")
+IO.puts("Proposed action:")
+IO.puts("  #{proposed_action["action_id"]}\n")
+IO.puts("Checks:")
+Enum.each(checks, fn c -> IO.puts(check_line.(c.name, c.status)) end)
+IO.puts("\nDecision:")
+IO.puts("  #{decision}\n")
+IO.puts("Execution allowed:")
+IO.puts("  #{execution_allowed}\n")
+IO.puts("Stop reason:")
+IO.puts("  #{stop_reason}\n")
+IO.puts("Artifact:")
+IO.puts("  #{artifact_path}\n")
+IO.puts("Result:")
+
+result_label = if decision == expected_decision, do: "PASS", else: "FAIL"
+IO.puts("  #{result_label} — expected #{expected_decision}, got #{decision}")

--- a/examples/paid_review_demo.exs
+++ b/examples/paid_review_demo.exs
@@ -32,14 +32,23 @@ decision =
 
 stop_reason =
   cond do
-    decision == "BLOCK" -> "authorization_or_wallet_allowlist_failed"
+    decision == "BLOCK" ->
+      "authorization_or_wallet_allowlist_failed"
+
     not quorum_approval_ok? and not policy_freshness_ok? ->
       "missing_quorum_approval_and_stale_policy_state"
 
-    not quorum_approval_ok? -> "missing_quorum_approval"
-    not policy_freshness_ok? -> "stale_policy_state"
-    decision == "ESCALATE" -> "high_value_low_reversibility_action"
-    true -> "approved_under_current_evidence"
+    not quorum_approval_ok? ->
+      "missing_quorum_approval"
+
+    not policy_freshness_ok? ->
+      "stale_policy_state"
+
+    decision == "ESCALATE" ->
+      "high_value_low_reversibility_action"
+
+    true ->
+      "approved_under_current_evidence"
   end
 
 execution_allowed = decision == "ALLOW"
@@ -49,7 +58,10 @@ checks = [
   %{name: "wallet_allowlist", status: if(wallet_allowlist_ok?, do: "PASS", else: "FAIL")},
   %{name: "quorum_approval", status: if(quorum_approval_ok?, do: "PASS", else: "FAIL")},
   %{name: "policy_freshness", status: if(policy_freshness_ok?, do: "PASS", else: "FAIL")},
-  %{name: "action_risk", status: if(action_risk == "high_value_low_reversibility", do: "REVIEW", else: "PASS")}
+  %{
+    name: "action_risk",
+    status: if(action_risk == "high_value_low_reversibility", do: "REVIEW", else: "PASS")
+  }
 ]
 
 artifact = %{

--- a/examples/paid_review_demo_expected_output.md
+++ b/examples/paid_review_demo_expected_output.md
@@ -1,0 +1,38 @@
+# Expected output: Paid review demo
+
+Run:
+
+```bash
+make demo
+```
+
+Expected reviewer-facing terminal output:
+
+```text
+PythiaLabs Demo: Web3 treasury action
+
+Proposed action:
+  transfer_25000_usdc
+
+Checks:
+  authorization ........ PASS
+  wallet_allowlist ..... PASS
+  quorum_approval ...... FAIL
+  policy_freshness ..... FAIL
+  action_risk .......... REVIEW
+
+Decision:
+  ESCALATE
+
+Execution allowed:
+  false
+
+Stop reason:
+  missing_quorum_approval_and_stale_policy_state
+
+Artifact:
+  examples/output/paid_review_demo_artifact.json
+
+Result:
+  PASS — expected ESCALATE, got ESCALATE
+```

--- a/examples/paid_review_demo_input.json
+++ b/examples/paid_review_demo_input.json
@@ -1,0 +1,21 @@
+{
+  "schema": "pythia.demo.input.v1",
+  "trace_id": "trace_paid_review_demo_001",
+  "proposed_action": {
+    "action_id": "transfer_25000_usdc",
+    "action_type": "web3_treasury_transfer",
+    "amount": 25000,
+    "asset": "USDC",
+    "recipient": "0xA11owListedRecipient",
+    "requested_by": "agent_treasury_alpha"
+  },
+  "evidence_context": {
+    "authorization": true,
+    "wallet_allowlist": true,
+    "quorum_approval": false,
+    "policy_freshness_seconds": 5400,
+    "policy_freshness_ttl_seconds": 1800,
+    "action_risk": "high_value_low_reversibility"
+  },
+  "expected_decision": "ESCALATE"
+}


### PR DESCRIPTION
### Motivation

- Provide a single-command, deterministic local demo that a reviewer can run and record to show PythiaLabs evaluating a risky agent action before execution.
- Show a clear Web3 treasury scenario (transfer of 25,000 USDC) and surface evidence checks, a stable stop reason, an `ESCALATE` decision, and a JSON artifact for auditability.

### Description

- Add a `Makefile` with a `make demo` target that runs `mix run examples/paid_review_demo.exs` to keep the demo one-command and recordable.
- Add `examples/paid_review_demo.exs`, a minimal deterministic evaluator that loads `examples/paid_review_demo_input.json`, runs evidence checks, produces `ALLOW/BLOCK/ESCALATE`, computes a stable `stop_reason`, writes an artifact to `examples/output/paid_review_demo_artifact.json`, and prints a clean terminal summary.
- Add `examples/paid_review_demo_input.json` containing the preferred scenario (25,000 USDC transfer) and `examples/paid_review_demo_expected_output.md` showing the exact terminal layout expected for recording.
- Add a committed artifact `examples/output/paid_review_demo_artifact.json` containing the required artifact fields (`schema`, `artifact_id`, `trace_id`, `proposed_action`, `decision_time_evidence`, `checks`, `outcome`, `execution_allowed`, `stop_reason`, and a digest placeholder) and update `README.md` with a short demo snippet.

### Testing

- Running `make demo` (which invokes `mix run examples/paid_review_demo.exs`) was attempted and failed because `mix deps.get` could not fetch dependencies due to TLS/CA issues contacting `repo.hex.pm` (automated command failed).
- Installing the Hex archive via `mix archive.install github hexpm/hex branch latest --force` succeeded, showing the environment can install archives.
- Running `mix deps.get` after installation still failed due to the environment TLS/unknown CA error, so `mix test` and a full runtime execution of the project could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5f51f3cc832d84f7c3356c7bd334)