### PR TITLE
site: improve demo proof mobile layout

### DIFF
--- a/site/src/inject_demo_proof.mjs
+++ b/site/src/inject_demo_proof.mjs
@@ -41,7 +41,8 @@ const css = `
 }
 
 .demo-terminal code {
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .demo-proof-cards {
@@ -68,6 +69,7 @@ const css = `
   color: var(--text-muted);
   font-size: 0.93rem;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .demo-proof-cta {
@@ -89,6 +91,18 @@ const css = `
     font-size: 0.78rem;
   }
 }
+
+@media (max-width: 600px) {
+  .demo-terminal {
+    padding: 0.9rem;
+    font-size: 0.72rem;
+    line-height: 1.5;
+  }
+
+  .demo-proof-card {
+    padding: 0.9rem 1rem;
+  }
+}
 `;
 
 const copy = {
@@ -97,7 +111,7 @@ const copy = {
     title: "See PythiaLabs evaluate risky AI-agent actions before execution",
     intro:
       "Run one command. Watch the real Web3 treasury engine evaluate four scenarios, verify SHA-256 evidence, and show a counterfactual decision flip.",
-    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS — all scenarios matched expectations`,
+    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS`,
     cards: [
       {
         title: "Real engine",
@@ -121,11 +135,11 @@ const copy = {
     title: "Посмотрите, как PythiaLabs проверяет рискованные действия AI-агента до выполнения",
     intro:
       "Одна команда запускает реальный Web3 treasury engine: четыре сценария, SHA-256 evidence verification и counterfactual, где изменение одного evidence-поля меняет решение.",
-    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS — all scenarios matched expectations`,
+    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS`,
     cards: [
       {
         title: "Реальный engine",
-        desc: "Используется Pythia.Showcase.Web3TreasuryAction.evaluate/2 — не mock.",
+        desc: "Демо использует настоящий Web3 treasury evaluator — не mock.",
       },
       {
         title: "Evidence verification",
@@ -145,7 +159,7 @@ const copy = {
     title: "See PythiaLabs evaluate risky AI-agent actions before execution",
     intro:
       "Run one command. Watch the real Web3 treasury engine evaluate four scenarios, verify SHA-256 evidence, and show a counterfactual decision flip.",
-    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS — all scenarios matched expectations`,
+    terminal: `$ make demo\n# Windows: mix run examples/paid_review_demo.exs\n\nPythiaLabs — Paid Review Demo\n\n[1/4] Clean 25,000 USDC treasury transfer\n  decision    : ● ACCEPTED\n  evidence    : verified\n\n[2/4] Quorum threshold not reached\n  decision    : ● REJECTED\n  stop_reason : quorum_not_met\n  evidence    : verified\n\nCounterfactual\n  rejected → accepted\n\nResult: PASS`,
     cards: [
       {
         title: "Real engine",


### PR DESCRIPTION
### Motivation
- The demo proof block was cramped on narrow screens due to a long terminal output line and a dense technical card description, causing horizontal overflow and poor readability.

### Description
- Updated `site/src/inject_demo_proof.mjs` to use `white-space: pre-wrap` and `overflow-wrap: anywhere` for terminal code and card text to prevent long-line overflow.
- Shortened the terminal result line in all locales to `Result: PASS` to avoid horizontal clipping on mobile screens.
- Simplified the Russian card copy for the “Реальный engine” card to a more mobile-friendly phrasing.
- Added a new `@media (max-width: 600px)` block to slightly reduce `.demo-terminal` padding and font-size and to compact `.demo-proof-card` padding for mobile.

### Testing
- Verified text and CSS changes were present with `rg` searches for the updated strings and properties.
- Inspected the modified file with `nl`/`sed` to confirm the `pre-wrap`/`overflow-wrap` changes and the added `@media (max-width: 600px)` rules.
- All automated checks used to validate the edits completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3e175298832d94e63cadea20baa0)