### PR TITLE
docs: add Further Reading section linking architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ Additional roadmap items:
 - multi-domain executors for QA, graph problems, puzzles, and agent actions
 - Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
+## Further Reading
+
+- [Database Architecture](docs/database_architecture.md) — Postgres, TimescaleDB, and LiminalDB as three kinds of truth.
+- [Agent Memory vs. Action Gates](docs/agent_memory_vs_action_gate.md) — why PythiaLabs is not an organizational memory product.
+- [Sponsorship and Paid Pilots](docs/SPONSORSHIP.md) — support paths, paid review scope, and sponsorship options.
+
 ## Research / Positioning / Docs
 
 - Open agentic models need evidence gates: `docs/open_agentic_models_need_evidence_gates.md`


### PR DESCRIPTION
## Description\nThis PR adds a 'Further Reading' section to the README to make important architecture documentation easier to discover.\n\n## Changes\n- Added 'Further Reading' section with links to:\n  - Database Architecture\n  - Agent Memory vs. Action Gates\n  - Sponsorship and Paid Pilots\n- Placed before Research/Positioning section for better flow\n\n## Related Issue\nCloses #82\n\n## Testing\n- README-only change, no build required\n- All links verified to existing docs