### PR TITLE
docs: add documentation index page (closes #97)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# PythiaLabs Documentation
+
+Welcome to the PythiaLabs documentation index. Use this page to quickly find
+the most important docs whether you are a new contributor, reviewer, or grantmaker.
+
+---
+
+## Architecture
+
+- [Database Architecture / Persistent Reasoning Memory](persistent_reasoning_memory.md)
+- [Agent Memory vs. Action Gates — Temporal-Causal Memory Stack](temporal_causal_memory_stack.md)
+- [Design Principles](design_principles.md)
+- [Research Roadmap — Open Agentic Models Need Evidence Gates](open_agentic_models_need_evidence_gates.md)
+- [Web3 Consensus Reason Layer](web3_consensus_reason_layer.md)
+
+---
+
+## Demos and Expected Outputs
+
+- [Paid Review Demo Expected Output](paid_review_demo_expected_output.md) *(if present)*
+- [Agent Infrastructure Showcase Expected Output](agent_infra_action_showcase_expected_output.md)
+- [Banking AI Risk Showcase Expected Output](banking_ai_risk_showcase_expected_output.md)
+- [Web3 Treasury Showcase Expected Output](web3_treasury_full_showcase_expected_output.md)
+
+---
+
+## Funding and Support
+
+- [Grant Readiness](grant_readiness.md)
+- [Grant One-Pager — Web3 Treasury Reason Layer](grant_one_pager_web3_treasury_reason_layer.md)
+- [Grant Application Summary](grant_application_summary.md)
+- [Threat Model — Web3 Treasury Reason Layer](threat_model_web3_treasury_reason_layer.md)
+- [License Strategy](license_strategy.md)
+
+---
+
+## Security and Governance
+
+- [Security Policy](../SECURITY.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Security Automation](security_automation.md)


### PR DESCRIPTION
## Summary

Adds `docs/README.md` as a documentation index page so new contributors,
reviewers, and grantmakers can find the most important docs quickly.

Closes #97

---

## What changed

- Created `docs/README.md` (new file only)
- No existing files were modified
- No site/build, demo, product, pricing, or workflow files were touched

---

## Structure

The index groups existing documentation into four categories:

- **Architecture** — memory stack, design principles, roadmap
- **Demos and Expected Outputs** — showcase expected output docs
- **Funding and Support** — grant materials, license strategy
- **Security and Governance** — security policy, code of conduct, contributing guide

All links use relative Markdown paths from within the `docs/` folder.

---

## Acceptance Criteria

- [x] `docs/README.md` exists
- [x] Links to major docs listed in the issue
- [x] All links use relative Markdown paths
- [x] No site/build files changed
- [x] No demo/product logic changed
- [x] No pricing or workflow files changed

---

## Testing

No code changes — documentation only.

To verify:
1. Open `docs/README.md` on GitHub
2. Click each link and confirm it resolves to an existing file