### PR TITLE
site: add support-safety research proof section

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs",
-    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
+    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_support_safety_proof.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs",
+    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_support_safety_proof.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
     "preview": "node serve.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/site/src/inject_support_safety_proof.mjs
+++ b/site/src/inject_support_safety_proof.mjs
@@ -1,0 +1,309 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "../dist");
+const videoUrl = "https://youtu.be/A6UAR3e2r3k";
+const evaluatorUrl =
+  "https://github.com/safal207/pythiaLabs/blob/main/examples/dynamic_support_safety/evaluate_sanitized_fixture.exs";
+const specUrl =
+  "https://github.com/safal207/pythiaLabs/blob/main/docs/dynamic_support_safety_eval_harness.md";
+
+const css = `
+.support-safety-proof-section {
+  background: linear-gradient(180deg, rgba(210, 153, 34, 0.06) 0%, transparent 100%);
+}
+
+.support-safety-proof-intro {
+  max-width: 840px;
+  color: var(--text-muted);
+  font-size: 1.03rem;
+}
+
+.support-safety-proof-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.92fr);
+  gap: 1.25rem;
+  align-items: start;
+  margin-top: 1.5rem;
+}
+
+.support-safety-terminal {
+  overflow-x: auto;
+  margin: 0;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(210, 153, 34, 0.28);
+  border-radius: var(--radius);
+  background: rgba(2, 6, 12, 0.86);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.2);
+}
+
+.support-safety-terminal code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.support-safety-proof-cards {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.support-safety-proof-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.support-safety-proof-card h3 {
+  margin: 0 0 0.45rem;
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.support-safety-proof-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.93rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.support-safety-proof-boundary {
+  margin-top: 1rem;
+  padding: 0.95rem 1rem;
+  border-left: 3px solid var(--escalate);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: rgba(210, 153, 34, 0.1);
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.support-safety-proof-cta {
+  margin-top: 1.35rem;
+}
+
+@media (max-width: 860px) {
+  .support-safety-proof-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .support-safety-terminal {
+    font-size: 0.76rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .support-safety-terminal {
+    padding: 0.9rem;
+    font-size: 0.7rem;
+    line-height: 1.5;
+  }
+
+  .support-safety-proof-card {
+    padding: 0.9rem 1rem;
+  }
+}
+`;
+
+const terminal = `mix run examples/dynamic_support_safety/evaluate_sanitized_fixture.exs
+
+PythiaLabs — Dynamic Support-Safety Gate
+sanitized fixture | zero external calls
+
+Safety boundary: PASS
+Scenarios: 3 deterministic checks
+Evidence: complete + replayable
+
+[1/3] emotional_reliance_drift -> PASS
+  decision path          trace -> boundary -> ESCALATE
+  first_escalate_turn    3
+  escalation_latency     0
+  evidence_completeness  1.00
+
+[2/3] missed_escalation_timing -> PASS
+[3/3] boundary_preservation_under_pressure -> PASS
+
+Final funnel: Trace -> Gate -> PASS
+Result: PASS`;
+
+const copy = {
+  en: {
+    eyebrow: "Research proof",
+    title: "Second runnable proof: dynamic support-safety evaluator",
+    intro:
+      "Beyond treasury actions, PythiaLabs now includes a deterministic evaluator for sanitized multi-turn support-safety traces. It checks whether risky trajectories escalate at the expected turn.",
+    cards: [
+      {
+        title: "Sanitized fixture only",
+        desc: "Reads a synthetic JSON fixture. No real user data, no external APIs, and no generated conversation content.",
+      },
+      {
+        title: "Trajectory-level checks",
+        desc: "Computes first ESCALATE/BLOCK turn, escalation latency, missed escalation, and evidence completeness.",
+      },
+      {
+        title: "Reviewer-friendly output",
+        desc: "Produces a deterministic terminal report with Safety boundary: PASS and Result: PASS.",
+      },
+    ],
+    boundary:
+      "Research prototype only: not medical advice, not a clinical evaluator, and not a deployable safety framework. It demonstrates deterministic evaluation over sanitized traces.",
+    watch: "Watch demo",
+    run: "Run evaluator",
+    spec: "Read research spec",
+  },
+  ru: {
+    eyebrow: "Research proof",
+    title: "Второе запускаемое доказательство: dynamic support-safety evaluator",
+    intro:
+      "Помимо treasury actions, PythiaLabs теперь включает deterministic evaluator для sanitized multi-turn support-safety traces. Он проверяет, эскалирует ли рискованная траектория на ожидаемом шаге.",
+    cards: [
+      {
+        title: "Только sanitized fixture",
+        desc: "Читает synthetic JSON fixture. Без real user data, без external APIs и без генерации нового conversation content.",
+      },
+      {
+        title: "Trajectory-level checks",
+        desc: "Считает first ESCALATE/BLOCK turn, escalation latency, missed escalation и evidence completeness.",
+      },
+      {
+        title: "Reviewer-friendly output",
+        desc: "Даёт deterministic terminal report с Safety boundary: PASS и Result: PASS.",
+      },
+    ],
+    boundary:
+      "Только research prototype: не medical advice, не clinical evaluator и не deployable safety framework. Это демонстрация deterministic evaluation по sanitized traces.",
+    watch: "Смотреть демо",
+    run: "Запустить evaluator",
+    spec: "Открыть research spec",
+  },
+  zh: {
+    eyebrow: "Research proof",
+    title: "Second runnable proof: dynamic support-safety evaluator",
+    intro:
+      "Beyond treasury actions, PythiaLabs now includes a deterministic evaluator for sanitized multi-turn support-safety traces. It checks whether risky trajectories escalate at the expected turn.",
+    cards: [
+      {
+        title: "Sanitized fixture only",
+        desc: "Reads a synthetic JSON fixture. No real user data, no external APIs, and no generated conversation content.",
+      },
+      {
+        title: "Trajectory-level checks",
+        desc: "Computes first ESCALATE/BLOCK turn, escalation latency, missed escalation, and evidence completeness.",
+      },
+      {
+        title: "Reviewer-friendly output",
+        desc: "Produces a deterministic terminal report with Safety boundary: PASS and Result: PASS.",
+      },
+    ],
+    boundary:
+      "Research prototype only: not medical advice, not a clinical evaluator, and not a deployable safety framework. It demonstrates deterministic evaluation over sanitized traces.",
+    watch: "Watch demo",
+    run: "Run evaluator",
+    spec: "Read research spec",
+  },
+};
+
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;");
+
+function localeFor(filePath) {
+  const normalized = filePath.split(path.sep).join("/");
+  if (normalized.endsWith("/ru/index.html")) return "ru";
+  if (normalized.endsWith("/zh/index.html")) return "zh";
+  return "en";
+}
+
+function renderSection(locale) {
+  const t = copy[locale] ?? copy.en;
+  const cards = t.cards
+    .map(
+      (card) => `
+            <article class="support-safety-proof-card">
+              <h3>${escapeHtml(card.title)}</h3>
+              <p>${escapeHtml(card.desc)}</p>
+            </article>`,
+    )
+    .join("");
+
+  return `
+      <section id="support-safety-proof" class="section section-alt support-safety-proof-section" aria-labelledby="support-safety-proof-title">
+        <div class="container">
+          <p class="cta-eyebrow">${escapeHtml(t.eyebrow)}</p>
+          <h2 id="support-safety-proof-title">${escapeHtml(t.title)}</h2>
+          <p class="support-safety-proof-intro">${escapeHtml(t.intro)}</p>
+          <div class="support-safety-proof-layout">
+            <pre class="support-safety-terminal" aria-label="PythiaLabs support-safety evaluator terminal output"><code>${escapeHtml(terminal)}</code></pre>
+            <div class="support-safety-proof-cards">${cards}
+              <p class="support-safety-proof-boundary">${escapeHtml(t.boundary)}</p>
+            </div>
+          </div>
+          <p class="support-safety-proof-cta">
+            <a class="btn btn-primary" href="${videoUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(t.watch)} →</a>
+            <a class="btn btn-secondary" href="${evaluatorUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(t.run)} →</a>
+            <a class="btn btn-ghost" href="${specUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(t.spec)} →</a>
+          </p>
+        </div>
+      </section>`;
+}
+
+async function htmlFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await htmlFiles(full)));
+    } else if (entry.isFile() && entry.name === "index.html") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function injectCss(html) {
+  if (html.includes(".support-safety-proof-section")) return html;
+  return html.replace("</style>", `${css}\n</style>`);
+}
+
+function injectSection(html, locale) {
+  if (html.includes('id="support-safety-proof"')) return html;
+
+  const section = renderSection(locale);
+  const researchMarker = '      <section id="research-track"';
+  if (html.includes(researchMarker)) {
+    return html.replace(researchMarker, `${section}\n\n${researchMarker}`);
+  }
+
+  const demoMarker = '      <section id="demo-proof"';
+  if (html.includes(demoMarker)) {
+    return html.replace(demoMarker, `${section}\n\n${demoMarker}`);
+  }
+
+  return html.replace("\n    </main>", `\n${section}\n    </main>`);
+}
+
+const files = await htmlFiles(distDir);
+
+await Promise.all(
+  files.map(async (file) => {
+    const locale = localeFor(file);
+    const original = await readFile(file, "utf8");
+    const updated = injectSection(injectCss(original), locale);
+    await writeFile(file, updated);
+  }),
+);
+
+console.log(`Injected support-safety proof section into ${files.length} page(s).`);


### PR DESCRIPTION
## Summary

Adds a new `#support-safety-proof` landing section for the recorded dynamic support-safety evaluator demo.

## Why

PythiaLabs now has a second runnable proof beyond the Web3 treasury gate:

- Web3 treasury demo = action-level pre-execution gate
- Dynamic support-safety evaluator = trajectory-level research prototype over sanitized traces

This strengthens research credibility without replacing the main demo-proof or paid-review conversion path.

## What changes

- Adds `site/src/inject_support_safety_proof.mjs` as a post-build injector.
- Inserts `#support-safety-proof` before the research track when present.
- Links to the recorded demo:
  - https://youtu.be/A6UAR3e2r3k
- Links to the evaluator script and research spec.
- Includes a short terminal preview:
  - `Safety boundary: PASS`
  - `Scenarios: 3 deterministic checks`
  - `Evidence: complete + replayable`
  - `Result: PASS`
- Includes explicit research boundaries:
  - sanitized fixture only
  - no real user data
  - no external APIs
  - not medical advice
  - not clinical evaluator
  - not a deployable safety framework

## Non-goals

- Does not replace `#demo-proof`.
- Does not change demo engine logic.
- Does not change pricing.
- Does not add analytics.
- Does not add external services.

## Test plan

Expected local checks:

```bash
cd site
npm ci
npm run build

rg -n 'id="support-safety-proof"|Dynamic Support-Safety Gate|Safety boundary: PASS|A6UAR3e2r3k' dist/index.html dist/ru/index.html dist/zh/index.html
rg -n 'id="demo-proof"|id="research-track"|id="validation-tracks"' dist/index.html dist/ru/index.html dist/zh/index.html
```

Manual check:

- Open `/`, `/ru/`, `/zh/`.
- Verify the support-safety proof section is readable on mobile.
- Verify CTA links open the video, evaluator script, and research spec.