### PR TITLE
docs: add corrected documentation index page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# PythiaLabs Documentation
+
+Welcome to the PythiaLabs documentation index. Use this page to quickly find
+the most important docs whether you are a new contributor, reviewer, or grantmaker.
+
+---
+
+## Architecture
+
+- [Database Architecture](database_architecture.md) — Postgres, TimescaleDB, and LiminalDB as three kinds of truth.
+- [Persistent Reasoning Memory](persistent_reasoning_memory.md) — append-only reasoning memory roadmap.
+- [Agent Memory vs. Action Gates](agent_memory_vs_action_gate.md) — why PythiaLabs is not an organizational memory product.
+- [Temporal-Causal Memory Stack](temporal_causal_memory_stack.md) — broader memory and replay architecture.
+- [Design Principles](design_principles.md)
+- [Web3 Consensus Reason Layer](web3_consensus_reason_layer.md)
+
+---
+
+## Research and Positioning
+
+- [Research Roadmap](research_roadmap.md)
+- [Open Agentic Models Need Evidence Gates](open_agentic_models_need_evidence_gates.md)
+- [Positioning vs. Transaction Simulation Tools](positioning_vs_transaction_simulation.md) — clarifies that PythiaLabs is not a Web3 transaction simulator; it is a pre-execution evidence gate for AI-agent proposed actions before tools are called.
+
+---
+
+## Demos and Expected Outputs
+
+- [Paid Review Demo Expected Output](../examples/paid_review_demo_expected_output.md)
+- [Agent Infrastructure Showcase Expected Output](agent_infra_action_showcase_expected_output.md)
+- [Banking AI Risk Showcase Expected Output](banking_ai_risk_showcase_expected_output.md)
+- [Web3 Treasury Showcase Expected Output](web3_treasury_full_showcase_expected_output.md)
+
+---
+
+## Funding and Support
+
+- [Grant Readiness](grant_readiness.md)
+- [Grant One-Pager — Web3 Treasury Reason Layer](grant_one_pager_web3_treasury_reason_layer.md)
+- [Grant Application Summary](grant_application_summary.md)
+- [Threat Model — Web3 Treasury Reason Layer](threat_model_web3_treasury_reason_layer.md)
+- [Sponsorship and Paid Pilots](SPONSORSHIP.md)
+- [License Strategy](license_strategy.md)
+
+---
+
+## Security and Governance
+
+- [Security Policy](../SECURITY.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Security Automation](security_automation.md)


### PR DESCRIPTION
## Summary

Adds `docs/README.md` as a documentation index page with corrected links and the latest positioning document.

## Why

PR #100 introduced a useful docs index, but it still had several link issues and the contributor branch is in a fork that this integration cannot update directly.

This maintainer PR preserves the same intent while fixing the links before merge.

## Changes

- Creates `docs/README.md`
- Adds architecture links including:
  - Database Architecture
  - Persistent Reasoning Memory
  - Agent Memory vs. Action Gates
  - Temporal-Causal Memory Stack
- Adds Research and Positioning section including:
  - Research Roadmap
  - Open Agentic Models Need Evidence Gates
  - Positioning vs. Transaction Simulation Tools
- Fixes Paid Review Demo Expected Output link to point to `../examples/paid_review_demo_expected_output.md`
- Adds Sponsorship and Paid Pilots link

## Scope

Docs-only.

No changes to:

- site/build files
- product runtime logic
- demo engine logic
- pricing
- workflows

## Related

- Supersedes #100 if merged first
- Closes #97