### PR TITLE
docs: link documentation index from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ PythiaLabs evaluates whether an AI/agent action should be allowed, blocked, or e
 For a concise reviewer-facing overview, see:
 
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
+- **Documentation index:** [`docs/README.md`](docs/README.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)
 


### PR DESCRIPTION
## Summary

Adds a direct link from the root README project summary to the new documentation index.

## Changes

- Adds `docs/README.md` to the Project summary link list

## Why

The documentation index is now the navigation hub for architecture, research, positioning, demos, funding, and governance docs. Linking it from the root README makes it visible to reviewers, contributors, and grantmakers immediately.

## Scope

Docs-only.

No changes to:

- site/build files
- product runtime logic
- demo engine logic
- pricing
- workflows