### PR TITLE
docs: add README links to expected output references (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,12 @@ Additional roadmap items:
 - Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
 
+## Further Reading
+
+- [Database Architecture](docs/database_architecture.md) — Postgres, TimescaleDB, and LiminalDB as three kinds of truth.
+- [Agent Memory vs. Action Gates](docs/agent_memory_vs_action_gate.md) — why PythiaLabs is not an organizational memory product.
+- [Sponsorship and Paid Pilots](docs/SPONSORSHIP.md) — support paths, paid review scope, and sponsorship options.
+
 ## Research / Positioning / Docs
 
 - Open agentic models need evidence gates: `docs/open_agentic_models_need_evidence_gates.md`

--- a/README.md
+++ b/README.md
@@ -66,8 +66,14 @@ AI agents are moving from text generation into real actions: infrastructure chan
 ## Current showcases
 
 - **Agent Infrastructure Action Safety** — destructive infrastructure actions such as production volume deletion.
+  
+  Expected output: [`docs/agent_infra_action_showcase_expected_output.md`](docs/agent_infra_action_showcase_expected_output.md)
 - **Banking AI Risk** — high-risk financial/agentic actions with operator approval, freshness, and decision-time knowledge checks.
+  
+  Expected output: [`docs/banking_ai_risk_showcase_expected_output.md`](docs/banking_ai_risk_showcase_expected_output.md)
 - **Web3 Treasury Governance** — DAO treasury action review with quorum, timelock, temporal authorization, evidence export, and tamper rejection.
+  
+  Expected output: [`docs/web3_treasury_full_showcase_expected_output.md`](docs/web3_treasury_full_showcase_expected_output.md)
 - **AI Coding Agents / CI Autofix** — pre-execution review for autonomous coding-agent actions such as CI fixes, PR updates, dependency changes, and deploy-adjacent workflows.
 
 ## Reviewer quickstart

--- a/README.md
+++ b/README.md
@@ -433,7 +433,6 @@ Additional roadmap items:
 - multi-domain executors for QA, graph problems, puzzles, and agent actions
 - Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
-
 ## Further Reading
 
 - [Database Architecture](docs/database_architecture.md) — Postgres, TimescaleDB, and LiminalDB as three kinds of truth.

--- a/README.md
+++ b/README.md
@@ -433,11 +433,6 @@ Additional roadmap items:
 - multi-domain executors for QA, graph problems, puzzles, and agent actions
 - Web3 consensus reason layer for DAO governance, treasury safety, and agentic on-chain actions
 
-## Further Reading
-
-- [Database Architecture](docs/database_architecture.md) — Postgres, TimescaleDB, and LiminalDB as three kinds of truth.
-- [Agent Memory vs. Action Gates](docs/agent_memory_vs_action_gate.md) — why PythiaLabs is not an organizational memory product.
-- [Sponsorship and Paid Pilots](docs/SPONSORSHIP.md) — support paths, paid review scope, and sponsorship options.
 
 ## Research / Positioning / Docs
 


### PR DESCRIPTION
Closes #101\n\nAdds expected output links to the Current showcases section in README.md for:\n- Agent Infrastructure Action Safety\n- Banking AI Risk\n- Web3 Treasury Governance