### PR TITLE
docs: add README positioning block

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Deterministic evidence gates for high-risk agentic actions.
 
 PythiaLabs evaluates whether an AI/agent action should be allowed, blocked, or escalated under current evidence, authorization, environment, credential, and recovery context — producing replayable traces, stable stop reasons, and tamper-checkable evidence artifacts.
 
+## Positioning
+
+PythiaLabs does not replace transaction simulation, wallet security, or contract-monitoring tools.
+
+It sits earlier in the workflow: evaluating AI-agent proposed actions before tools are called.
+
+Web3 treasury is one high-risk demo scenario, not the product category.
+
 ## Project summary
 
 For a concise reviewer-facing overview, see:


### PR DESCRIPTION
## Summary

Adds a short positioning block near the top of the root README.

## Why

Recent feedback showed that PythiaLabs can be misread as a Web3 transaction simulator if the Web3 treasury demo is foregrounded too strongly. This README block clarifies the category before reviewers reach the demo sections.

## Changes

Adds this positioning near the top of README:

```text
PythiaLabs does not replace transaction simulation, wallet security, or contract-monitoring tools.

It sits earlier in the workflow: evaluating AI-agent proposed actions before tools are called.

Web3 treasury is one high-risk demo scenario, not the product category.
```

## Scope

Docs-only.

No changes to:

- site/build files
- product runtime logic
- demo engine logic
- pricing
- workflows

## Related

- Builds on `docs/positioning_vs_transaction_simulation.md`
- Follow-up to #118 and #119