### PR TITLE
docs: document AI coding agent CI autofix use case

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 - [Research Roadmap](research_roadmap.md)
 - [Open Agentic Models Need Evidence Gates](open_agentic_models_need_evidence_gates.md)
 - [Positioning vs. Transaction Simulation Tools](positioning_vs_transaction_simulation.md) — clarifies that PythiaLabs is not a Web3 transaction simulator; it is a pre-execution evidence gate for AI-agent proposed actions before tools are called.
+- [AI Coding Agents and CI Autofix Use Case](ai_coding_agents_ci_autofix_use_case.md) — documents how PythiaLabs can gate autonomous coding-agent and CI autofix actions before tools are called.
 
 ---
 

--- a/docs/ai_coding_agents_ci_autofix_use_case.md
+++ b/docs/ai_coding_agents_ci_autofix_use_case.md
@@ -1,0 +1,133 @@
+# AI Coding Agents and CI Autofix Use Case
+
+Status: use-case note.
+
+Scope: documentation only. This document does not claim production enforcement, autonomous deployment safety, certified security review, or replacement of existing coding-agent tools.
+
+## Why this use case matters
+
+Coding agents are moving from chat-based assistance toward autonomous workflows triggered by GitHub events, CI failures, webhooks, cron jobs, issue queues, and scheduled routines.
+
+That changes the central safety question.
+
+The question is no longer only:
+
+```text
+Can the agent write code?
+```
+
+The question becomes:
+
+```text
+Should the agent be allowed to perform this action now, under this evidence?
+```
+
+PythiaLabs is designed for this earlier decision point: before a tool call, pull request, merge, CI fix, infrastructure command, or deployment-related action proceeds.
+
+## Core flow
+
+```text
+GitHub event / CI failure / scheduled routine
+        ↓
+AI coding agent proposes an action
+        ↓
+PythiaLabs captures an evidence snapshot
+        ↓
+ALLOW / BLOCK / ESCALATE
+        ↓
+Tool call / pull request / human review / no-op
+```
+
+## What PythiaLabs gates
+
+PythiaLabs can evaluate proposed actions such as:
+
+- opening or updating a pull request
+- applying an automated CI fix
+- changing dependency versions
+- modifying build or deployment scripts
+- touching infrastructure-related code
+- running repository automation
+- triggering a deploy-adjacent workflow
+
+The gate decides before execution. It does not replace the coding agent, CI system, repository host, code review process, or runtime security controls.
+
+## Example: CI autofix
+
+A CI job fails. An AI coding agent proposes a fix.
+
+Before the agent applies the change or opens a PR, PythiaLabs can ask:
+
+- What failed?
+- What files would be changed?
+- Is the proposed change limited to the failing area?
+- Does the change touch security, credentials, infrastructure, or deployment paths?
+- Are tests fresh enough to support the action?
+- Is the repository state clean?
+- Is the action allowed under the current policy?
+- Should this be allowed, blocked, or escalated to a human reviewer?
+
+The output is a deterministic decision with reviewer-facing evidence.
+
+## Example evidence fields
+
+A coding-agent evidence snapshot may include:
+
+```json
+{
+  "trigger": "ci_failure",
+  "agent_action": "propose_pr_fix",
+  "changed_files": ["mix.exs", "lib/example.ex"],
+  "risk_flags": ["dependency_change"],
+  "tests_observed": ["mix test"],
+  "test_freshness": "fresh",
+  "repo_state": "clean",
+  "policy_result": "requires_review",
+  "decision": "ESCALATE"
+}
+```
+
+The exact schema is intentionally not finalized here. This document defines the use case and reviewer journey, not a production API contract.
+
+## Relationship to coding agents
+
+PythiaLabs complements coding agents.
+
+Coding agents answer:
+
+```text
+What change should I make?
+```
+
+PythiaLabs answers:
+
+```text
+Should this proposed action be allowed to proceed under the current evidence?
+```
+
+This distinction keeps PythiaLabs out of the crowded coding-agent market and positions it as a pre-execution evidence gate for autonomous developer workflows.
+
+## Non-goals
+
+This use case does not claim:
+
+- replacement of Claude Code, GitHub Copilot, Cursor, or other coding agents
+- replacement of CI systems
+- replacement of human code review
+- production security certification
+- automatic safe deployment
+- vulnerability detection guarantees
+- runtime enforcement
+- cloud, IAM, or infrastructure integration
+
+## Reviewer-facing takeaway
+
+As coding agents become more autonomous, teams need deterministic gates before agents take consequential actions.
+
+PythiaLabs sits at that boundary:
+
+```text
+agent proposes action → evidence → ALLOW / BLOCK / ESCALATE
+```
+
+The more autonomous coding agents become, the more important pre-execution evidence gates become.


### PR DESCRIPTION
## Summary

Documents an AI coding agent / CI autofix use case for PythiaLabs.

## Why

Developer tools are moving toward autonomous coding agents triggered by GitHub events, CI failures, webhooks, cron jobs, issue queues, and routines.

This use case clarifies where PythiaLabs fits: not as a coding agent, but as a pre-execution evidence gate before an autonomous agent applies a fix, opens a PR, touches infrastructure-adjacent code, or triggers deploy-adjacent workflows.

## Changes

- Adds `docs/ai_coding_agents_ci_autofix_use_case.md`
- Links it from `docs/README.md`

## Core flow

```text
GitHub event / CI failure / scheduled routine
→ AI coding agent proposes an action
→ PythiaLabs captures an evidence snapshot
→ ALLOW / BLOCK / ESCALATE
→ tool call / pull request / human review / no-op
```

## Scope

Docs-only.

No changes to:

- runtime gate logic
- demo engine logic
- pricing
- workflows
- site build files

## Related

Closes #128
Closes #129