### PR TITLE
docs: add AI coding agents to README showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ AI agents are moving from text generation into real actions: infrastructure chan
 - **Agent Infrastructure Action Safety** — destructive infrastructure actions such as production volume deletion.
 - **Banking AI Risk** — high-risk financial/agentic actions with operator approval, freshness, and decision-time knowledge checks.
 - **Web3 Treasury Governance** — DAO treasury action review with quorum, timelock, temporal authorization, evidence export, and tamper rejection.
+- **AI Coding Agents / CI Autofix** — pre-execution review for autonomous coding-agent actions such as CI fixes, PR updates, dependency changes, and deploy-adjacent workflows.
 
 ## Reviewer quickstart
 


### PR DESCRIPTION
## Summary

Adds AI Coding Agents / CI Autofix as a visible README showcase.

## Why

The AI coding agent use case is now documented in `docs/ai_coding_agents_ci_autofix_use_case.md`. This PR makes the category visible from the root README so reviewers immediately see that PythiaLabs applies beyond Web3 treasury demos.

## Changes

Adds one bullet under `Current showcases`:

```text
AI Coding Agents / CI Autofix — pre-execution review for autonomous coding-agent actions such as CI fixes, PR updates, dependency changes, and deploy-adjacent workflows.
```

## Scope

Docs-only.

No changes to:

- runtime gate logic
- demo engine logic
- pricing
- workflows
- site build files

## Related

Builds on #130.