### PR TITLE
site: add AI coding agents CI autofix landing copy

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs",
-    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
+    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs && node src/inject_ai_coding_agents_ci_autofix.mjs",
+    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_validation_tracks.mjs && node src/inject_ai_coding_agents_ci_autofix.mjs && node serve.mjs",
     "preview": "node serve.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/site/src/inject_ai_coding_agents_ci_autofix.mjs
+++ b/site/src/inject_ai_coding_agents_ci_autofix.mjs
@@ -1,0 +1,63 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "../dist");
+
+const replacements = [
+  {
+    from: "AI coding agents",
+    to: "AI Coding Agents / CI Autofix",
+  },
+  {
+    from:
+      "Before merge, patch, or production change, the agent leaves a verifiable trace and passes pre-execution validation.",
+    to:
+      "Before an autonomous coding agent fixes CI, opens a PR, updates dependencies, or touches deploy-adjacent workflows, PythiaLabs evaluates the proposed action and evidence first.",
+  },
+  {
+    from: "AI coding agents",
+    to: "AI Coding Agents / CI Autofix",
+  },
+  {
+    from:
+      "Перед merge, patch или production change агент оставляет проверяемый trace и проходит pre-execution validation.",
+    to:
+      "Перед тем как автономный coding agent чинит CI, открывает PR, обновляет зависимости или трогает deploy-adjacent workflow, PythiaLabs сначала оценивает proposed action и evidence.",
+  },
+];
+
+async function htmlFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await htmlFiles(full)));
+    } else if (entry.isFile() && entry.name === "index.html") {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function inject(html) {
+  let updated = html;
+  for (const { from, to } of replacements) {
+    updated = updated.split(from).join(to);
+  }
+  return updated;
+}
+
+const files = await htmlFiles(distDir);
+
+await Promise.all(
+  files.map(async (file) => {
+    const original = await readFile(file, "utf8");
+    const updated = inject(original);
+    await writeFile(file, updated);
+  }),
+);
+
+console.log(`Injected AI coding agents / CI autofix landing copy into ${files.length} page(s).`);


### PR DESCRIPTION
## Summary

Adds AI Coding Agents / CI Autofix positioning to the landing page output.

## Why

The repo now documents AI coding agents / CI autofix as a PythiaLabs use case. This PR brings the same category onto the public landing page without rewriting the large localization source file.

## Changes

- Adds `site/src/inject_ai_coding_agents_ci_autofix.mjs`
- Runs the new injection script after the existing landing build injections
- Updates the use-case copy from generic `AI coding agents` to `AI Coding Agents / CI Autofix`
- Clarifies the CI autofix flow:

```text
Before an autonomous coding agent fixes CI, opens a PR, updates dependencies, or touches deploy-adjacent workflows, PythiaLabs evaluates the proposed action and evidence first.
```

## Scope

Site copy/build pipeline only.

No changes to:

- runtime gate logic
- demo engine logic
- pricing
- workflows
- backend/product logic

## Related

Builds on #130 and #131.