### PR TITLE
docs/site: add support-safety gate demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For a concise reviewer-facing overview, see:
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
+- **Support-safety gate demo:** https://youtu.be/A6UAR3e2r3k
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)
 
 ## Landing Page

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 
 ## Demos and Expected Outputs
 
+- [Support-safety gate demo](https://youtu.be/A6UAR3e2r3k) — deterministic support-safety gate: sanitized trace → safety boundary → scenario checks → evidence → PASS
 - [Paid Review Demo Expected Output](../examples/paid_review_demo_expected_output.md)
 - [Agent Infrastructure Showcase Expected Output](agent_infra_action_showcase_expected_output.md)
 - [Banking AI Risk Showcase Expected Output](banking_ai_risk_showcase_expected_output.md)

--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -45,6 +45,11 @@ export const siteConfig = {
       labelKey: "short2",
       campaign: "founder_video_short_2",
     },
+    {
+      url: "https://youtu.be/A6UAR3e2r3k",
+      labelKey: "supportSafetyGate",
+      campaign: "support_safety_gate_demo",
+    },
   ],
   email: "safal0645@gmail.com",
   pilotEmailSubject: "PythiaLabs pilot inquiry",

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -396,6 +396,12 @@ export const locales = {
           desc: "The next frontier of AI safety is pre-execution control. PythiaLabs is building a deterministic gate for agentic actions — before code changes, infrastructure commands, financial decisions, or governance operations are executed.",
           cta: "Watch the short",
         },
+        supportSafetyGate: {
+          name: "Support-safety gate demo",
+          headline: "Support-safety gate demo",
+          desc: "A deterministic demo using a sanitized trace fixture to evaluate safety boundary, escalation timing, missed escalation, evidence completeness, and replayability.",
+          cta: "Watch support-safety demo",
+        },
       },
     },
     faq: {
@@ -892,6 +898,12 @@ export const locales = {
           desc: "Следующая граница AI safety — это контроль до выполнения. PythiaLabs строит детерминированный шлюз для agentic-действий: перед изменением кода, infra-командой, финансовым решением или governance-операцией.",
           cta: "Смотреть шортс",
         },
+        supportSafetyGate: {
+          name: "Support-safety gate demo",
+          headline: "Support-safety gate demo",
+          desc: "A deterministic demo using a sanitized trace fixture to evaluate safety boundary, escalation timing, missed escalation, evidence completeness, and replayability.",
+          cta: "Watch support-safety demo",
+        },
       },
     },
     faq: {
@@ -1356,6 +1368,12 @@ export const locales = {
           headline: "执行前控制",
           desc: "AI 安全的下一个前沿是执行前控制。PythiaLabs 正在为 agentic 行动构建确定性门控 — 在代码变更、基础设施命令、金融决策或治理操作执行之前。",
           cta: "观看短视频",
+        },
+        supportSafetyGate: {
+          name: "Support-safety gate demo",
+          headline: "Support-safety gate demo",
+          desc: "A deterministic demo using a sanitized trace fixture to evaluate safety boundary, escalation timing, missed escalation, evidence completeness, and replayability.",
+          cta: "Watch support-safety demo",
         },
       },
     },


### PR DESCRIPTION
## Summary

Adds the new support-safety gate demo video as a reviewer-facing asset.

Video:

https://youtu.be/A6UAR3e2r3k

## Why

This video turns the dynamic support-safety evaluator into a reviewer-facing demo asset. It shows a sanitized trace fixture moving through a visible safety funnel:

```text
Trace → Safety boundary → Scenario checks → Evidence → PASS
```

The demo highlights:

- safety boundary
- escalation timing
- missed escalation
- evidence completeness
- deterministic replayability

## Changes

- Adds the support-safety gate demo link to `README.md`
- Adds a minimal link in `docs/README.md`
- Adds the video to the landing page video config
- Adds localized landing copy for the new video card

## Scope

README and site/demo copy only.

No changes to:

- runtime gate logic
- evaluator logic
- demo engine logic
- pricing
- backend
- workflows

## Verification

Claude reported:

```text
cd site
npm ci
npm run build
```

Build passed for EN/RU/ZH, and the output contains `Support-safety gate demo`, `A6UAR3e2r3k`, and the existing `IUk3iO0N4YU` demo link remains present.