### PR TITLE
site: add canonical support-safety proof section

### DIFF
--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -65,4 +65,11 @@ export const siteConfig = {
   showcaseScriptCount: 6,
   testFileCount: 17,
   mcpReadmePath: "integrations/mcp/README.md",
+  supportSafety: {
+    videoUrl: "https://youtu.be/A6UAR3e2r3k",
+    evaluatorPath: "examples/dynamic_support_safety/evaluate_sanitized_fixture.exs",
+    specPath: "docs/dynamic_support_safety_eval_harness.md",
+    tracesPath: "docs/dynamic_support_safety_trace_examples.md",
+    campaign: "support_safety_proof",
+  },
 };

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -404,6 +404,37 @@ export const locales = {
         },
       },
     },
+    supportSafetyProof: {
+      eyebrow: "Trajectory-level research prototype",
+      title: "Support-safety gate demo",
+      intro:
+        "A deterministic support-safety gate demo using a sanitized trace fixture. The evaluator checks safety boundary, escalation timing, missed escalation, evidence completeness, and deterministic replayability.",
+      positioning:
+        "Web3 treasury demo is the action-level pre-execution gate. The dynamic support-safety evaluator is a trajectory-level research prototype over sanitized traces — a second proof path beyond Web3 treasury.",
+      funnelLabel: "Funnel",
+      funnel: "Trace → Safety boundary → Scenario checks → Evidence → PASS",
+      evidenceTitle: "Evidence",
+      evidenceItems: [
+        "Safety boundary: PASS",
+        "Scenarios: 3 deterministic checks",
+        "Evidence: complete + replayable",
+        "Result: PASS",
+      ],
+      scopeTitle: "Scope and safety boundaries",
+      scopeItems: [
+        "Sanitized fixture only — no real user data",
+        "No external APIs",
+        "Not medical advice",
+        "Not a clinical evaluator",
+        "Not a deployable safety framework",
+      ],
+      links: {
+        video: "Watch the demo",
+        evaluator: "Evaluator script",
+        spec: "Research spec",
+        traces: "Trace examples",
+      },
+    },
     faq: {
       title: "Frequently asked questions",
       items: [
@@ -906,6 +937,37 @@ export const locales = {
         },
       },
     },
+    supportSafetyProof: {
+      eyebrow: "Trajectory-level research prototype",
+      title: "Support-safety gate demo",
+      intro:
+        "Детерминированное демо support-safety gate на санитизированном trace fixture. Evaluator проверяет safety boundary, escalation timing, пропущенную эскалацию, полноту evidence и детерминированную replayability.",
+      positioning:
+        "Web3 treasury demo — это action-level pre-execution gate. Dynamic support-safety evaluator — это trajectory-level research prototype поверх санитизированных traces, второй proof path за пределами Web3 treasury.",
+      funnelLabel: "Воронка",
+      funnel: "Trace → Safety boundary → Scenario checks → Evidence → PASS",
+      evidenceTitle: "Evidence",
+      evidenceItems: [
+        "Safety boundary: PASS",
+        "Scenarios: 3 детерминированные проверки",
+        "Evidence: полное и replayable",
+        "Result: PASS",
+      ],
+      scopeTitle: "Scope и safety boundaries",
+      scopeItems: [
+        "Только санитизированный fixture — никаких данных реальных пользователей",
+        "Никаких внешних API",
+        "Не медицинский совет",
+        "Не клинический evaluator",
+        "Не готовый к деплою safety framework",
+      ],
+      links: {
+        video: "Смотреть демо",
+        evaluator: "Скрипт evaluator",
+        spec: "Research spec",
+        traces: "Примеры traces",
+      },
+    },
     faq: {
       title: "Частые вопросы",
       items: [
@@ -1375,6 +1437,37 @@ export const locales = {
           desc: "A deterministic demo using a sanitized trace fixture to evaluate safety boundary, escalation timing, missed escalation, evidence completeness, and replayability.",
           cta: "Watch support-safety demo",
         },
+      },
+    },
+    supportSafetyProof: {
+      eyebrow: "Trajectory-level research prototype",
+      title: "Support-safety gate demo",
+      intro:
+        "A deterministic support-safety gate demo using a sanitized trace fixture. The evaluator checks safety boundary, escalation timing, missed escalation, evidence completeness, and deterministic replayability.",
+      positioning:
+        "Web3 treasury demo is the action-level pre-execution gate. The dynamic support-safety evaluator is a trajectory-level research prototype over sanitized traces — a second proof path beyond Web3 treasury.",
+      funnelLabel: "Funnel",
+      funnel: "Trace → Safety boundary → Scenario checks → Evidence → PASS",
+      evidenceTitle: "Evidence",
+      evidenceItems: [
+        "Safety boundary: PASS",
+        "Scenarios: 3 deterministic checks",
+        "Evidence: complete + replayable",
+        "Result: PASS",
+      ],
+      scopeTitle: "Scope and safety boundaries",
+      scopeItems: [
+        "Sanitized fixture only — no real user data",
+        "No external APIs",
+        "Not medical advice",
+        "Not a clinical evaluator",
+        "Not a deployable safety framework",
+      ],
+      links: {
+        video: "Watch the demo",
+        evaluator: "Evaluator script",
+        spec: "Research spec",
+        traces: "Trace examples",
       },
     },
     faq: {

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -683,6 +683,39 @@ export function renderPage(currentId, year, buildDate) {
         </div>
       </section>
 
+      <section id="support-safety-proof" class="section section-alt support-safety-proof-section" aria-labelledby="support-safety-proof-title">
+        <div class="container">
+          <p class="cta-eyebrow">${escape(t.supportSafetyProof.eyebrow)}</p>
+          <h2 id="support-safety-proof-title">${escape(t.supportSafetyProof.title)}</h2>
+          <p class="support-safety-proof-intro">${escape(t.supportSafetyProof.intro)}</p>
+          <p class="support-safety-proof-positioning">${escape(t.supportSafetyProof.positioning)}</p>
+          <p class="support-safety-proof-funnel">
+            <span class="support-safety-proof-funnel-label">${escape(t.supportSafetyProof.funnelLabel)}:</span>
+            <span class="support-safety-proof-funnel-value">${escape(t.supportSafetyProof.funnel)}</span>
+          </p>
+          <div class="support-safety-proof-grid">
+            <article class="support-safety-proof-card">
+              <h3>${escape(t.supportSafetyProof.evidenceTitle)}</h3>
+              <ul class="support-safety-proof-evidence">${t.supportSafetyProof.evidenceItems
+                .map((item) => `<li><span class="check" aria-hidden="true">✓</span><span>${escape(item)}</span></li>`)
+                .join("")}</ul>
+            </article>
+            <article class="support-safety-proof-card support-safety-proof-card-scope">
+              <h3>${escape(t.supportSafetyProof.scopeTitle)}</h3>
+              <ul class="support-safety-proof-scope">${t.supportSafetyProof.scopeItems
+                .map((item) => `<li><span class="not-mark" aria-hidden="true">✕</span><span>${escape(item)}</span></li>`)
+                .join("")}</ul>
+            </article>
+          </div>
+          <p class="support-safety-proof-actions">
+            <a class="btn btn-primary" href="${utm(siteConfig.supportSafety.videoUrl, siteConfig.supportSafety.campaign)}" target="_blank" rel="noopener noreferrer">${escape(t.supportSafetyProof.links.video)} →</a>
+            <a class="btn btn-secondary" href="${siteConfig.repoUrl}/blob/main/${siteConfig.supportSafety.evaluatorPath}" target="_blank" rel="noopener noreferrer">${escape(t.supportSafetyProof.links.evaluator)} →</a>
+            <a class="btn btn-ghost" href="${siteConfig.repoUrl}/blob/main/${siteConfig.supportSafety.specPath}" target="_blank" rel="noopener noreferrer">${escape(t.supportSafetyProof.links.spec)} →</a>
+            <a class="btn btn-ghost" href="${siteConfig.repoUrl}/blob/main/${siteConfig.supportSafety.tracesPath}" target="_blank" rel="noopener noreferrer">${escape(t.supportSafetyProof.links.traces)} →</a>
+          </p>
+        </div>
+      </section>
+
       <section id="faq" class="section section-alt">
         <div class="container">
           <h2>${escape(t.faq.title)}</h2>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1845,3 +1845,100 @@ blockquote {
     text-align: center;
   }
 }
+
+/* Support-safety proof section */
+.support-safety-proof-section .support-safety-proof-intro,
+.support-safety-proof-section .support-safety-proof-positioning {
+  max-width: 820px;
+  color: var(--text-muted);
+  font-size: 1.03rem;
+}
+
+.support-safety-proof-funnel {
+  max-width: 820px;
+  margin: 1rem 0 0;
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--accent);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  background: rgba(124, 196, 255, 0.08);
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.support-safety-proof-funnel-label {
+  display: inline-block;
+  margin-right: 0.5rem;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.support-safety-proof-funnel-value {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.support-safety-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.support-safety-proof-card {
+  padding: 1.15rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.support-safety-proof-card h3 {
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.support-safety-proof-evidence,
+.support-safety-proof-scope {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.support-safety-proof-evidence li,
+.support-safety-proof-scope li {
+  display: grid;
+  grid-template-columns: 1.1rem 1fr;
+  gap: 0.45rem;
+  align-items: start;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.support-safety-proof-card-scope {
+  border-color: rgba(210, 153, 34, 0.32);
+  background: rgba(210, 153, 34, 0.06);
+}
+
+.support-safety-proof-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .support-safety-proof-actions .btn {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated canonical landing section for the support-safety gate demo.

## Why

This implements the idea from #117 without reviving its old post-build injector approach. The section is now built through the current site source-of-truth path: config, i18n, renderer, and scoped styles.

The section presents the dynamic support-safety evaluator as a second proof path beyond the Web3 treasury demo:

```text
Web3 treasury demo = action-level pre-execution gate
Dynamic support-safety evaluator = trajectory-level research prototype over sanitized traces
```

## Changes

- `site/src/config.mjs`: adds support-safety links/campaign metadata
- `site/src/i18n.mjs`: adds EN/RU/ZH `supportSafetyProof` copy
- `site/src/render.mjs`: renders `<section id="support-safety-proof">` after the videos block
- `site/src/styles.css`: adds scoped styles for the new section

## Section funnel

```text
Trace → Safety boundary → Scenario checks → Evidence → PASS
```

## Scope boundaries

The section states clear limitations:

- sanitized fixture only
- no real user data
- no external APIs
- not medical advice
- not a clinical evaluator
- not a deployable safety framework

## Verification

Claude reported:

```bash
cd site
npm ci
npm run build
```

Build passed for EN/RU/ZH.

Acceptance criteria reported as passing:

- `id="support-safety-proof"` present in EN/RU/ZH dist pages
- `Support-safety gate demo` appears in each locale
- `A6UAR3e2r3k` present
- existing demo video card remains present
- no post-build string replacement script added

## Related

Closes #139
Builds on #138
Supersedes the implementation approach from #117

## Scope

Site copy/layout only.

No changes to runtime gate logic, evaluator logic, demo engine logic, pricing, backend, workflows, or GitHub Actions.