### PR TITLE
site: add colored support-safety terminal preview

### DIFF
--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -434,6 +434,9 @@ export const locales = {
         spec: "Research spec",
         traces: "Trace examples",
       },
+      terminalCaption: "Reviewer-facing terminal output",
+      terminalAriaLabel:
+        "Reviewer-facing terminal output — deterministic, sanitized, replayable",
     },
     faq: {
       title: "Frequently asked questions",
@@ -967,6 +970,9 @@ export const locales = {
         spec: "Research spec",
         traces: "Примеры traces",
       },
+      terminalCaption: "Reviewer-facing terminal output",
+      terminalAriaLabel:
+        "Reviewer-facing terminal output — детерминированный, санитизированный, replayable",
     },
     faq: {
       title: "Частые вопросы",
@@ -1469,6 +1475,9 @@ export const locales = {
         spec: "Research spec",
         traces: "Trace examples",
       },
+      terminalCaption: "Reviewer-facing terminal output",
+      terminalAriaLabel:
+        "Reviewer-facing terminal output — deterministic, sanitized, replayable",
     },
     faq: {
       title: "常见问题",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -42,6 +42,24 @@ const ARTIFACT_JSON = `{
   }
 }`;
 
+const SUPPORT_SAFETY_TERMINAL_HTML = `<span class="ts-title">PythiaLabs — Dynamic Support-Safety Gate</span>
+<span class="ts-dim">deterministic evaluator | sanitized fixture | zero external calls</span>
+
+<span class="ts-key">Fixture:</span> <span class="ts-trace">dynamic_support_safety_sanitized_v1</span>
+<span class="ts-key">Safety boundary:</span> <span class="ts-pass">PASS</span>
+<span class="ts-key">Scenarios:</span> 3 deterministic checks
+<span class="ts-key">Evidence:</span> complete + replayable
+
+┌──────────────────────────┬──────────────────────────────┐
+│ <span class="ts-amber">Safety boundary</span>          │ <span class="ts-pass">PASS</span>                         │
+│ Scenarios checked        │ <span class="ts-pass">3 / 3 PASS</span>                   │
+│ Evidence completeness    │ <span class="ts-pass">1.00 each scenario</span>           │
+│ Replayability            │ <span class="ts-trace">deterministic</span>                │
+│ Final verdict            │ <span class="ts-pass">PASS</span>                         │
+└──────────────────────────┴──────────────────────────────┘
+
+<span class="ts-key">Result:</span> <span class="ts-pass">PASS</span>`;
+
 const exampleDecisions = {
   en: {
     eyebrow: "Example decision",
@@ -689,6 +707,10 @@ export function renderPage(currentId, year, buildDate) {
           <h2 id="support-safety-proof-title">${escape(t.supportSafetyProof.title)}</h2>
           <p class="support-safety-proof-intro">${escape(t.supportSafetyProof.intro)}</p>
           <p class="support-safety-proof-positioning">${escape(t.supportSafetyProof.positioning)}</p>
+          <figure class="support-safety-terminal-figure">
+            <pre class="support-safety-terminal" role="img" aria-label="${escape(t.supportSafetyProof.terminalAriaLabel)}"><code>${SUPPORT_SAFETY_TERMINAL_HTML}</code></pre>
+            <figcaption class="support-safety-terminal-caption">${escape(t.supportSafetyProof.terminalCaption)}</figcaption>
+          </figure>
           <p class="support-safety-proof-funnel">
             <span class="support-safety-proof-funnel-label">${escape(t.supportSafetyProof.funnelLabel)}:</span>
             <span class="support-safety-proof-funnel-value">${escape(t.supportSafetyProof.funnel)}</span>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1942,3 +1942,74 @@ blockquote {
     text-align: center;
   }
 }
+
+.support-safety-terminal-figure {
+  margin: 1.25rem 0 0;
+}
+
+.support-safety-terminal {
+  overflow-x: auto;
+  margin: 0;
+  padding: 1.1rem 1.25rem;
+  border: 1px solid rgba(124, 196, 255, 0.24);
+  border-radius: var(--radius);
+  background: rgba(2, 6, 12, 0.92);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+}
+
+.support-safety-terminal code {
+  display: block;
+  white-space: pre;
+  color: var(--text);
+}
+
+.support-safety-terminal .ts-title {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.support-safety-terminal .ts-dim,
+.support-safety-terminal .ts-key {
+  color: var(--text-muted);
+}
+
+.support-safety-terminal .ts-pass {
+  color: var(--allow);
+  font-weight: 600;
+}
+
+.support-safety-terminal .ts-amber {
+  color: var(--escalate);
+  font-weight: 600;
+}
+
+.support-safety-terminal .ts-trace {
+  color: var(--accent);
+}
+
+.support-safety-terminal-caption {
+  margin-top: 0.55rem;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .support-safety-terminal {
+    font-size: 0.74rem;
+    padding: 0.9rem 1rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .support-safety-terminal {
+    font-size: 0.66rem;
+    line-height: 1.5;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a compact, colored reviewer-facing terminal output preview inside the existing `#support-safety-proof` landing section (added in #140). The terminal is intended to feel like a real deterministic terminal proof, not marketing decoration.

- Sits between the positioning paragraph and the funnel — visual proof artifact
- Uses existing CSS tokens only: `--allow` (PASS green), `--escalate` (Safety boundary amber), `--accent` (trace cyan)
- Same English technical block across EN/RU/ZH; only the small caption + `aria-label` are localized
- Evidence card retained as the compact semantic summary; terminal is the proof artifact

## Scope

Site copy/layout only. No runtime, evaluator, demo, pricing, backend, or workflow changes. No new injector scripts. Implemented through canonical source files only:

- `site/src/i18n.mjs` — `terminalCaption` + `terminalAriaLabel` for EN/RU/ZH
- `site/src/render.mjs` — `SUPPORT_SAFETY_TERMINAL_HTML` constant + `<figure>` markup
- `site/src/styles.css` — scoped `.support-safety-terminal` + `.ts-*` styles

## Builds on

#140 (canonical support-safety proof section)

## Test plan

- [x] `npm ci && npm run build` passes for EN/RU/ZH
- [x] `dist/index.html`, `dist/ru/index.html`, `dist/zh/index.html` each contain `class="support-safety-terminal"`
- [x] Terminal block (title, fixture, box, `Result: PASS`) preserved in all locales
- [x] RU `aria-label` localized; EN/ZH `aria-label` in English
- [x] Existing Evidence + Scope cards remain
- [ ] CI green (build / Secret scan / lighthouse)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqVBPcfdRk1v12DWAhRGWN)_