### PR TITLE
site: fix support-safety terminal mobile layout

### DIFF
--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -42,23 +42,21 @@ const ARTIFACT_JSON = `{
   }
 }`;
 
-const SUPPORT_SAFETY_TERMINAL_HTML = `<span class="ts-title">PythiaLabs — Dynamic Support-Safety Gate</span>
-<span class="ts-dim">deterministic evaluator | sanitized fixture | zero external calls</span>
-
-<span class="ts-key">Fixture:</span> <span class="ts-trace">dynamic_support_safety_sanitized_v1</span>
-<span class="ts-key">Safety boundary:</span> <span class="ts-pass">PASS</span>
-<span class="ts-key">Scenarios:</span> 3 deterministic checks
-<span class="ts-key">Evidence:</span> complete + replayable
-
-┌──────────────────────────┬──────────────────────────────┐
-│ <span class="ts-amber">Safety boundary</span>          │ <span class="ts-pass">PASS</span>                         │
-│ Scenarios checked        │ <span class="ts-pass">3 / 3 PASS</span>                   │
-│ Evidence completeness    │ <span class="ts-pass">1.00 each scenario</span>           │
-│ Replayability            │ <span class="ts-trace">deterministic</span>                │
-│ Final verdict            │ <span class="ts-pass">PASS</span>                         │
-└──────────────────────────┴──────────────────────────────┘
-
-<span class="ts-key">Result:</span> <span class="ts-pass">PASS</span>`;
+const SUPPORT_SAFETY_TERMINAL_HTML = `<div class="ts-line ts-title">PythiaLabs — Dynamic Support-Safety Gate</div>
+<div class="ts-line ts-dim">deterministic evaluator | sanitized fixture | zero external calls</div>
+<div class="ts-spacer" aria-hidden="true"></div>
+<div class="ts-line"><span class="ts-key">Fixture:</span> <span class="ts-trace">dynamic_support_safety_sanitized_v1</span></div>
+<div class="ts-line"><span class="ts-key">Safety boundary:</span> <span class="ts-pass">PASS</span></div>
+<div class="ts-line"><span class="ts-key">Scenarios:</span> 3 deterministic checks</div>
+<div class="ts-line"><span class="ts-key">Evidence:</span> complete + replayable</div>
+<dl class="ts-table">
+  <div class="ts-row"><dt><span class="ts-amber">Safety boundary</span></dt><dd><span class="ts-pass">PASS</span></dd></div>
+  <div class="ts-row"><dt>Scenarios checked</dt><dd><span class="ts-pass">3 / 3 PASS</span></dd></div>
+  <div class="ts-row"><dt>Evidence completeness</dt><dd><span class="ts-pass">1.00 each scenario</span></dd></div>
+  <div class="ts-row"><dt>Replayability</dt><dd><span class="ts-trace">deterministic</span></dd></div>
+  <div class="ts-row"><dt>Final verdict</dt><dd><span class="ts-pass">PASS</span></dd></div>
+</dl>
+<div class="ts-line ts-result"><span class="ts-key">Result:</span> <span class="ts-pass">PASS</span></div>`;
 
 const exampleDecisions = {
   en: {
@@ -708,7 +706,7 @@ export function renderPage(currentId, year, buildDate) {
           <p class="support-safety-proof-intro">${escape(t.supportSafetyProof.intro)}</p>
           <p class="support-safety-proof-positioning">${escape(t.supportSafetyProof.positioning)}</p>
           <figure class="support-safety-terminal-figure">
-            <pre class="support-safety-terminal" role="img" aria-label="${escape(t.supportSafetyProof.terminalAriaLabel)}"><code>${SUPPORT_SAFETY_TERMINAL_HTML}</code></pre>
+            <div class="support-safety-terminal" role="img" aria-label="${escape(t.supportSafetyProof.terminalAriaLabel)}">${SUPPORT_SAFETY_TERMINAL_HTML}</div>
             <figcaption class="support-safety-terminal-caption">${escape(t.supportSafetyProof.terminalCaption)}</figcaption>
           </figure>
           <p class="support-safety-proof-funnel">

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1948,7 +1948,6 @@ blockquote {
 }
 
 .support-safety-terminal {
-  overflow-x: auto;
   margin: 0;
   padding: 1.1rem 1.25rem;
   border: 1px solid rgba(124, 196, 255, 0.24);
@@ -1956,15 +1955,18 @@ blockquote {
   background: rgba(2, 6, 12, 0.92);
   color: var(--text);
   font-family: var(--mono);
-  font-size: 0.85rem;
-  line-height: 1.55;
+  font-size: 0.9rem;
+  line-height: 1.6;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 
-.support-safety-terminal code {
-  display: block;
-  white-space: pre;
-  color: var(--text);
+.support-safety-terminal .ts-line {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.support-safety-terminal .ts-spacer {
+  height: 0.7rem;
 }
 
 .support-safety-terminal .ts-title {
@@ -1991,6 +1993,36 @@ blockquote {
   color: var(--accent);
 }
 
+.support-safety-terminal .ts-table {
+  margin: 0.85rem 0;
+  padding: 0.7rem 0;
+  border-top: 1px dashed rgba(124, 196, 255, 0.18);
+  border-bottom: 1px dashed rgba(124, 196, 255, 0.18);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.support-safety-terminal .ts-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.support-safety-terminal .ts-row dt,
+.support-safety-terminal .ts-row dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.support-safety-terminal .ts-row dt {
+  color: var(--text-muted);
+}
+
+.support-safety-terminal .ts-result {
+  margin-top: 0.15rem;
+}
+
 .support-safety-terminal-caption {
   margin-top: 0.55rem;
   color: var(--text-muted);
@@ -2002,14 +2034,31 @@ blockquote {
 
 @media (max-width: 720px) {
   .support-safety-terminal {
-    font-size: 0.74rem;
-    padding: 0.9rem 1rem;
+    font-size: 0.82rem;
+    padding: 1rem 1rem;
+    line-height: 1.55;
+  }
+
+  .support-safety-terminal .ts-row {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 0.5rem;
   }
 }
 
-@media (max-width: 520px) {
+@media (max-width: 480px) {
   .support-safety-terminal {
-    font-size: 0.66rem;
-    line-height: 1.5;
+    font-size: 0.78rem;
+  }
+
+  .support-safety-terminal .ts-row {
+    grid-template-columns: 1fr;
+    gap: 0.05rem;
+    padding: 0.15rem 0;
+  }
+
+  .support-safety-terminal .ts-row dt {
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
   }
 }


### PR DESCRIPTION
## Summary

Replaces the ASCII box-drawing table inside the support-safety terminal preview (added in #141) with a semantic `<dl>` grid. ASCII tables drift on mobile when the font is shrunk and the column borders stop lining up; a CSS grid stays aligned at any width.

Visual result is the same — same colored tokens (`PASS` green, `Safety boundary` amber, trace cyan), same terminal-card framing, same content. Under 480px the grid collapses to a single column with the metric label rendered as a small uppercase eyebrow above the value.

## Changes

- `site/src/render.mjs` — rebuild terminal block with `.ts-line` / `.ts-table` / `.ts-row` / `.ts-result`; switch wrapper from `<pre><code>` to `<div>` (no longer relying on pre-formatted whitespace).
- `site/src/styles.css` — replace whitespace-pre code styles with grid table styles + responsive breakpoints at 720px and 480px.

## Scope

Site copy/layout only. No runtime, evaluator, i18n, workflow, or backend changes. No new injector scripts. Canonical source files only.

## Builds on

#141 (colored support-safety terminal preview)

## Test plan

- [x] `npm ci && npm run build` passes for EN/RU/ZH
- [x] All three `dist/.../index.html` contain `class="support-safety-terminal"`
- [x] Zero remaining ASCII box-drawing chars (`┌`, `└`, `│`) in any locale
- [x] `.ts-table` / `.ts-row` rendered in all locales
- [ ] CI green (build / Secret scan / lighthouse)
- [ ] Visual mobile check on the live page after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqVBPcfdRk1v12DWAhRGWN)_