### PR TITLE
site: embed support-safety demo video in proof section

### DIFF
--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -67,8 +67,7 @@ export const siteConfig = {
   mcpReadmePath: "integrations/mcp/README.md",
   supportSafety: {
     videoUrl: "https://youtu.be/A6UAR3e2r3k",
-    videoEmbedUrl:
-      "https://www.youtube-nocookie.com/embed/A6UAR3e2r3k?controls=1&rel=0&modestbranding=1",
+    videoEmbedUrl: "https://www.youtube-nocookie.com/embed/A6UAR3e2r3k?rel=0&modestbranding=1",
     evaluatorPath: "examples/dynamic_support_safety/evaluate_sanitized_fixture.exs",
     specPath: "docs/dynamic_support_safety_eval_harness.md",
     tracesPath: "docs/dynamic_support_safety_trace_examples.md",

--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -67,6 +67,8 @@ export const siteConfig = {
   mcpReadmePath: "integrations/mcp/README.md",
   supportSafety: {
     videoUrl: "https://youtu.be/A6UAR3e2r3k",
+    videoEmbedUrl:
+      "https://www.youtube-nocookie.com/embed/A6UAR3e2r3k?controls=1&rel=0&modestbranding=1",
     evaluatorPath: "examples/dynamic_support_safety/evaluate_sanitized_fixture.exs",
     specPath: "docs/dynamic_support_safety_eval_harness.md",
     tracesPath: "docs/dynamic_support_safety_trace_examples.md",

--- a/site/src/i18n.mjs
+++ b/site/src/i18n.mjs
@@ -437,6 +437,8 @@ export const locales = {
       terminalCaption: "Reviewer-facing terminal output",
       terminalAriaLabel:
         "Reviewer-facing terminal output — deterministic, sanitized, replayable",
+      videoCaption: "Watch the support-safety gate demo",
+      videoIframeTitle: "PythiaLabs support-safety gate demo",
     },
     faq: {
       title: "Frequently asked questions",
@@ -973,6 +975,8 @@ export const locales = {
       terminalCaption: "Reviewer-facing terminal output",
       terminalAriaLabel:
         "Reviewer-facing terminal output — детерминированный, санитизированный, replayable",
+      videoCaption: "Смотреть демо support-safety gate",
+      videoIframeTitle: "PythiaLabs support-safety gate demo",
     },
     faq: {
       title: "Частые вопросы",
@@ -1478,6 +1482,8 @@ export const locales = {
       terminalCaption: "Reviewer-facing terminal output",
       terminalAriaLabel:
         "Reviewer-facing terminal output — deterministic, sanitized, replayable",
+      videoCaption: "Watch the support-safety gate demo",
+      videoIframeTitle: "PythiaLabs support-safety gate demo",
     },
     faq: {
       title: "常见问题",

--- a/site/src/render.mjs
+++ b/site/src/render.mjs
@@ -705,6 +705,18 @@ export function renderPage(currentId, year, buildDate) {
           <h2 id="support-safety-proof-title">${escape(t.supportSafetyProof.title)}</h2>
           <p class="support-safety-proof-intro">${escape(t.supportSafetyProof.intro)}</p>
           <p class="support-safety-proof-positioning">${escape(t.supportSafetyProof.positioning)}</p>
+          <figure class="support-safety-video-figure">
+            <div class="support-safety-video-frame">
+              <iframe
+                src="${siteConfig.supportSafety.videoEmbedUrl}"
+                title="${escape(t.supportSafetyProof.videoIframeTitle)}"
+                loading="lazy"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+                referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            </div>
+            <figcaption class="support-safety-video-caption">${escape(t.supportSafetyProof.videoCaption)}</figcaption>
+          </figure>
           <figure class="support-safety-terminal-figure">
             <div class="support-safety-terminal" role="img" aria-label="${escape(t.supportSafetyProof.terminalAriaLabel)}">${SUPPORT_SAFETY_TERMINAL_HTML}</div>
             <figcaption class="support-safety-terminal-caption">${escape(t.supportSafetyProof.terminalCaption)}</figcaption>

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1943,6 +1943,39 @@ blockquote {
   }
 }
 
+.support-safety-video-figure {
+  margin: 1.5rem 0 0;
+  max-width: 820px;
+}
+
+.support-safety-video-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid rgba(124, 196, 255, 0.32);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 22px 56px rgba(0, 0, 0, 0.32);
+}
+
+.support-safety-video-frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.support-safety-video-caption {
+  margin-top: 0.55rem;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .support-safety-terminal-figure {
   margin: 1.25rem 0 0;
 }


### PR DESCRIPTION
## Summary

Embeds the support-safety gate demo as a 16:9 lazy-loaded iframe (`youtube-nocookie`) at the top of the existing `#support-safety-proof` section, above the colored terminal preview. The video becomes the first proof artifact; the terminal stays directly below as the deterministic reviewer-facing artifact.

Reuses the same `youtube-nocookie` pattern already in use by the `demoSeries` embeds; CSP `frame-src` already covers it. The existing "Watch the demo" CTA link is kept as a fallback action.

## Changes (canonical source files only)

- `site/src/config.mjs` — add `supportSafety.videoEmbedUrl`
- `site/src/i18n.mjs` — add `videoIframeTitle` and `videoCaption` for EN/RU/ZH (RU caption localized; iframe title kept English as a technical name, matching the `demoSeries` convention)
- `site/src/render.mjs` — `<figure>` with iframe inserted between `positioning` and the terminal figure
- `site/src/styles.css` — scoped `.support-safety-video-figure` / `.support-safety-video-frame` / `.support-safety-video-caption` with 16:9 `aspect-ratio` frame and accent border

## Scope

Site copy/layout only. No runtime, evaluator, workflow, or backend changes. No new injector scripts.

## Builds on

#142 (mobile-friendly terminal grid)

## Test plan

- [x] `npm ci && npm run build` passes for EN/RU/ZH
- [x] All three `dist/.../index.html` contain `class="support-safety-video-frame"` (figure + frame = 2 occurrences each)
- [x] All three `dist/.../index.html` contain `youtube-nocookie.com/embed/A6UAR3e2r3k`
- [x] Existing "Watch the demo" CTA + terminal preview still rendered
- [ ] CI green (build / Secret scan / lighthouse)
- [ ] Visual check on the live page (iframe loads, 16:9 ratio, no CSP violations in console)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqVBPcfdRk1v12DWAhRGWN)_