### PR TITLE
site: enable seek controls on embedded demo videos

### DIFF
--- a/site/src/config.mjs
+++ b/site/src/config.mjs
@@ -4,17 +4,17 @@ export const siteConfig = {
   repoSlug: "safal207/pythiaLabs",
   hookUrl: "https://www.youtube.com/shorts/Ot5tMRDN0l4",
   demoUrl: "https://youtu.be/JDe3qS67A-I",
-  demoEmbedUrl: "https://www.youtube-nocookie.com/embed/JDe3qS67A-I?controls=0&disablekb=1&rel=0&modestbranding=1",
+  demoEmbedUrl: "https://www.youtube-nocookie.com/embed/JDe3qS67A-I?rel=0&modestbranding=1",
   demoSeries: [
     {
       url: "https://youtu.be/JDe3qS67A-I",
-      embedUrl: "https://www.youtube-nocookie.com/embed/JDe3qS67A-I?controls=0&disablekb=1&rel=0&modestbranding=1",
+      embedUrl: "https://www.youtube-nocookie.com/embed/JDe3qS67A-I?rel=0&modestbranding=1",
       labelKey: "part1",
       campaign: "demo_series_part_1",
     },
     {
       url: "https://youtu.be/pIJodVRD2Ro",
-      embedUrl: "https://www.youtube-nocookie.com/embed/pIJodVRD2Ro?controls=0&disablekb=1&rel=0&modestbranding=1",
+      embedUrl: "https://www.youtube-nocookie.com/embed/pIJodVRD2Ro?rel=0&modestbranding=1",
       labelKey: "part2",
       campaign: "demo_series_part_2",
     },


### PR DESCRIPTION
## Summary

Drops `controls=0&disablekb=1` from the embedded demo videos so viewers can actually scrub the timeline. The previous flags removed the YouTube player UI entirely — viewers could only play, pause, or restart, and couldn't jump to a specific moment. That hurts viewing intent: someone landing mid-video has no way to seek.

The new player keeps `rel=0` (no end-screen suggestions from other channels) and `modestbranding=1` (less YouTube logo), so the look stays clean — it's just seekable now.

## Affected embeds

- `siteConfig.demoEmbedUrl`
- `siteConfig.demoSeries[0].embedUrl` (Part 1)
- `siteConfig.demoSeries[1].embedUrl` (Part 2)

The new `siteConfig.supportSafety.videoEmbedUrl` introduced in #143 already uses `controls=1` and is unaffected.

## Scope

Single-file change to `site/src/config.mjs`. No runtime, evaluator, render, CSS, or workflow changes.

## Test plan

- [x] `npm ci && npm run build` passes for EN/RU/ZH
- [x] No remaining `controls=0` in any locale's `dist/.../index.html`
- [x] Embed URLs render with `rel=0&modestbranding=1` only
- [ ] CI green (build / Secret scan / lighthouse)
- [ ] Manual: open the live page and confirm timeline scrubbing works on all demo videos

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqVBPcfdRk1v12DWAhRGWN)_