### PR TITLE
docs: add agent action audit sample report

### DIFF
--- a/docs/AGENT_ACTION_AUDIT_SAMPLE_REPORT.md
+++ b/docs/AGENT_ACTION_AUDIT_SAMPLE_REPORT.md
@@ -1,0 +1,475 @@
+# Agent Action Audit Sample Report
+
+Status: synthetic customer-facing sample.
+
+Scope: this is a filled example of the Agent Action Audit Report for a fictional coding-agent CI autofix workflow. It contains no customer data, no secrets, and no production details.
+
+## Report title
+
+```text
+Agent Action Audit Report: Coding Agent CI Autofix
+```
+
+## Confidentiality note
+
+```text
+This sample report is synthetic. It should be used to demonstrate report structure, evidence-chain reasoning, failure classification, and pilot deliverable shape. It does not describe a real customer system.
+```
+
+## One-sentence purpose
+
+```text
+This report evaluates whether one coding-agent CI autofix workflow is allowed, evidenced, replayable, reversible, and causally valid enough to scale safely.
+```
+
+## Executive summary
+
+| Field | Value |
+| --- | --- |
+| Customer / team | Fictional Platform Team |
+| Workflow audited | Coding agent proposes CI autofix after failed pipeline |
+| Action class | PR autofix / CI remediation |
+| Date | 2026-05-08 |
+| Auditor | Aleksei Safonov / PythiaLabs |
+| Input artifacts | Synthetic workflow description, anonymized trace sketch, sample agent action, current approval rule summary |
+| Overall verdict | YELLOW |
+| Primary risk | Agent can propose CI configuration changes without explicit decision-time authorization evidence |
+| Recommended next control | Require DRP decision record + PythiaLabs pre-action gate before CI config changes |
+
+### Summary paragraph
+
+```text
+We reviewed a synthetic coding-agent workflow where an AI agent observes a failed CI run and proposes a pull request that modifies CI configuration. The audit found that the workflow has a useful human review point at pull request merge time, but the agent can still propose high-impact configuration changes without an explicit pre-action evidence gate or decision record. The workflow is currently YELLOW because it is not immediately unsafe in the reviewed scope, but it lacks enough decision-time evidence, trace replay, and causal authorization to scale safely. Before expanding this workflow, the team should require a structured decision record, pre-action gate, and explicit side-effect boundary for CI configuration changes.
+```
+
+## Verdict scale
+
+| Verdict | Meaning | Recommended response |
+| --- | --- | --- |
+| GREEN | Action path is sufficiently evidenced and bounded for the reviewed scope. | Continue with monitoring and periodic review. |
+| YELLOW | Workflow may continue only with additional controls, review, or limited blast radius. | Add controls before scale-up. |
+| RED | Workflow should not proceed in current form. | Block, redesign, or require human approval. |
+
+## Audit scope
+
+### In scope
+
+- Coding agent CI autofix workflow.
+- Proposed pull request after CI failure.
+- Action class: modifying workflow/test configuration.
+- Synthetic trace/log sketch.
+- Current review boundary: human PR review before merge.
+- Question: whether the action should be allowed, blocked, or escalated before PR creation.
+
+### Out of scope
+
+- Full platform security review.
+- Full compliance review.
+- Penetration testing.
+- Production deployment sign-off.
+- Model capability evaluation beyond this workflow.
+- Verification of real customer artifacts.
+- Analysis of private repositories or production CI logs.
+
+## Input artifacts reviewed
+
+| Artifact | Description | Sensitivity | Notes |
+| --- | --- | --- | --- |
+| Synthetic workflow description | Agent observes failing test suite and opens PR | Synthetic | Built for demonstration |
+| Synthetic trace sketch | Step-level event sequence | Synthetic | No real logs |
+| Sample proposed action | Modify `.github/workflows/ci.yml` retry/timeout behavior | Synthetic | Representative high-impact config change |
+| Current approval summary | Human reviews PR before merge | Synthetic | Review exists late in workflow |
+
+## Workflow overview
+
+```text
+CI fails
+→ agent reads failed job summary
+→ agent infers probable flaky timeout
+→ agent proposes CI config change
+→ agent opens PR
+→ human may review PR
+→ CI reruns
+→ merge may change future CI behavior
+→ reviewer inspects final PR and logs
+```
+
+### Workflow narrative
+
+```text
+The agent receives a CI failure signal. It observes that the test suite timed out after 90 seconds and proposes increasing a timeout plus adding retry behavior. The action may affect future CI reliability, masking real regressions or changing deployment confidence. Current controls include human PR review before merge. Current gaps include missing decision-time evidence, missing explicit authorization for CI config changes, and incomplete replay path from failure signal to proposed fix.
+```
+
+## Agent action map
+
+| Step | Actor | Action | External state change? | Evidence available? | Human review? | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | CI system | Emits failed pipeline signal | No | Yes | No | CI failure log exists |
+| 2 | Agent | Reads job summary and failing test name | No | Partial | No | Full raw log not anchored |
+| 3 | Agent | Infers flaky timeout | No | Partial | No | Inference may be unsupported |
+| 4 | Agent | Proposes increasing timeout and retry count | No | Partial | No | High-impact config action |
+| 5 | Agent | Opens pull request modifying CI config | Yes | Partial | Later | PR creation changes repo state |
+| 6 | Human reviewer | Reviews PR before merge | Potentially | Yes | Yes | Review exists but late |
+| 7 | CI system | Reruns after PR | No | Yes | No | Outcome is tracked, but consequence memory is informal |
+
+## Action boundary classification
+
+| Boundary | Status | Notes |
+| --- | --- | --- |
+| Read-only observation | Present | Agent reads CI failure summary. |
+| Recommendation only | Present but not isolated | Agent recommendation quickly becomes PR creation. |
+| Tool call | Present | Agent can open or modify a pull request. |
+| External side effect | Present | Repository state changes when PR is opened. |
+| Irreversible / hard-to-reverse change | Partial | PR is reversible, but merged CI config can mask future failures. |
+| Human approval boundary | Present late | Human review exists before merge, not before high-impact PR creation. |
+
+## Evidence chain
+
+```text
+Signal
+→ Care-Case / policy gate
+→ Decision record
+→ Consequence memory
+→ Pre-action gate
+→ Side-effect lifecycle
+→ Execution trace
+→ Causal audit
+→ Reviewer report
+```
+
+| Layer | Audit question | Evidence found | Status | Gap |
+| --- | --- | --- | --- | --- |
+| Signal | What happened or what was proposed? | CI failure event and job summary | PASS | Full raw log not anchored |
+| Guardian Layer / Care-Case | Was the signal converted into a reviewable case? | No explicit care-case | FAIL | Failure signal goes directly to proposed fix |
+| DRP / Decision record | What decision was made and why? | Informal agent reasoning | FAIL | No structured decision record |
+| DMP / Consequence memory | What happened after the decision? | CI rerun result visible | PARTIAL | No memory of later masking/regression risk |
+| PythiaLabs / Pre-action gate | Was the action gated before execution? | No explicit pre-action gate | FAIL | CI config action should be ESCALATE |
+| CaPU / Side-effect lifecycle | Was commit-before-effect enforced? | Human review before merge only | PARTIAL | PR creation side effect occurs before commit logic |
+| T-Trace / LTP | Can the path be replayed or inspected? | Partial event sequence | PARTIAL | Trace lacks anchors and admissibility checks |
+| CML | Is causal/authorization lineage valid? | No parent authorization record | FAIL | Missing parent decision and authorization lineage |
+| Reviewer / Operator | Can a human understand the chain? | PR plus logs are understandable | PARTIAL | Reviewer must reconstruct intent manually |
+
+## Decision-time evidence
+
+Key question:
+
+```text
+What evidence existed before the agent acted — not after the fact?
+```
+
+| Evidence item | Available before action? | Fresh? | Verifiable? | Used in decision? | Notes |
+| --- | --- | --- | --- | --- | --- |
+| CI failure status | Yes | Yes | Yes | Yes | Basic signal was available. |
+| Full failing job log | Partial | Yes | Partial | Unclear | Agent referenced summary, not anchored full log. |
+| Historical flake rate | No | N/A | N/A | No | Timeout inference lacks history. |
+| Ownership of CI config | No | N/A | N/A | No | No CODEOWNERS/policy check in evidence chain. |
+| Risk classification for CI config edits | No | N/A | N/A | No | Should be high-risk action class. |
+| Human authorization before PR creation | No | N/A | N/A | No | Review occurs later. |
+
+## ALLOW / BLOCK / ESCALATE criteria
+
+| Decision | Criteria | Evidence required |
+| --- | --- | --- |
+| ALLOW | Agent proposes comment-only diagnosis or low-risk test rerun. | CI failure, no side effect, no config edit. |
+| BLOCK | Agent attempts direct merge, disables tests, removes checks, or changes protected workflow without review. | Detection of protected file/action class. |
+| ESCALATE | Agent modifies CI config, retry logic, timeout policy, release gate, or deployment workflow. | CI evidence, owner approval, decision record, pre-action gate. |
+
+### Recommended decision for reviewed workflow
+
+```text
+Recommended gate: ESCALATE
+Reason: CI configuration changes can alter future trust in test results and should require explicit decision-time evidence and owner review.
+Required next evidence/control: DRP decision record + PythiaLabs pre-action gate + CODEOWNERS/policy owner check for CI config modifications.
+```
+
+## Causal validity review
+
+Key question:
+
+```text
+Was the action not only functionally successful, but causally authorized?
+```
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| Parent decision exists | FAIL | No explicit decision record authorizing CI config change. |
+| Authorization exists | FAIL | Human review exists before merge, not before PR creation. |
+| Evidence supports action | PARTIAL | CI failed, but timeout inference lacks flake history. |
+| Handoff is marked | PARTIAL | PR indicates agent action, but handoff semantics are informal. |
+| Side-effect boundary is explicit | FAIL | Opening PR is treated as ordinary output, not side effect. |
+| Replay path is complete | PARTIAL | Basic sequence visible; evidence anchors missing. |
+| Reversibility is known | PARTIAL | PR can be closed; merged config may mask regressions. |
+
+## Failure classes
+
+| Code | Failure class | Description | Severity |
+| --- | --- | --- | --- |
+| AAA-R1 | Missing authorization | CI config change lacks explicit authorization before PR creation. | High |
+| AAA-R2 | Missing parent | Proposed fix has no structured parent decision record. | High |
+| AAA-R3 | Replay gap | Reviewer cannot fully reconstruct evidence path from failure to proposed fix. | Medium |
+| AAA-R4 | Stale or incomplete evidence | Agent relies on CI summary without flake history or owner policy. | Medium |
+| AAA-R5 | Unmarked side effect | PR creation changes repository state but is not treated as side effect. | High |
+| AAA-R10 | Consequence memory missing | Long-term impact on CI reliability is not tracked. | Medium |
+
+## Findings
+
+### Finding 1 — CI config change lacks pre-action authorization
+
+| Field | Value |
+| --- | --- |
+| Code | AAA-R1 |
+| Severity | High |
+| Evidence | Synthetic action map step 5; no decision record before PR creation |
+| Affected step | Agent opens pull request modifying CI config |
+| Status | Open |
+
+**Description**
+
+```text
+The agent can open a pull request that modifies CI configuration without a structured authorization record or policy-owner approval before the repository state changes.
+```
+
+**Why it matters**
+
+```text
+CI configuration determines how future changes are validated. A seemingly helpful timeout/retry change can hide flaky tests, mask real regressions, or weaken deployment confidence.
+```
+
+**Recommended control**
+
+```text
+Classify CI configuration edits as ESCALATE. Require a DRP decision record, policy owner evidence, and PythiaLabs pre-action gate before PR creation.
+```
+
+### Finding 2 — Timeout inference is not supported by enough decision-time evidence
+
+| Field | Value |
+| --- | --- |
+| Code | AAA-R4 |
+| Severity | Medium |
+| Evidence | Synthetic trace sketch; agent inferred timeout from single failed job summary |
+| Affected step | Agent infers probable flaky timeout |
+| Status | Open |
+
+**Description**
+
+```text
+The agent inferred that the test failure was caused by a timeout or flake, but the reviewed evidence did not include historical flake rate, recent runtime trend, code ownership, or linked regression data.
+```
+
+**Why it matters**
+
+```text
+Without evidence freshness and historical context, the agent may optimize away a symptom instead of addressing root cause.
+```
+
+**Recommended control**
+
+```text
+Require decision-time evidence for timeout/retry changes: historical runtime trend, flake score, owner approval, and alternative hypothesis check.
+```
+
+### Finding 3 — PR creation is not modeled as a side effect
+
+| Field | Value |
+| --- | --- |
+| Code | AAA-R5 |
+| Severity | High |
+| Evidence | Synthetic workflow step where agent opens PR |
+| Affected step | Agent moves from recommendation to repository mutation |
+| Status | Open |
+
+**Description**
+
+```text
+The workflow treats PR creation as a normal output, but it changes shared repository state, notifies reviewers, triggers CI, and may influence later merge decisions.
+```
+
+**Why it matters**
+
+```text
+Agentic systems need explicit side-effect boundaries. Otherwise teams may only review the final PR while missing whether the action should have been allowed to create the PR at all.
+```
+
+**Recommended control**
+
+```text
+Add a CaPU-style side-effect lifecycle: Gate → Incubate → Commit → Execute for PR creation on protected files or high-risk paths.
+```
+
+## Severity model
+
+| Severity | Meaning | Recommended response |
+| --- | --- | --- |
+| Critical | Current workflow can create high-impact side effects without authorization, replay, or review. | Block until redesigned. |
+| High | Workflow has serious gaps around authorization, side effects, or causal lineage. | Require controls before scale-up. |
+| Medium | Workflow has incomplete evidence, replay, or consequence tracking. | Fix before broad deployment. |
+| Low | Minor documentation or observability gap. | Track and improve. |
+
+## Control recommendations
+
+| Priority | Control | Owner | Effort | Risk reduced |
+| --- | --- | --- | --- | --- |
+| P0 | Add pre-action gate for CI config modifications | Platform / AI tooling | M | Unauthorized high-risk PR actions |
+| P0 | Require DRP decision record before protected-file PR creation | Platform / Repo owners | M | Missing parent and authorization lineage |
+| P1 | Add evidence freshness checks for timeout/retry changes | QA / CI owners | M | Unsupported flake/timeout inference |
+| P1 | Add side-effect lifecycle for PR creation | AI tooling / DevEx | L | Unmarked repository state mutation |
+| P2 | Add consequence memory for CI config changes | QA / Reliability | M | Long-term masking/regression risk |
+
+Recommended control library applied here:
+
+- Add pre-action gate for high-risk tool calls.
+- Add explicit decision record before action.
+- Add evidence freshness check.
+- Add trace anchors for key claims/actions.
+- Add human review for yellow/red gates.
+- Add commit-before-effect lifecycle.
+- Add consequence memory after execution.
+- Add causal lineage audit for side-effect actions.
+- Add replayable trace export.
+- Add responsibility owner for each action class.
+
+## Minimum viable hardening plan
+
+```text
+Week 1:
+- classify CI config edits as ESCALATE
+- define ALLOW / BLOCK / ESCALATE rules for agent PR actions
+- require decision record for protected file modifications
+
+Week 2:
+- add trace anchors for CI failure evidence
+- add side-effect boundary before PR creation
+- require owner/human review for yellow/red cases
+
+Week 3+:
+- add causal audit checks for missing parent / missing authorization
+- add consequence memory for CI config changes
+- prepare continuous monitoring or integration pilot
+```
+
+## Reviewer checklist
+
+A reviewer should be able to answer:
+
+```text
+1. What action did the agent propose?
+   Modify CI timeout/retry configuration.
+
+2. What evidence existed before action?
+   CI failure summary; incomplete full log/history.
+
+3. Was the action allowed?
+   Not explicitly before PR creation.
+
+4. Who or what authorized it?
+   No structured authorization record was found.
+
+5. Was the action reversible?
+   PR can be closed; merged config may have longer-term effects.
+
+6. Did the workflow cross a side-effect boundary?
+   Yes, opening a PR changed repository state.
+
+7. Can the path be replayed?
+   Partially, but evidence anchors are missing.
+
+8. Is the causal lineage valid?
+   No, parent decision and authorization are missing.
+
+9. What happened after execution?
+   CI rerun result exists, but consequence memory is informal.
+
+10. What control should be added next?
+   DRP decision record + PythiaLabs pre-action gate for protected CI config changes.
+```
+
+## Customer-safe sharing guidance
+
+For a real engagement, ask the customer to share only non-sensitive materials:
+
+- anonymized workflow description,
+- synthetic trace/log sample,
+- redacted policy or approval rule,
+- generic action class,
+- non-production scenario,
+- summary of current controls.
+
+Do not request or store:
+
+- credentials,
+- secrets,
+- customer data,
+- regulated data,
+- raw production incidents without approval,
+- private prompts or proprietary traces unless explicitly authorized.
+
+## Final report conclusion
+
+```text
+The reviewed workflow is currently YELLOW.
+
+The strongest existing control is human PR review before merge.
+The largest trust gap is missing decision-time authorization before the agent creates a PR modifying CI configuration.
+
+Before scaling this workflow, the team should classify CI configuration changes as ESCALATE and require a structured DRP decision record plus PythiaLabs pre-action gate before PR creation.
+```
+
+## Appendix A — Evidence chain diagram
+
+```text
+CI failure signal
+  ↓
+Care-Case / Policy Gate: missing
+  ↓
+Decision Record: missing
+  ↓
+Consequence Memory: partial
+  ↓
+Pre-Action Gate: missing
+  ↓
+Commit-Before-Effect: partial / late
+  ↓
+Execution Trace: partial
+  ↓
+Causal Audit: invalid lineage
+  ↓
+Reviewer Report: this report
+```
+
+## Appendix B — One-page version
+
+```text
+Workflow: Coding agent CI autofix
+Action class: PR autofix / CI remediation
+Verdict: YELLOW
+Primary risk: CI config change without explicit pre-action authorization
+Top recommendation: require DRP decision record + PythiaLabs pre-action gate before protected CI config changes
+
+Evidence chain status:
+- Signal: PASS
+- Decision record: FAIL
+- Pre-action gate: FAIL
+- Side-effect boundary: FAIL
+- Trace replay: PARTIAL
+- Causal lineage: FAIL
+- Consequence memory: PARTIAL
+
+Top findings:
+1. AAA-R1 — Missing authorization before CI config PR creation
+2. AAA-R4 — Timeout inference lacks enough decision-time evidence
+3. AAA-R5 — PR creation is not modeled as a side effect
+
+Next controls:
+1. Classify CI config edits as ESCALATE
+2. Require DRP decision record before protected-file PR creation
+3. Add PythiaLabs pre-action gate and trace anchors for CI failure evidence
+```
+
+## Final short version
+
+```text
+The answer may look right.
+The PR may even pass.
+But the action is not yet causally accountable.
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 - [Agent Action Audit Kit](AGENT_ACTION_AUDIT_KIT.md) — sales-facing pilot wedge for auditing one AI-agent workflow and turning opaque behavior into a structured evidence chain.
 - [Agent Action Audit Outreach Pack](AGENT_ACTION_AUDIT_OUTREACH.md) — outbound messages, discovery-call structure, qualification questions, and objection handling for first pilots.
 - [Agent Action Audit Report Template](AGENT_ACTION_AUDIT_REPORT_TEMPLATE.md) — customer-facing pilot deliverable template for one workflow, action class, or trace/log sample.
+- [Agent Action Audit Sample Report](AGENT_ACTION_AUDIT_SAMPLE_REPORT.md) — filled synthetic report for a coding-agent CI autofix workflow showing the expected customer-facing output.
 - [Research Roadmap](research_roadmap.md)
 - [Open Agentic Models Need Evidence Gates](open_agentic_models_need_evidence_gates.md)
 - [Positioning vs. Transaction Simulation Tools](positioning_vs_transaction_simulation.md) — clarifies that PythiaLabs is not a Web3 transaction simulator; it is a pre-execution evidence gate for AI-agent proposed actions before tools are called.


### PR DESCRIPTION
## Summary

Adds a filled synthetic sample report for Agent Action Audit Kit.

## Changes

- Adds `docs/AGENT_ACTION_AUDIT_SAMPLE_REPORT.md`
- Links it from `docs/README.md`
- Demonstrates a fictional coding-agent CI autofix audit with verdict, evidence chain, findings, recommendations, and one-page summary

## Scope

Docs-only. No site, runtime, evaluator, demo, or API changes.