### PR TITLE
site: improve agent action audit SEO

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -1,1 +1,17 @@
-{"name":"pythialabs-site","private":true,"type":"module","scripts":{"build":"node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs","dev":"node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs && node serve.mjs","preview":"node serve.mjs","format":"prettier --write .","format:check":"prettier --check ."},"devDependencies":{"@resvg/resvg-js":"^2.6.2","lightningcss":"^1.27.0","prettier":"^3.3.0"}}
+{
+  "name": "pythialabs-site",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs",
+    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
+    "preview": "node serve.mjs",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
+    "lightningcss": "^1.27.0",
+    "prettier": "^3.3.0"
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs",
-    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
+    "build": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_agent_action_audit_one_pager_seo.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs",
+    "dev": "node build.mjs && node src/inject_demo_proof.mjs && node src/inject_hero_clarity.mjs && node src/inject_research_track.mjs && node src/inject_milestones.mjs && node src/inject_threat_model.mjs && node src/inject_contributor_roadmap.mjs && node src/inject_agent_action_audit_kit.mjs && node src/inject_agent_action_audit_one_pager.mjs && node src/inject_agent_action_audit_one_pager_seo.mjs && node src/inject_pilot_capture.mjs && node src/inject_validation_tracks.mjs && node serve.mjs",
     "preview": "node serve.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/site/src/inject_agent_action_audit_one_pager_seo.mjs
+++ b/site/src/inject_agent_action_audit_one_pager_seo.mjs
@@ -1,0 +1,102 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "../dist");
+const onePagerPath = path.join(distDir, "agent-action-audit-kit-one-pager", "index.html");
+
+const origin = "https://safal207.github.io/pythiaLabs";
+const url = `${origin}/agent-action-audit-kit-one-pager/`;
+const title = "Agent Action Audit Kit One-Pager — PythiaLabs";
+const description =
+  "One-page brief for auditing AI-agent actions: one workflow, one evidence chain, one trust report. Built for coding agents, CI/CD, incident response, and internal tool-calling workflows.";
+const image = `${origin}/og.png`;
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      name: title,
+      description,
+      url,
+      isPartOf: {
+        "@type": "WebSite",
+        name: "PythiaLabs",
+        url: origin,
+      },
+      about: [
+        "AI agent safety",
+        "agent action audit",
+        "pre-execution safety gate",
+        "causal audit",
+        "AI governance",
+      ],
+      primaryImageOfPage: {
+        "@type": "ImageObject",
+        url: image,
+      },
+    },
+    {
+      "@type": "Service",
+      name: "Agent Action Audit Kit",
+      serviceType: "AI agent workflow audit",
+      provider: {
+        "@type": "Organization",
+        name: "PythiaLabs",
+        url: origin,
+      },
+      description:
+        "A focused audit for one AI-agent workflow, action class, or trace/log sample. The output is a reviewer-ready evidence chain with ALLOW, BLOCK, or ESCALATE criteria and causal-validity findings.",
+      areaServed: "Worldwide",
+      audience: {
+        "@type": "Audience",
+        audienceType:
+          "AI safety teams, platform engineering teams, security reviewers, compliance reviewers, and AI governance teams",
+      },
+    },
+  ],
+};
+
+const seoHead = `
+  <meta name="description" content="${description}" />
+  <meta name="author" content="Aleksei Safonov" />
+  <meta name="robots" content="index, follow" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <link rel="canonical" href="${url}" />
+  <meta property="og:site_name" content="PythiaLabs" />
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="${description}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="${url}" />
+  <meta property="og:image" content="${image}" />
+  <meta property="og:image:alt" content="PythiaLabs Agent Action Audit Kit one-page brief" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@lim746048" />
+  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:description" content="${description}" />
+  <meta name="twitter:image" content="${image}" />
+  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>`;
+
+const html = await readFile(onePagerPath, "utf8");
+
+const withoutOldDescription = html.replace(
+  /\n\s*<meta name="description" content="Agent Action Audit Kit: one workflow, one evidence chain, one trust report\." \/>/,
+  "",
+);
+
+const updatedTitle = withoutOldDescription.replace(
+  /<title>Agent Action Audit Kit — One-Pager<\/title>/,
+  `<title>${title}</title>`,
+);
+
+const updated = updatedTitle.includes("application/ld+json")
+  ? updatedTitle
+  : updatedTitle.replace("  <style>", `${seoHead}\n  <style>`);
+
+await writeFile(onePagerPath, updated);
+console.log("Injected SEO metadata into Agent Action Audit one-pager.");

--- a/site/src/sitemap.mjs
+++ b/site/src/sitemap.mjs
@@ -7,6 +7,14 @@ function urlFor(id) {
   return id === "en" ? `${origin()}/` : `${origin()}/${id}/`;
 }
 
+const standaloneUrls = [
+  {
+    loc: `${origin()}/agent-action-audit-kit-one-pager/`,
+    changefreq: "monthly",
+    priority: "0.9",
+  },
+];
+
 export function renderSitemap(today = new Date().toISOString().slice(0, 10)) {
   const alternates = (currentId) =>
     localeOrder
@@ -17,7 +25,7 @@ export function renderSitemap(today = new Date().toISOString().slice(0, 10)) {
       .concat(`      <xhtml:link rel="alternate" hreflang="x-default" href="${urlFor("en")}"/>`)
       .join("\n");
 
-  const urls = localeOrder
+  const localizedUrls = localeOrder
     .map(
       (id) => `  <url>
     <loc>${urlFor(id)}</loc>
@@ -29,10 +37,22 @@ ${alternates(id)}
     )
     .join("\n");
 
+  const standalone = standaloneUrls
+    .map(
+      (entry) => `  <url>
+    <loc>${entry.loc}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>${entry.changefreq}</changefreq>
+    <priority>${entry.priority}</priority>
+  </url>`,
+    )
+    .join("\n");
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-${urls}
+${localizedUrls}
+${standalone}
 </urlset>
 `;
 }


### PR DESCRIPTION
Improve SEO for the Agent Action Audit one-pager and site build. Adds sitemap coverage, one-pager metadata, Open Graph/Twitter tags, structured data, and restores readable package.json formatting.