### PR TITLE
docs: add snapshot outreach sequence

### DIFF
--- a/docs/AGENT_ACTION_AUDIT_SNAPSHOT_OUTREACH.md
+++ b/docs/AGENT_ACTION_AUDIT_SNAPSHOT_OUTREACH.md
@@ -1,0 +1,232 @@
+# Agent Action Audit Snapshot Outreach Sequence
+
+Status: commercial outreach playbook.
+
+Goal: contact the first 10-20 teams using AI agents that can touch code, CI/CD, infrastructure, internal tools, or customer workflows.
+
+## Offer ladder
+
+```text
+One-page brief
+-> $197 Snapshot
+-> $497 Snapshot Plus
+-> $1,500-$3,000 Full Audit Pilot
+-> Design Partner Sprint
+```
+
+Do not sell the whole stack first. Sell one bounded review:
+
+```text
+one workflow -> one trust-break map -> one next control
+```
+
+## Core message
+
+```text
+Your AI agent may produce the right output.
+But can you prove it was allowed to do what it did?
+```
+
+## Best targets
+
+Prioritize:
+
+- AI coding-agent teams,
+- DevTools founders,
+- CI/CD platform engineers,
+- AI safety engineers,
+- AI governance reviewers,
+- security reviewers for AI systems,
+- infra automation engineers,
+- open-source maintainers testing agents.
+
+Avoid first:
+
+- teams only using chatbots,
+- people without a concrete workflow,
+- large enterprises with long procurement cycles,
+- customers asking for full production integration before a bounded review.
+
+## Short DM - general
+
+```text
+Hi <Name> - quick question.
+
+Are you using AI agents that can touch code, CI/CD, infra, internal tools, or customer workflows?
+
+I am building Agent Action Audit Snapshot: a small review of one AI-agent workflow.
+
+For $197, we map where trust breaks:
+- what the agent did
+- whether the action was allowed
+- what evidence existed before action
+- whether the workflow should ALLOW, BLOCK, or ESCALATE
+
+Snapshot Plus adds a live walkthrough and hardening roadmap.
+
+Open to testing this on one non-sensitive workflow?
+```
+
+## Short DM - coding agents
+
+```text
+Hi <Name> - saw your work around coding agents / developer tooling.
+
+I am testing a small offer called Agent Action Audit Snapshot.
+
+The question is simple:
+when an AI coding agent changes code, CI, or config, can the team prove the action was allowed before it happened?
+
+For $197, I review one workflow and return a short trust-break map:
+- action boundary
+- evidence available before action
+- missing authorization / review gaps
+- ALLOW / BLOCK / ESCALATE recommendation
+
+Open to trying it on one non-sensitive coding-agent workflow?
+```
+
+## Cold email
+
+Subject options:
+
+```text
+Quick question about AI-agent workflow safety
+One small audit for an AI-agent workflow
+Can your team prove an AI-agent action was allowed?
+```
+
+Email:
+
+```text
+Hi <Name>,
+
+I am Aleksei, building PythiaLabs - an evidence layer for AI-agent actions.
+
+I am opening a small review called Agent Action Audit Snapshot.
+
+The goal is simple: review one AI-agent workflow and show where trust breaks before the workflow scales.
+
+For $197, the Snapshot maps:
+- what the agent did or proposed
+- whether the action was allowed
+- what evidence existed before action
+- what evidence is missing
+- whether the workflow should ALLOW, BLOCK, or ESCALATE
+
+Snapshot Plus is $497 and adds a 45-minute walkthrough plus prioritized hardening roadmap.
+
+Would you be open to reviewing one non-sensitive workflow?
+
+Best,
+Aleksei
+PythiaLabs
+https://safal207.github.io/pythiaLabs/
+```
+
+## Follow-up 1
+
+```text
+Hi <Name> - quick follow-up.
+
+The smallest useful version is just one workflow:
+
+1 agent action class
+1 redacted trace/log/example
+1 short evidence-risk Snapshot
+
+The question we answer is:
+where does trust break before the agent scales?
+
+If useful, I can send the one-page brief.
+```
+
+## Follow-up 2
+
+```text
+Hi <Name> - closing the loop.
+
+I am looking for a few early workflows to test Agent Action Audit Snapshot.
+
+Best fit:
+- coding-agent PR changes
+- CI/CD autofix
+- incident-response agents
+- internal tool calls
+- agentic governance review
+
+No sensitive data needed - a redacted workflow is enough.
+
+Would it make sense to review one example?
+```
+
+## X / LinkedIn post
+
+```text
+AI agents will not be trusted only because they produce good outputs.
+
+They will be trusted when teams can prove:
+
+- why an action happened
+- whether it was allowed
+- what evidence existed before action
+- what should be blocked or escalated next time
+
+I am opening a small Agent Action Audit Snapshot:
+
+one workflow -> one trust-break map -> one clear next control.
+```
+
+## Reply: when someone says interesting
+
+```text
+Great - the easiest next step is to pick one bounded workflow.
+
+For example:
+- coding agent opens a PR
+- CI/autofix agent changes config
+- incident agent proposes an action
+- internal agent calls a tool
+
+I do not need sensitive data. A redacted workflow description or trace/log sample is enough.
+
+The Snapshot output is a short evidence-risk review with ALLOW / BLOCK / ESCALATE and top controls before scaling.
+```
+
+## Reply: what do you need?
+
+```text
+For the Snapshot, I need:
+
+1. Workflow / agent system
+2. Action class
+3. What the agent can execute today
+4. What logs/traces can be safely shared
+5. What could go wrong
+6. Current stage: prototype / pilot / production / exploring
+
+Please do not include secrets, credentials, customer data, regulated data, or sensitive production details.
+```
+
+## Reply: why not just use logs?
+
+```text
+Logs show that something happened.
+
+The Snapshot asks a different question:
+was the action allowed and evidenced before it happened?
+
+The review maps action boundary, evidence before action, permission gap, replayability gap, causal-validity gap, and next control.
+
+So this complements observability rather than replacing it.
+```
+
+## Daily execution target
+
+```text
+Send 10 targeted messages.
+Track every response.
+Ask for one non-sensitive workflow.
+```
+
+The first proof is one real workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 - [Agent Action Audit Snapshot](AGENT_ACTION_AUDIT_SNAPSHOT.md) — small paid OTO / entry offer for one workflow before a full audit pilot.
 - [Agent Action Audit Snapshot Plus](AGENT_ACTION_AUDIT_SNAPSHOT_PLUS.md) — $497 upsell with live walkthrough and prioritized hardening roadmap after the Snapshot.
 - [Agent Action Audit Outreach Pack](AGENT_ACTION_AUDIT_OUTREACH.md) — outbound messages, discovery-call structure, qualification questions, and objection handling for first pilots.
+- [Agent Action Audit Snapshot Outreach Sequence](AGENT_ACTION_AUDIT_SNAPSHOT_OUTREACH.md) — short DM, cold email, follow-up, and objection scripts for the $197/$497 offer ladder.
 - [Agent Action Audit Report Template](AGENT_ACTION_AUDIT_REPORT_TEMPLATE.md) — customer-facing pilot deliverable template for one workflow, action class, or trace/log sample.
 - [Agent Action Audit Sample Report](AGENT_ACTION_AUDIT_SAMPLE_REPORT.md) — filled synthetic report for a coding-agent CI autofix workflow showing the expected customer-facing output.
 - [Research Roadmap](research_roadmap.md)


### PR DESCRIPTION
Add a compact outreach playbook for the $197 Agent Action Audit Snapshot and $497 Snapshot Plus offer ladder. Includes short DMs, cold email, follow-ups, objection replies, and a daily execution target.