### PR TITLE
docs: link related ProofPath prototype

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 
 - [Research Roadmap](research_roadmap.md)
 - [Open Agentic Models Need Evidence Gates](open_agentic_models_need_evidence_gates.md)
+- [Related Prototype: ProofPath](related_proofpath.md) — explains how ProofPath serves as a separate runnable protocol/gateway lab for the PythiaLabs evidence-gate idea.
 - [Positioning vs. Transaction Simulation Tools](positioning_vs_transaction_simulation.md) — clarifies that PythiaLabs is not a Web3 transaction simulator; it is a pre-execution evidence gate for AI-agent proposed actions before tools are called.
 - [AI Coding Agents and CI Autofix Use Case](ai_coding_agents_ci_autofix_use_case.md) — documents how PythiaLabs can gate autonomous coding-agent and CI autofix actions before tools are called.
 

--- a/docs/related_proofpath.md
+++ b/docs/related_proofpath.md
@@ -1,0 +1,70 @@
+# Related prototype: ProofPath
+
+ProofPath is a separate open-source repository that implements a small, runnable reference prototype of the PythiaLabs evidence-gate idea.
+
+Repository:
+
+https://github.com/safal207/ProofPath
+
+## Relationship to PythiaLabs
+
+PythiaLabs is the broader evidence-gate research/product framing:
+
+```text
+Should this high-risk AI-agent action be allowed, blocked, or escalated under current evidence?
+```
+
+ProofPath is a minimal protocol/gateway laboratory focused on HTTP/API actions:
+
+```text
+agent action -> ProofPath decision -> forward or block -> audit trail
+```
+
+They are not the same project.
+
+ProofPath is useful as a runnable reference implementation and community lab for one concrete form of evidence gate.
+
+## Why this matters
+
+A model or agent can have valid tool access, credentials, and HTTPS transport while still proposing an invalid or unsafe action.
+
+ProofPath demonstrates a pre-execution action boundary that checks:
+
+- declared intent;
+- causal parent;
+- action scope;
+- reversibility;
+- human approval when required;
+- gateway decision;
+- auditability.
+
+## Current ProofPath artifacts
+
+ProofPath currently includes:
+
+- protocol draft;
+- Rust verifier;
+- Axum gateway;
+- upstream forwarding;
+- dangerous AI-agent action demo;
+- real-model-agent demo;
+- hash-chained JSONL audit log;
+- community experiment levels.
+
+Core line:
+
+> HTTPS protects the connection. ProofPath protects the meaning of the action.
+
+## Positioning
+
+Use ProofPath as:
+
+```text
+A runnable reference implementation of pre-execution action gates for AI agents.
+```
+
+Use PythiaLabs as:
+
+```text
+The broader deterministic evidence-gate framework for high-risk agentic actions.
+```


### PR DESCRIPTION
## Summary

Adds a documentation link from PythiaLabs to ProofPath as a separate related prototype.

## Added

- `docs/related_proofpath.md`
  - explains that ProofPath is a separate runnable protocol/gateway lab for the PythiaLabs evidence-gate idea
  - maps PythiaLabs as the broader deterministic evidence-gate framework and ProofPath as a minimal HTTP/API action-boundary implementation
- `docs/README.md` link under Research and Positioning

## Why

PythiaLabs already frames the core problem as deterministic evidence gates for high-risk agentic actions. ProofPath now provides a concrete reference implementation and community lab that reviewers and grantmakers can run separately.

## Positioning

PythiaLabs remains the broader evidence-gate framework.

ProofPath is the separate runnable protocol/gateway reference prototype.