### PR TITLE
docs: link PythiaLabs to LS grant path

### DIFF
--- a/docs/RELATED_LS_GRANT_PATH.md
+++ b/docs/RELATED_LS_GRANT_PATH.md
@@ -1,0 +1,48 @@
+# Related LS Grant Path
+
+PythiaLabs is part of a broader Liminal research and tooling ecosystem around deterministic oversight, continuity, causal validity, and evidence-gated agent actions.
+
+## Relationship to LS
+
+- **LS:** session continuity, repair, human-owned cognitive artifacts, outreach/audit packaging, and AI co-work continuity reports.
+- **PythiaLabs:** deterministic evidence gates for high-risk agentic actions before tools are called.
+- **CML:** causal validity and authorization-lineage checking for sensitive actions.
+- **LTP:** deterministic replay and trace inspection for agent execution paths.
+
+In the LS stack, PythiaLabs answers:
+
+```text
+Before an agent acts, does it have enough evidence, authorization, freshness, and recovery context to proceed?
+```
+
+LS answers the complementary question:
+
+```text
+Before an agent continues, writes memory, or acts, is the session context continuous enough to trust?
+```
+
+## Reviewer path
+
+For grant or reviewer context, start with:
+
+- LS repository: https://github.com/safal207/LS
+- LS Session Continuity Repair Layer: https://github.com/safal207/LS/blob/main/docs/SESSION_CONTINUITY_REPAIR_LAYER.md
+- LS ecosystem map: https://github.com/safal207/LS/blob/main/docs/ECOSYSTEM_INTEGRATION_MAP.md
+- LS AI Co-work Continuity Audit offer: https://github.com/safal207/LS/blob/main/docs/offers/AI_COWORK_CONTINUITY_AUDIT.md
+- Causal Memory Layer: https://github.com/safal207/Causal-Memory-Layer
+- Liminal Thread Protocol: https://github.com/safal207/L-THREAD-Liminal-Thread-Secure-Protocol-LTP-
+
+## Positioning boundary
+
+PythiaLabs should not be presented as the whole LS stack.
+
+It is the action/evidence-gate primitive inside the broader LS grant path:
+
+```text
+continuity check
+-> causal validity check
+-> evidence/action gate
+-> trace/replay/audit artifact
+```
+
+This keeps the repository focused while making the broader research system visible to grant reviewers.


### PR DESCRIPTION
## Summary

Adds a reviewer-facing document that links PythiaLabs to the broader LS grant path.

## Added

- `docs/RELATED_LS_GRANT_PATH.md`

## Why

PythiaLabs is the deterministic evidence/action-gate primitive in the broader LS ecosystem. This makes that relationship explicit for grant reviewers without broadening PythiaLabs beyond its focused scope.

## Relationship

```text
LS -> session continuity and repair
ausal Memory Layer -> causal validity and authorization lineage
PythiaLabs -> evidence gates before high-risk agent actions
LTP -> deterministic replay and trace inspection
```

## Testing

Documentation-only change.