### PR TITLE
docs: add LS grant path link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a concise reviewer-facing overview, see:
 
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
+- **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
 - **Support-safety gate demo:** https://youtu.be/A6UAR3e2r3k
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)


### PR DESCRIPTION
## Summary

Adds a visible README link to the related LS grant path document.

## Updated

- `README.md`

## Why

This makes the broader LS ecosystem connection visible from the PythiaLabs landing page for grant reviewers.

## Testing

Documentation-only change.