### PR TITLE
docs: add LS grant path link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a concise reviewer-facing overview, see:
 
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
+- **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
 - **Support-safety gate demo:** https://youtu.be/A6UAR3e2r3k
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)


### PR DESCRIPTION
## Summary

Superseded by the newer ProofPath continuation work.

The intended README-level reviewer path is now covered by the merged continuation note and README link:

- #168 added `docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md`
- #170 linked that continuation note from the README

This older PR is closed to keep the board clean.

## Status

Closed as superseded.