### PR TITLE
Link ProofPath continuation note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For a concise reviewer-facing overview, see:
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
 - **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
+- **ProofPath continuation for reviewers:** [`docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md`](docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
 - **Support-safety gate demo:** https://youtu.be/A6UAR3e2r3k
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)


### PR DESCRIPTION
## Summary

Links the ProofPath continuation note from the PythiaLabs README project summary.

## Updated

- `README.md`
  - adds `ProofPath continuation for reviewers` next to the existing reviewer-facing links.

## Why

Reviewers arriving from already-submitted grant applications should not need to know the filename under `docs/`. This keeps the route to the current ProofPath / Compute Witness executable evidence layer visible and native.

## Issue

Refs #169