### PR TITLE
Link ProofPath continuation note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For a concise reviewer-facing overview, see:
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
 - **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
+- **ProofPath continuation for reviewers:** [`docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md`](docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md)
 - **Demo video:** https://youtu.be/IUk3iO0N4YU
 - **Support-safety gate demo:** https://youtu.be/A6UAR3e2r3k
 - **Landing page:** [`site/`](site/) (deployable via GitHub Pages)


### PR DESCRIPTION
## Summary

Superseded by the already-merged README link work.

The intended README link to `docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md` was merged in #170. This PR is a duplicate/stale open PR and is closed to keep the board clean.

## Status

Closed as superseded / duplicate.