### PR TITLE
fix: bug audit batch — canonicalization, scoring, kernels, tests

### DIFF
--- a/lib/pythia.ex
+++ b/lib/pythia.ex
@@ -47,6 +47,10 @@ defmodule Pythia do
            best: result.best,
            trace: result.trace
          }}
+      else
+        {:error, reason} when is_atom(reason) -> {:error, reason}
+        {:error, _} -> {:error, :refine_failed}
+        _ -> {:error, :refine_failed}
       end
     else
       {:error, :invalid_request}

--- a/lib/pythia/kernels.ex
+++ b/lib/pythia/kernels.ex
@@ -1,15 +1,25 @@
 defmodule Pythia.Kernels do
   @moduledoc "Rust NIF wrapper with safe fallback."
   use Rustler, otp_app: :liminal_pythia, crate: "fast_kernels"
+  require Logger
   alias Pythia.KernelsFallback
 
   def levenshtein(a, b) when is_binary(a) and is_binary(b) do
     try do
       levenshtein_nif(a, b)
     rescue
-      _ -> KernelsFallback.levenshtein(a, b)
-    catch
-      :exit, _ -> KernelsFallback.levenshtein(a, b)
+      e in [ErlangError, UndefinedFunctionError] ->
+        case e do
+          %ErlangError{original: :nif_not_loaded} ->
+            KernelsFallback.levenshtein(a, b)
+
+          %UndefinedFunctionError{} ->
+            KernelsFallback.levenshtein(a, b)
+
+          other ->
+            Logger.warning("levenshtein NIF raised #{inspect(other)}; falling back")
+            KernelsFallback.levenshtein(a, b)
+        end
     end
   end
 

--- a/lib/pythia/kernels_fallback.ex
+++ b/lib/pythia/kernels_fallback.ex
@@ -1,26 +1,40 @@
 defmodule Pythia.KernelsFallback do
-  @moduledoc "Pure Elixir fallback (slower)."
-  def levenshtein(a, b), do: do_lev(String.graphemes(a), String.graphemes(b))
+  @moduledoc """
+  Pure Elixir fallback for `Pythia.Kernels.levenshtein/2`.
+
+  Operates on Unicode codepoints (`String.to_charlist/1`) so behaviour
+  matches the Rust NIF, which iterates via `str::chars()`. Uses a tuple
+  for the previous DP row to keep indexed reads O(1), giving overall
+  O(m·n) time.
+  """
+
+  def levenshtein(a, b) when is_binary(a) and is_binary(b) do
+    do_lev(String.to_charlist(a), String.to_charlist(b))
+  end
 
   defp do_lev([], ys), do: length(ys)
   defp do_lev(xs, []), do: length(xs)
 
   defp do_lev(xs, ys) do
     n = length(ys)
-    row0 = Enum.to_list(0..n)
+    initial_prev = List.to_tuple(Enum.to_list(0..n))
+    indexed_ys = Enum.with_index(ys, 1)
 
-    Enum.with_index(xs, 1)
-    |> Enum.reduce(row0, fn {xi, i}, prev_row ->
-      Enum.with_index(ys, 1)
-      |> Enum.reduce([i], fn {yj, j}, acc ->
-        cost = if xi == yj, do: 0, else: 1
-        insert = hd(acc) + 1
-        delete = Enum.at(prev_row, j) + 1
-        replace = Enum.at(prev_row, j - 1) + cost
-        [Enum.min([insert, delete, replace]) | acc]
-      end)
-      |> Enum.reverse()
+    xs
+    |> Enum.with_index(1)
+    |> Enum.reduce(initial_prev, fn {xi, i}, prev_row ->
+      {curr_rev, _last} =
+        Enum.reduce(indexed_ys, {[i], i}, fn {yj, j}, {acc, prev_in_row} ->
+          cost = if xi == yj, do: 0, else: 1
+          insert = prev_in_row + 1
+          delete = elem(prev_row, j) + 1
+          replace = elem(prev_row, j - 1) + cost
+          new_val = min(insert, min(delete, replace))
+          {[new_val | acc], new_val}
+        end)
+
+      curr_rev |> Enum.reverse() |> List.to_tuple()
     end)
-    |> List.last()
+    |> elem(n)
   end
 end

--- a/lib/pythia/planner.ex
+++ b/lib/pythia/planner.ex
@@ -1,7 +1,7 @@
 defmodule Pythia.Planner do
   @moduledoc "HRM-like outer loop: propose → run → measure → refine (string demo)."
   require Logger
-  alias Pythia.Executor
+  alias Pythia.{Critic, Executor, Kernels}
 
   defstruct problem: nil,
             objective: nil,
@@ -87,7 +87,7 @@ defmodule Pythia.Planner do
         finalize(p, :threshold)
 
       no_improve >= p.no_improve_limit ->
-        _ = critic
+        _ = Critic.advise(p.state, p.trace)
         finalize(p, :no_improve_limit)
 
       true ->
@@ -96,15 +96,23 @@ defmodule Pythia.Planner do
   end
 
   defp finalize(p, stop_reason) do
+    best = ensure_numeric_best(p.best, p.objective)
+
     :telemetry.execute(
       [:pythia, :planner, :stop],
       %{steps: p.step},
-      %{trace_id: p.trace_id, stop_reason: stop_reason, best_score: p.best.score}
+      %{trace_id: p.trace_id, stop_reason: stop_reason, best_score: best.score}
     )
 
     Logger.info("pythia_stop trace_id=#{p.trace_id} steps=#{p.step} reason=#{stop_reason}")
-    {:ok, %{best: p.best, steps: p.step, stop_reason: stop_reason, trace: Enum.reverse(p.trace)}}
+    {:ok, %{best: best, steps: p.step, stop_reason: stop_reason, trace: Enum.reverse(p.trace)}}
   end
+
+  defp ensure_numeric_best(%{score: :infinity, candidate: candidate}, objective) do
+    %{candidate: candidate, score: Kernels.levenshtein(candidate, objective)}
+  end
+
+  defp ensure_numeric_best(best, _objective), do: best
 
   defp propose(current, target) do
     {prefix, c_rest, t_rest} = longest_common_prefix(current, target)

--- a/lib/pythia/showcase/web3_treasury_action.ex
+++ b/lib/pythia/showcase/web3_treasury_action.ex
@@ -259,12 +259,14 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
       when is_map(envelope) and is_binary(signer_id) do
     with :ok <- validate_demo_signer_id(signer_id),
          {:ok, _verified_unsigned_envelope} <- verify_evidence_envelope(envelope) do
+      canonical_signer_id = String.trim(signer_id)
+
       {:ok,
        Map.put(envelope, "signature", %{
          "status" => "signed_demo",
          "algorithm" => "sha256-demo",
-         "signer_id" => signer_id,
-         "signature" => demo_signature(envelope, signer_id)
+         "signer_id" => canonical_signer_id,
+         "signature" => demo_signature(envelope, canonical_signer_id)
        })}
     end
   end
@@ -284,7 +286,11 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
          :ok <- verify_signed_signature_algorithm(signature),
          :ok <- verify_signed_signer_id(signature),
          :ok <- verify_signed_signature_digest(signature),
-         true <- signature["signature"] == demo_signature(envelope, signature["signer_id"]) do
+         true <-
+           secure_equal?(
+             signature["signature"],
+             demo_signature(envelope, signature["signer_id"])
+           ) do
       {:ok,
        %{
          status: :verified,
@@ -500,19 +506,44 @@ defmodule Pythia.Showcase.Web3TreasuryAction do
     "\"" <> escape_string(value) <> "\""
   end
 
-  defp canonical_encode(value) when is_number(value), do: to_string(value)
+  defp canonical_encode(value) when is_integer(value), do: Integer.to_string(value)
+  defp canonical_encode(value) when is_float(value), do: :erlang.float_to_binary(value, [:short])
   defp canonical_encode(true), do: "true"
   defp canonical_encode(false), do: "false"
   defp canonical_encode(nil), do: "null"
 
   defp escape_string(value) do
     value
-    |> String.replace("\\", "\\\\")
-    |> String.replace("\"", "\\\"")
-    |> String.replace("\n", "\\n")
-    |> String.replace("\r", "\\r")
-    |> String.replace("\t", "\\t")
+    |> String.to_charlist()
+    |> Enum.map_join(&escape_codepoint/1)
   end
+
+  defp escape_codepoint(?\\), do: "\\\\"
+  defp escape_codepoint(?"), do: "\\\""
+  defp escape_codepoint(?\n), do: "\\n"
+  defp escape_codepoint(?\r), do: "\\r"
+  defp escape_codepoint(?\t), do: "\\t"
+  defp escape_codepoint(?\b), do: "\\b"
+  defp escape_codepoint(?\f), do: "\\f"
+
+  defp escape_codepoint(codepoint) when codepoint in 0..31 do
+    "\\u" <> (codepoint |> Integer.to_string(16) |> String.pad_leading(4, "0"))
+  end
+
+  defp escape_codepoint(codepoint), do: <<codepoint::utf8>>
+
+  defp secure_equal?(a, b)
+       when is_binary(a) and is_binary(b) and byte_size(a) == byte_size(b) do
+    import Bitwise
+
+    a
+    |> :binary.bin_to_list()
+    |> Enum.zip(:binary.bin_to_list(b))
+    |> Enum.reduce(0, fn {x, y}, acc -> bor(acc, bxor(x, y)) end)
+    |> Kernel.==(0)
+  end
+
+  defp secure_equal?(_, _), do: false
 
   defp run_checks(action, governance_record, trace) do
     Enum.reduce_while(@check_order, {:ok, trace}, fn check, {:ok, acc_trace} ->

--- a/test/port_worker_test.exs
+++ b/test/port_worker_test.exs
@@ -5,28 +5,44 @@ defmodule Pythia.PortWorkerTest do
   @binary Path.join([@worker_dir, "target", "release", "solver_port"])
 
   setup_all do
-    unless File.exists?(@binary) do
-      case System.find_executable("cargo") do
-        nil ->
-          :ok
+    cond do
+      File.exists?(@binary) ->
+        :ok
 
-        cargo ->
-          {_, 0} =
-            System.cmd(cargo, ["build", "--release"],
-              cd: @worker_dir,
-              stderr_to_stdout: true
-            )
-      end
+      cargo = System.find_executable("cargo") ->
+        {output, code} =
+          System.cmd(cargo, ["build", "--release"],
+            cd: @worker_dir,
+            stderr_to_stdout: true
+          )
+
+        if code != 0 do
+          raise "cargo build failed with exit #{code}:\n#{output}"
+        end
+
+        unless File.exists?(@binary) do
+          raise "cargo build succeeded but binary not found at #{@binary}"
+        end
+
+        :ok
+
+      true ->
+        :ok
     end
-
-    :ok
   end
 
   defp open_worker do
-    if File.exists?(@binary) do
-      Port.open({:spawn_executable, @binary}, [:binary, args: [], packet: 4])
-    else
-      {:error, :binary_missing}
+    cond do
+      File.exists?(@binary) ->
+        Port.open({:spawn_executable, @binary}, [:binary, args: [], packet: 4])
+
+      is_nil(System.find_executable("cargo")) ->
+        {:error, :no_cargo}
+
+      true ->
+        ExUnit.Assertions.flunk(
+          "solver_port binary missing at #{@binary} despite cargo being available"
+        )
     end
   end
 
@@ -42,7 +58,7 @@ defmodule Pythia.PortWorkerTest do
 
   test "packet:4 round-trip returns shortest path length" do
     case open_worker() do
-      {:error, :binary_missing} ->
+      {:error, :no_cargo} ->
         IO.puts(:stderr, "[port_worker_test] binary missing, skipping")
 
       port ->
@@ -70,7 +86,7 @@ defmodule Pythia.PortWorkerTest do
 
   test "worker reports validation error for malformed grid" do
     case open_worker() do
-      {:error, :binary_missing} ->
+      {:error, :no_cargo} ->
         IO.puts(:stderr, "[port_worker_test] binary missing, skipping")
 
       port ->
@@ -92,7 +108,7 @@ defmodule Pythia.PortWorkerTest do
 
   test "worker handles multiple frames on the same port" do
     case open_worker() do
-      {:error, :binary_missing} ->
+      {:error, :no_cargo} ->
         IO.puts(:stderr, "[port_worker_test] binary missing, skipping")
 
       port ->


### PR DESCRIPTION
## Summary

Глубокий аудит выявил баги в канонизации, scoring-логике планировщика, расхождение Rust NIF vs Elixir fallback, и тихо-зелёный тест port worker. Этот PR чинит всё подтверждённое.

### Что починено

| Severity | Файл | Что |
|----------|------|-----|
| HIGH | `lib/pythia/showcase/web3_treasury_action.ex` | `escape_string` теперь покрывает `\b`, `\f`, control codepoints 0..31. Числа сериализуются через `Integer.to_string` / `:erlang.float_to_binary(..., :short)` — формат совпал с `banking_risk_action.ex` |
| HIGH | `lib/pythia/planner.ex` | `ensure_numeric_best/2` в `finalize/2` гарантирует, что `best.score` всегда `non_neg_integer()` — раньше при `max_steps: 0` возвращался атом `:infinity`, нарушая `refine_v1_response` |
| MEDIUM | `lib/pythia/kernels_fallback.ex` | Перешёл с `String.graphemes` на `String.to_charlist`, чтобы поведение совпало с Rust NIF (`str::chars()`). Внутренний цикл переписан через tuple-индексацию → O(m·n) вместо O(m·n²) |
| MEDIUM | `lib/pythia/kernels.ex` | `rescue` сужен до `ErlangError` / `UndefinedFunctionError`. Неожиданные ошибки NIF логируются до fallback, чтобы реальные баги NIF не маскировались |
| MEDIUM | `lib/pythia/showcase/web3_treasury_action.ex` | Сравнение подписи — constant-time `secure_equal?`. `signer_id` тримится до подписи, чтобы trimmed/untrimmed формы не расходились |
| MEDIUM | `lib/pythia/planner.ex` | `Critic.advise(state, trace)` реально вызывается на выходе по `:no_improve_limit` (был мёртвый `_ = critic`) |
| MEDIUM | `test/port_worker_test.exs` | Если cargo есть, а бинаря/сборки нет — громкое `raise`/`flunk`. Тихий скип только когда cargo отсутствует |
| LOW | `lib/pythia.ex` | `with` в `refine_v1/1` получил `else`-ветку |

### Что я НЕ трогал и почему

- Tamper-test в `test/web3_treasury_payload_tamper_invariant_test.exs` — при перечитывании увидел, что он уже корректно фильтрует пустые подмены (строка 164) и ассертит `tampered != original` (строка 187). Это был мой ложный сигнал.
- Несколько HIGH-claim’ов от автоматических агентов (byte-vs-char в `executor.ex`, `:infinity` крэш, `usize`-overflow в Rust BFS, bounds-check в `bfs()`) при ручной верификации оказались ложными.

## Test plan

- [ ] `mix compile --warnings-as-errors`
- [ ] `mix test` (полный прогон — в окружении web’а Elixir отсутствует, не смог прогнать локально)
- [ ] Проверить, что `test/planner_test.exs` `"stops by no_improve_limit when objective cannot improve"` всё ещё ожидает `steps: 4` — `ensure_numeric_best` срабатывает только когда score реально `:infinity`, поэтому существующие пути не задеты
- [ ] Проверить, что demo-подпись для уже подписанных и сохранённых envelope’ов остаётся прежней (изменения в `canonical_encode` чисел и `escape_string` могут сменить digest, если payload содержал `\b`/`\f`/control chars — в фикстурах их нет)
- [ ] `cargo build --release` для `workers/solver_port` и `mix test test/port_worker_test.exs`

https://claude.ai/code/session_01GBFeHJFeWpBThNMTiqNnAP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBFeHJFeWpBThNMTiqNnAP)_