### PR TITLE
docs: add architecture diagram link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a concise reviewer-facing overview, see:
 
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
+- **Architecture diagram:** [`docs/architecture_diagram.md`](docs/architecture_diagram.md)
 - **OTF reviewer path:** [`docs/OTF_REVIEWER_PATH.md`](docs/OTF_REVIEWER_PATH.md)
 - **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
 - **ProofPath continuation for reviewers:** [`docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md`](docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md)


### PR DESCRIPTION
## Summary

- Add a reviewer-friendly README link to docs/architecture_diagram.md

## Scope

- README-only documentation change
- No site/build files changed
- No demo/product logic changed

Closes #177