### PR TITLE
docs: add reviewer evidence links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For a concise reviewer-facing overview, see:
 - **One-page summary:** [`docs/PYTHIALABS_ONE_PAGE_SUMMARY.md`](docs/PYTHIALABS_ONE_PAGE_SUMMARY.md)
 - **Documentation index:** [`docs/README.md`](docs/README.md)
 - **Architecture diagram:** [`docs/architecture_diagram.md`](docs/architecture_diagram.md)
+- **Paid review demo reviewer checklist:** [`docs/paid_review_demo_reviewer_checklist.md`](docs/paid_review_demo_reviewer_checklist.md)
+- **Evidence artifact schema:** [`docs/evidence_artifact_schema.md`](docs/evidence_artifact_schema.md)
 - **OTF reviewer path:** [`docs/OTF_REVIEWER_PATH.md`](docs/OTF_REVIEWER_PATH.md)
 - **Related LS grant path:** [`docs/RELATED_LS_GRANT_PATH.md`](docs/RELATED_LS_GRANT_PATH.md)
 - **ProofPath continuation for reviewers:** [`docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md`](docs/PROOFPATH_CONTINUATION_FOR_REVIEWERS.md)


### PR DESCRIPTION
## Summary\n- Add root README links to the paid review demo reviewer checklist\n- Add root README link to the evidence artifact schema\n\n## Notes\nThis keeps the PR limited to README navigation, following the maintainer's suggested documentation-only scope.