### PR TITLE
docs: add OpenHands-compatible evidence gate decision event

### DIFF
--- a/docs/integrations/OPENHANDS_EVIDENCE_GATE_DECISION_EVENT.md
+++ b/docs/integrations/OPENHANDS_EVIDENCE_GATE_DECISION_EVENT.md
@@ -1,0 +1,120 @@
+# OpenHands-compatible Evidence Gate Decision Event
+
+Status: experimental interoperability note, not an OpenHands feature or endorsement.
+
+## Purpose
+
+This note defines an optional reviewer-facing event that can be emitted after an action has been assessed and before its tool call is dispatched.
+
+It does not replace the OpenHands security analyzer, policy rails, confirmation policy, event log, sandboxing, or human review. It only packages the decision context into one exportable record.
+
+## Why a separate event
+
+The current OpenHands `ActionEvent` already records the action identity, tool call, summary, model reasoning, and `security_risk`. Deterministic policy rails can also produce stable rule names and reasons.
+
+The missing reviewer-facing unit is a single record that binds together:
+
+- the evaluated `ActionEvent`;
+- the security assessment;
+- matched deterministic rules;
+- evidence that was present, missing, stale, or redacted;
+- an authorization decision;
+- the runtime interaction used to satisfy that decision;
+- the policy version and replay digests.
+
+## Decision versus interaction
+
+These concepts should remain separate:
+
+| Policy decision | Meaning | Runtime interaction |
+|---|---|---|
+| `ALLOW` | The current evidence and policy permit dispatch. | Usually `NONE`. |
+| `BLOCK` | A hard rule denies dispatch and cannot be overridden by ordinary confirmation. | `DENY`. |
+| `ESCALATE` | The action may be valid but requires an authorized reviewer. | OpenHands can use `CONFIRM` to satisfy the escalation. |
+
+`ESCALATE` is the decision; `CONFIRM` is the interaction mechanism.
+
+## Mapping to OpenHands SDK concepts
+
+| Proposed field | OpenHands source |
+|---|---|
+| `action_event_id` | `ActionEvent.id` |
+| `timestamp` | event timestamp or gate-evaluation timestamp |
+| `tool_call_id` | `ActionEvent.tool_call_id` |
+| `tool_name` | `ActionEvent.tool_name` |
+| `action_summary` | `ActionEvent.summary` |
+| `security_assessment.risk` | `ActionEvent.security_risk` |
+| `matched_rules[].rule_id` | stable policy-rail ID, external policy ID, or evidence-check ID |
+| `matched_rules[].reason` | `RailDecision.reason` or equivalent deterministic reason |
+| `gate_decision.runtime_interaction` | result expected from the confirmation policy |
+
+## Suggested emission point
+
+```text
+ActionEvent created
+-> security analyzer and deterministic rails evaluated
+-> optional external policy/evidence checks evaluated
+-> EvidenceGateDecisionEvent emitted
+-> ALLOW dispatches, BLOCK denies, ESCALATE requests confirmation
+```
+
+The event can remain outside the LLM-visible conversation and be stored as a reviewer/export artifact.
+
+## Minimal fields
+
+```json
+{
+  "schema_version": "pythia.openhands.evidence_gate_decision.v0.1",
+  "event_type": "evidence_gate_decision",
+  "event_id": "gate_evt_01",
+  "timestamp": "2026-06-19T10:00:00Z",
+  "source": "security",
+  "action_event_id": "action_evt_01",
+  "tool_call_id": "tool_call_01",
+  "tool_name": "terminal",
+  "action_summary": "modify production deployment workflow",
+  "security_assessment": {
+    "risk": "HIGH",
+    "basis": "ensemble"
+  },
+  "gate_decision": {
+    "decision": "ESCALATE",
+    "runtime_interaction": "CONFIRM",
+    "decision_basis": "hybrid",
+    "stop_reasons": [
+      "OWNER_APPROVAL_REQUIRED",
+      "PRODUCTION_SCOPE_REQUIRES_REVIEW"
+    ]
+  },
+  "matched_rules": [],
+  "evidence_refs": [],
+  "policy_context": {
+    "policy_id": "repo-production-change-policy",
+    "policy_version": "1",
+    "policy_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "replay": {
+    "replayable": true,
+    "canonical_input_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "decision_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "sensitive_data_redacted": true
+}
+```
+
+## Concrete reviewer scenario
+
+An agent proposes changing a production deployment workflow and rotating a secret reference.
+
+A normal trajectory can show the command, reasoning, risk, and human confirmation. The decision event additionally answers:
+
+1. Was the workflow in the authorized task scope?
+2. Was only a secret reference changed, or was secret material read?
+3. Which rule required approval?
+4. Which evidence was missing at decision time?
+5. Which policy version produced the decision?
+6. Can the same normalized inputs be replayed against that policy version?
+
+## Non-claims
+
+This experimental event does not prove that an action is correct, secure, compliant, or safe. It does not define production authorization, identity verification, or cryptographic signing. It is a small interoperability proposal for structured review and replay.

--- a/schemas/integrations/openhands_evidence_gate_decision_event.schema.json
+++ b/schemas/integrations/openhands_evidence_gate_decision_event.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence Gate Decision Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_type",
+    "event_id",
+    "timestamp",
+    "source",
+    "action_event_id",
+    "tool_call_id",
+    "tool_name",
+    "security_assessment",
+    "gate_decision",
+    "matched_rules",
+    "evidence_refs",
+    "policy_context",
+    "replay"
+  ],
+  "properties": {
+    "schema_version": {"const": "pythia.openhands.evidence_gate_decision.v0.1"},
+    "event_type": {"const": "evidence_gate_decision"},
+    "event_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "source": {"const": "security"},
+    "action_event_id": {"type": "string", "minLength": 1},
+    "tool_call_id": {"type": "string", "minLength": 1},
+    "tool_name": {"type": "string", "minLength": 1},
+    "action_summary": {"type": ["string", "null"]},
+    "security_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["risk", "basis"],
+      "properties": {
+        "risk": {"enum": ["UNKNOWN", "LOW", "MEDIUM", "HIGH"]},
+        "basis": {"enum": ["openhands_analyzer", "policy_rail", "ensemble", "external"]},
+        "analyzer_id": {"type": ["string", "null"]}
+      }
+    },
+    "gate_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "runtime_interaction", "decision_basis", "stop_reasons"],
+      "properties": {
+        "decision": {"enum": ["ALLOW", "BLOCK", "ESCALATE"]},
+        "runtime_interaction": {"enum": ["NONE", "CONFIRM", "DENY"]},
+        "decision_basis": {"enum": ["deterministic", "model_assisted", "hybrid"]},
+        "stop_reasons": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "rationale": {"type": ["string", "null"]}
+      }
+    },
+    "matched_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "layer", "outcome", "reason"],
+        "properties": {
+          "rule_id": {"type": "string", "minLength": 1},
+          "layer": {"enum": ["openhands_policy_rail", "external_policy", "evidence_gate"]},
+          "outcome": {"enum": ["PASS", "FAIL", "REQUIRE_APPROVAL"]},
+          "reason": {"type": "string"}
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["evidence_id", "evidence_type", "status"],
+        "properties": {
+          "evidence_id": {"type": "string", "minLength": 1},
+          "evidence_type": {"type": "string", "minLength": 1},
+          "status": {"enum": ["PRESENT", "MISSING", "STALE", "REDACTED"]},
+          "digest": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+        }
+      }
+    },
+    "policy_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "policy_version", "policy_hash"],
+      "properties": {
+        "policy_id": {"type": "string", "minLength": 1},
+        "policy_version": {"type": "string", "minLength": 1},
+        "policy_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "evaluator_version": {"type": ["string", "null"]}
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["replayable", "canonical_input_digest", "decision_digest"],
+      "properties": {
+        "replayable": {"type": "boolean"},
+        "canonical_input_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "decision_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "sensitive_data_redacted": {"type": "boolean", "default": true}
+  }
+}


### PR DESCRIPTION
## Summary

Adds a schema-first interoperability proposal for a reviewer-facing evidence-gate decision event that can map onto the existing OpenHands `ActionEvent`, security analyzer, deterministic policy rails, and confirmation flow.

## Included

- JSON Schema for `pythia.openhands.evidence_gate_decision.v0.1`;
- mapping from OpenHands SDK fields to the proposed event;
- explicit separation of policy decisions (`ALLOW` / `BLOCK` / `ESCALATE`) from runtime interactions (`NONE` / `CONFIRM` / `DENY`);
- suggested emission point before tool dispatch;
- concrete production-workflow review scenario and non-claims.

## Scope

This is an experimental PythiaLabs interoperability note. It is not an OpenHands feature, integration, endorsement, production authorization system, or replacement for existing OpenHands security primitives.