### PR TITLE
feat: add two-phase evidence receipt protocol v0.2

### DIFF
--- a/docs/examples/openhands-evidence-gate-decision-v0.2.json
+++ b/docs/examples/openhands-evidence-gate-decision-v0.2.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "pythia.openhands.evidence_gate_decision.v0.2",
+  "event_type": "evidence_gate_decision",
+  "event_id": "gate_evt_01",
+  "receipt_id": "receipt_01",
+  "timestamp": "2026-06-21T14:00:00Z",
+  "source": "security",
+  "action_event_id": "action_evt_01",
+  "tool_call_id": "tool_call_01",
+  "tool_name": "terminal",
+  "action_summary": "modify production deployment workflow",
+  "security_assessment": {
+    "risk": "HIGH",
+    "basis": "ensemble",
+    "analyzer_id": "openhands-ensemble-v1"
+  },
+  "gate_decision": {
+    "decision": "ESCALATE",
+    "runtime_interaction": "CONFIRM",
+    "decision_basis": "hybrid",
+    "stop_reasons": [
+      "OWNER_APPROVAL_REQUIRED",
+      "PRODUCTION_SCOPE_REQUIRES_REVIEW"
+    ],
+    "rationale": "Production workflow changes require an authorized reviewer."
+  },
+  "matched_rules": [
+    {
+      "rule_id": "production-workflow-owner-approval",
+      "layer": "external_policy",
+      "outcome": "REQUIRE_APPROVAL",
+      "reason": "Production deployment workflow requires owner approval."
+    }
+  ],
+  "evidence_refs": [
+    {
+      "evidence_id": "task_scope_01",
+      "evidence_type": "authorized_task_scope",
+      "status": "PRESENT",
+      "digest": "4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  ],
+  "policy_context": {
+    "policy_id": "repo-production-change-policy",
+    "policy_version": "1",
+    "policy_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluator_version": "pythia-labs-experimental-v0.2"
+  },
+  "replay": {
+    "replayable": true,
+    "canonical_input_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "decision_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "verification_required": true,
+  "sensitive_data_redacted": true
+}

--- a/docs/examples/openhands-evidence-gate-receipt-v0.1.json
+++ b/docs/examples/openhands-evidence-gate-receipt-v0.1.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "pythia.openhands.evidence_gate_receipt.v0.1",
+  "event_type": "evidence_gate_receipt",
+  "receipt_id": "receipt_01",
+  "generated_at": "2026-06-21T14:05:01Z",
+  "action": {
+    "action_event_id": "action_evt_01",
+    "tool_call_id": "tool_call_01",
+    "observation_event_id": "observation_evt_01",
+    "tool_name": "terminal",
+    "action_summary": "modify production deployment workflow",
+    "final_artifact_refs": [
+      {
+        "ref_id": "deployment_diff_01",
+        "ref_type": "diff",
+        "digest": "3333333333333333333333333333333333333333333333333333333333333333"
+      }
+    ]
+  },
+  "decision": {
+    "gate_event_id": "gate_evt_01",
+    "decision": "ESCALATE",
+    "runtime_interaction": "CONFIRM",
+    "stop_reasons": [
+      "OWNER_APPROVAL_REQUIRED",
+      "PRODUCTION_SCOPE_REQUIRES_REVIEW"
+    ],
+    "policy_id": "repo-production-change-policy",
+    "policy_version": "1",
+    "policy_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "event_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "verification": {
+    "verification_event_id": "verify_evt_01",
+    "status": "PASS",
+    "verifier_id": "pytest",
+    "verifier_version": "9.0",
+    "result_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "event_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "trace_chain": [
+    {
+      "stage": "DECISION",
+      "event_id": "gate_evt_01",
+      "event_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    {
+      "stage": "ACTION",
+      "event_id": "action_evt_01",
+      "event_digest": "2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    {
+      "stage": "OBSERVATION",
+      "event_id": "observation_evt_01",
+      "event_digest": "1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    {
+      "stage": "VERIFICATION",
+      "event_id": "verify_evt_01",
+      "event_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    {
+      "stage": "ARTIFACT",
+      "event_id": "deployment_diff_01",
+      "event_digest": "3333333333333333333333333333333333333333333333333333333333333333"
+    }
+  ],
+  "complete": true,
+  "sensitive_data_redacted": true
+}

--- a/docs/examples/openhands-evidence-gate-verification-v0.1.json
+++ b/docs/examples/openhands-evidence-gate-verification-v0.1.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "pythia.openhands.evidence_gate_verification.v0.1",
+  "event_type": "evidence_gate_verification",
+  "event_id": "verify_evt_01",
+  "receipt_id": "receipt_01",
+  "timestamp": "2026-06-21T14:05:00Z",
+  "gate_event_id": "gate_evt_01",
+  "action_event_id": "action_evt_01",
+  "tool_call_id": "tool_call_01",
+  "observation_event_id": "observation_evt_01",
+  "verifier": {
+    "type": "command",
+    "id": "pytest",
+    "version": "9.0",
+    "identity_ref": null
+  },
+  "verification_command": {
+    "display": "pytest tests/deployment/",
+    "normalized_digest": "22cf890526e6af5b417b5a0081fee385325d3909b2a342967ef634ec101f932a",
+    "environment_ref": "sandbox:openhands-session-01"
+  },
+  "result": {
+    "status": "PASS",
+    "exit_code": 0,
+    "summary": "Deployment workflow tests passed.",
+    "output_refs": [
+      {
+        "ref_id": "observation_evt_01",
+        "ref_type": "observation",
+        "digest": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      {
+        "ref_id": "test_report_01",
+        "ref_type": "report",
+        "digest": "3333333333333333333333333333333333333333333333333333333333333333"
+      }
+    ],
+    "result_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "evidence_refs": [
+    {
+      "evidence_id": "task_scope_01",
+      "status": "PRESENT",
+      "digest": "4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  ],
+  "sensitive_data_redacted": true
+}

--- a/docs/integrations/OPENHANDS_EVIDENCE_GATE_DECISION_EVENT.md
+++ b/docs/integrations/OPENHANDS_EVIDENCE_GATE_DECISION_EVENT.md
@@ -1,120 +1,194 @@
-# OpenHands-compatible Evidence Gate Decision Event
+# OpenHands-compatible Evidence Gate Receipt Protocol v0.2
 
 Status: experimental interoperability note, not an OpenHands feature or endorsement.
 
 ## Purpose
 
-This note defines an optional reviewer-facing event that can be emitted after an action has been assessed and before its tool call is dispatched.
+This note defines an optional reviewer-facing, two-phase record for high-impact
+agent actions:
 
-It does not replace the OpenHands security analyzer, policy rails, confirmation policy, event log, sandboxing, or human review. It only packages the decision context into one exportable record.
+1. a pre-action decision event emitted after security and policy evaluation but
+   before tool dispatch;
+2. a post-action verification event emitted after an observation or artifact is
+   available;
+3. a reviewer receipt projected from those append-only records.
 
-## Why a separate event
+It does not replace the OpenHands security analyzer, policy rails, confirmation
+policy, event log, hooks, sandboxing, or human review. It packages decision and
+verification context into exportable records that can be inspected without
+reconstructing the full trajectory.
 
-The current OpenHands `ActionEvent` already records the action identity, tool call, summary, model reasoning, and `security_risk`. Deterministic policy rails can also produce stable rule names and reasons.
+## Why two phases
 
-The missing reviewer-facing unit is a single record that binds together:
+Authorization and verification happen at different times.
 
-- the evaluated `ActionEvent`;
-- the security assessment;
-- matched deterministic rules;
-- evidence that was present, missing, stale, or redacted;
-- an authorization decision;
-- the runtime interaction used to satisfy that decision;
-- the policy version and replay digests.
+```text
+proposed action
+-> security / policy / evidence evaluation
+-> EvidenceGateDecisionEvent
+-> ALLOW | BLOCK | ESCALATE
+-> optional confirmation
+-> tool dispatch
+-> ObservationEvent or rejection
+-> verification command / reviewer check
+-> EvidenceGateVerificationEvent
+-> reviewer receipt projection
+```
+
+The pre-action decision must not be rewritten after dispatch merely to attach a
+test result. Keeping decision and verification as separate linked events
+preserves an append-only audit model and makes the timing of each claim explicit.
 
 ## Decision versus interaction
 
-These concepts should remain separate:
+These concepts remain separate:
 
 | Policy decision | Meaning | Runtime interaction |
 |---|---|---|
-| `ALLOW` | The current evidence and policy permit dispatch. | Usually `NONE`. |
+| `ALLOW` | Current evidence and policy permit dispatch. | Usually `NONE`. |
 | `BLOCK` | A hard rule denies dispatch and cannot be overridden by ordinary confirmation. | `DENY`. |
-| `ESCALATE` | The action may be valid but requires an authorized reviewer. | OpenHands can use `CONFIRM` to satisfy the escalation. |
+| `ESCALATE` | The action may be valid but requires an authorized reviewer. | OpenHands may use `CONFIRM` to satisfy the escalation. |
 
-`ESCALATE` is the decision; `CONFIRM` is the interaction mechanism.
+`ESCALATE` is the policy decision. `CONFIRM` is the runtime interaction used to
+resolve it.
+
+## Record 1: EvidenceGateDecisionEvent
+
+The decision event is emitted before the tool call is dispatched.
+
+It binds:
+
+- the evaluated action and tool-call identity;
+- OpenHands security risk;
+- matched deterministic rules;
+- evidence that was present, missing, stale, or redacted;
+- `ALLOW`, `BLOCK`, or `ESCALATE`;
+- runtime interaction;
+- stable stop reasons;
+- policy version and hash;
+- replay digests;
+- a shared `receipt_id`;
+- whether post-action verification is required.
+
+Latest schema:
+
+[`../../schemas/integrations/openhands_evidence_gate_decision_event.schema.json`](../../schemas/integrations/openhands_evidence_gate_decision_event.schema.json)
+
+The previous v0.1 schema is retained for compatibility:
+
+[`../../schemas/integrations/openhands_evidence_gate_decision_event.v0.1.schema.json`](../../schemas/integrations/openhands_evidence_gate_decision_event.v0.1.schema.json)
+
+## Record 2: EvidenceGateVerificationEvent
+
+The verification event is emitted only after the action has produced an
+observation, rejection, or reviewable artifact.
+
+It records:
+
+- the `receipt_id` and gate event being verified;
+- action, tool-call, and observation event IDs;
+- verifier type, identity, and version;
+- the verification command and its normalized digest;
+- `PASS`, `FAIL`, `ERROR`, or `SKIPPED`;
+- exit code and summary where applicable;
+- output references and result digest;
+- evidence references used during verification.
+
+Schema:
+
+[`../../schemas/integrations/openhands_evidence_gate_verification_event.schema.json`](../../schemas/integrations/openhands_evidence_gate_verification_event.schema.json)
+
+A verification event is not proof that an action was safe or correct. It only
+records that a named verification procedure produced a particular result.
+
+## Reviewer receipt
+
+The receipt is a projection joining the linked records. It is not the mutable
+source of truth.
+
+The receipt gives a reviewer one compact path:
+
+```text
+final diff / report / observation
+-> verification event
+-> executed action
+-> pre-action decision
+-> matched policy and checked evidence
+```
+
+It includes:
+
+- action and final-artifact references;
+- decision event ID and digest;
+- policy ID, version, and hash;
+- verification event ID and digest;
+- verifier and result digest;
+- an ordered trace chain;
+- a `complete` flag.
+
+Schema:
+
+[`../../schemas/integrations/openhands_evidence_gate_receipt.schema.json`](../../schemas/integrations/openhands_evidence_gate_receipt.schema.json)
 
 ## Mapping to OpenHands SDK concepts
 
-| Proposed field | OpenHands source |
+| Protocol field | OpenHands source or integration point |
 |---|---|
 | `action_event_id` | `ActionEvent.id` |
-| `timestamp` | event timestamp or gate-evaluation timestamp |
 | `tool_call_id` | `ActionEvent.tool_call_id` |
 | `tool_name` | `ActionEvent.tool_name` |
 | `action_summary` | `ActionEvent.summary` |
 | `security_assessment.risk` | `ActionEvent.security_risk` |
-| `matched_rules[].rule_id` | stable policy-rail ID, external policy ID, or evidence-check ID |
-| `matched_rules[].reason` | `RailDecision.reason` or equivalent deterministic reason |
-| `gate_decision.runtime_interaction` | result expected from the confirmation policy |
+| `matched_rules[].rule_id` | stable policy-rail ID, hook rule ID, external policy ID, or evidence-check ID |
+| `observation_event_id` | `ObservationEvent.id` or a rejection observation ID |
+| verification observation link | `ObservationEvent.action_id` plus `tool_call_id` |
+| runtime denial | `UserRejectObservation`, including hook or user rejection source |
+| `runtime_interaction` | confirmation-policy or hook interaction result |
+| final artifact reference | diff, log, report, or other exported artifact produced by the workflow |
 
-## Suggested emission point
+## Example records
 
-```text
-ActionEvent created
--> security analyzer and deterministic rails evaluated
--> optional external policy/evidence checks evaluated
--> EvidenceGateDecisionEvent emitted
--> ALLOW dispatches, BLOCK denies, ESCALATE requests confirmation
-```
+- [Decision event v0.2](../examples/openhands-evidence-gate-decision-v0.2.json)
+- [Verification event v0.1](../examples/openhands-evidence-gate-verification-v0.1.json)
+- [Reviewer receipt v0.1](../examples/openhands-evidence-gate-receipt-v0.1.json)
 
-The event can remain outside the LLM-visible conversation and be stored as a reviewer/export artifact.
+The examples describe an agent changing a production deployment workflow,
+receiving an escalation decision, obtaining confirmation, running a test
+command, and exporting a receipt that links the final diff back to the
+pre-action evidence.
 
-## Minimal fields
+## Integrity semantics
 
-```json
-{
-  "schema_version": "pythia.openhands.evidence_gate_decision.v0.1",
-  "event_type": "evidence_gate_decision",
-  "event_id": "gate_evt_01",
-  "timestamp": "2026-06-19T10:00:00Z",
-  "source": "security",
-  "action_event_id": "action_evt_01",
-  "tool_call_id": "tool_call_01",
-  "tool_name": "terminal",
-  "action_summary": "modify production deployment workflow",
-  "security_assessment": {
-    "risk": "HIGH",
-    "basis": "ensemble"
-  },
-  "gate_decision": {
-    "decision": "ESCALATE",
-    "runtime_interaction": "CONFIRM",
-    "decision_basis": "hybrid",
-    "stop_reasons": [
-      "OWNER_APPROVAL_REQUIRED",
-      "PRODUCTION_SCOPE_REQUIRES_REVIEW"
-    ]
-  },
-  "matched_rules": [],
-  "evidence_refs": [],
-  "policy_context": {
-    "policy_id": "repo-production-change-policy",
-    "policy_version": "1",
-    "policy_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  },
-  "replay": {
-    "replayable": true,
-    "canonical_input_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "decision_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-  },
-  "sensitive_data_redacted": true
-}
-```
+The schemas use SHA-256-shaped digest fields to make the intended linkage
+explicit. They do not define canonicalization, signing, key management,
+identity assurance, or trusted timestamping.
 
-## Concrete reviewer scenario
+A production implementation would still need to define:
 
-An agent proposes changing a production deployment workflow and rotating a secret reference.
+- canonical serialization;
+- digest scope;
+- verifier identity and authorization;
+- policy distribution and trust;
+- secure storage;
+- signature and timestamp semantics;
+- redaction rules;
+- failure handling for incomplete receipts.
 
-A normal trajectory can show the command, reasoning, risk, and human confirmation. The decision event additionally answers:
+## Versioning
 
-1. Was the workflow in the authorized task scope?
-2. Was only a secret reference changed, or was secret material read?
-3. Which rule required approval?
-4. Which evidence was missing at decision time?
-5. Which policy version produced the decision?
-6. Can the same normalized inputs be replayed against that policy version?
+- Decision event v0.1 remains available as a compatibility snapshot.
+- Decision event v0.2 adds `receipt_id` and `verification_required`.
+- Verification event v0.1 introduces the post-action record.
+- Receipt v0.1 introduces the reviewer-facing projection.
+
+Future versions should add fields rather than reinterpret existing decisions.
+A receipt should never change the meaning of the original gate event.
 
 ## Non-claims
 
-This experimental event does not prove that an action is correct, secure, compliant, or safe. It does not define production authorization, identity verification, or cryptographic signing. It is a small interoperability proposal for structured review and replay.
+This experimental protocol does not prove that an action is correct, secure,
+compliant, authorized in production, or safe. It does not define production
+identity verification, cryptographic signing, enforcement, or certification.
+
+It is a small interoperability proposal for structured review, traceability,
+and replay around existing agent-security primitives.

--- a/docs/integrations/OPENHANDS_EVIDENCE_GATE_RECEIPT_PROTOCOL_V0_2.md
+++ b/docs/integrations/OPENHANDS_EVIDENCE_GATE_RECEIPT_PROTOCOL_V0_2.md
@@ -1,0 +1,15 @@
+# Evidence Gate Receipt Protocol v0.2 — reviewer entry point
+
+The canonical protocol note is:
+
+- [OpenHands-compatible Evidence Gate Receipt Protocol v0.2](OPENHANDS_EVIDENCE_GATE_DECISION_EVENT.md)
+
+It defines three linked, append-only artifacts:
+
+1. pre-action `EvidenceGateDecisionEvent`;
+2. post-action `EvidenceGateVerificationEvent`;
+3. reviewer-facing `EvidenceGateReceipt` projection.
+
+Schemas and validated examples are linked from the canonical note.
+
+Status: experimental interoperability proposal only. It is not an OpenHands feature, endorsement, production authorization system, security certification, or compliance claim.

--- a/schemas/integrations/openhands_evidence_gate_decision_event.schema.json
+++ b/schemas/integrations/openhands_evidence_gate_decision_event.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Evidence Gate Decision Event",
+  "title": "Evidence Gate Decision Event v0.2",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -9,6 +9,7 @@
     "event_id",
     "timestamp",
     "source",
+    "receipt_id",
     "action_event_id",
     "tool_call_id",
     "tool_name",
@@ -17,42 +18,126 @@
     "matched_rules",
     "evidence_refs",
     "policy_context",
-    "replay"
+    "replay",
+    "verification_required"
   ],
   "properties": {
-    "schema_version": {"const": "pythia.openhands.evidence_gate_decision.v0.1"},
-    "event_type": {"const": "evidence_gate_decision"},
-    "event_id": {"type": "string", "minLength": 1},
-    "timestamp": {"type": "string", "format": "date-time"},
-    "source": {"const": "security"},
-    "action_event_id": {"type": "string", "minLength": 1},
-    "tool_call_id": {"type": "string", "minLength": 1},
-    "tool_name": {"type": "string", "minLength": 1},
-    "action_summary": {"type": ["string", "null"]},
+    "schema_version": {
+      "const": "pythia.openhands.evidence_gate_decision.v0.2"
+    },
+    "event_type": {
+      "const": "evidence_gate_decision"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "const": "security"
+    },
+    "action_event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool_call_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_summary": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "security_assessment": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["risk", "basis"],
+      "required": [
+        "risk",
+        "basis"
+      ],
       "properties": {
-        "risk": {"enum": ["UNKNOWN", "LOW", "MEDIUM", "HIGH"]},
-        "basis": {"enum": ["openhands_analyzer", "policy_rail", "ensemble", "external"]},
-        "analyzer_id": {"type": ["string", "null"]}
+        "risk": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ]
+        },
+        "basis": {
+          "enum": [
+            "openhands_analyzer",
+            "policy_rail",
+            "ensemble",
+            "external"
+          ]
+        },
+        "analyzer_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
     "gate_decision": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["decision", "runtime_interaction", "decision_basis", "stop_reasons"],
+      "required": [
+        "decision",
+        "runtime_interaction",
+        "decision_basis",
+        "stop_reasons"
+      ],
       "properties": {
-        "decision": {"enum": ["ALLOW", "BLOCK", "ESCALATE"]},
-        "runtime_interaction": {"enum": ["NONE", "CONFIRM", "DENY"]},
-        "decision_basis": {"enum": ["deterministic", "model_assisted", "hybrid"]},
+        "decision": {
+          "enum": [
+            "ALLOW",
+            "BLOCK",
+            "ESCALATE"
+          ]
+        },
+        "runtime_interaction": {
+          "enum": [
+            "NONE",
+            "CONFIRM",
+            "DENY"
+          ]
+        },
+        "decision_basis": {
+          "enum": [
+            "deterministic",
+            "model_assisted",
+            "hybrid"
+          ]
+        },
         "stop_reasons": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "uniqueItems": true
         },
-        "rationale": {"type": ["string", "null"]}
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
     "matched_rules": {
@@ -60,12 +145,34 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["rule_id", "layer", "outcome", "reason"],
+        "required": [
+          "rule_id",
+          "layer",
+          "outcome",
+          "reason"
+        ],
         "properties": {
-          "rule_id": {"type": "string", "minLength": 1},
-          "layer": {"enum": ["openhands_policy_rail", "external_policy", "evidence_gate"]},
-          "outcome": {"enum": ["PASS", "FAIL", "REQUIRE_APPROVAL"]},
-          "reason": {"type": "string"}
+          "rule_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "layer": {
+            "enum": [
+              "openhands_policy_rail",
+              "external_policy",
+              "evidence_gate"
+            ]
+          },
+          "outcome": {
+            "enum": [
+              "PASS",
+              "FAIL",
+              "REQUIRE_APPROVAL"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
         }
       }
     },
@@ -74,36 +181,95 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["evidence_id", "evidence_type", "status"],
+        "required": [
+          "evidence_id",
+          "evidence_type",
+          "status"
+        ],
         "properties": {
-          "evidence_id": {"type": "string", "minLength": 1},
-          "evidence_type": {"type": "string", "minLength": 1},
-          "status": {"enum": ["PRESENT", "MISSING", "STALE", "REDACTED"]},
-          "digest": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "enum": [
+              "PRESENT",
+              "MISSING",
+              "STALE",
+              "REDACTED"
+            ]
+          },
+          "digest": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[a-f0-9]{64}$"
+          }
         }
       }
     },
     "policy_context": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["policy_id", "policy_version", "policy_hash"],
+      "required": [
+        "policy_id",
+        "policy_version",
+        "policy_hash"
+      ],
       "properties": {
-        "policy_id": {"type": "string", "minLength": 1},
-        "policy_version": {"type": "string", "minLength": 1},
-        "policy_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
-        "evaluator_version": {"type": ["string", "null"]}
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "evaluator_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
     "replay": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["replayable", "canonical_input_digest", "decision_digest"],
+      "required": [
+        "replayable",
+        "canonical_input_digest",
+        "decision_digest"
+      ],
       "properties": {
-        "replayable": {"type": "boolean"},
-        "canonical_input_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
-        "decision_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+        "replayable": {
+          "type": "boolean"
+        },
+        "canonical_input_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "decision_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
       }
     },
-    "sensitive_data_redacted": {"type": "boolean", "default": true}
+    "sensitive_data_redacted": {
+      "type": "boolean",
+      "default": true
+    },
+    "verification_required": {
+      "type": "boolean"
+    }
   }
 }

--- a/schemas/integrations/openhands_evidence_gate_decision_event.v0.1.schema.json
+++ b/schemas/integrations/openhands_evidence_gate_decision_event.v0.1.schema.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence Gate Decision Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_type",
+    "event_id",
+    "timestamp",
+    "source",
+    "action_event_id",
+    "tool_call_id",
+    "tool_name",
+    "security_assessment",
+    "gate_decision",
+    "matched_rules",
+    "evidence_refs",
+    "policy_context",
+    "replay"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pythia.openhands.evidence_gate_decision.v0.1"
+    },
+    "event_type": {
+      "const": "evidence_gate_decision"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "const": "security"
+    },
+    "action_event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool_call_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_summary": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "security_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "risk",
+        "basis"
+      ],
+      "properties": {
+        "risk": {
+          "enum": [
+            "UNKNOWN",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ]
+        },
+        "basis": {
+          "enum": [
+            "openhands_analyzer",
+            "policy_rail",
+            "ensemble",
+            "external"
+          ]
+        },
+        "analyzer_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "gate_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "runtime_interaction",
+        "decision_basis",
+        "stop_reasons"
+      ],
+      "properties": {
+        "decision": {
+          "enum": [
+            "ALLOW",
+            "BLOCK",
+            "ESCALATE"
+          ]
+        },
+        "runtime_interaction": {
+          "enum": [
+            "NONE",
+            "CONFIRM",
+            "DENY"
+          ]
+        },
+        "decision_basis": {
+          "enum": [
+            "deterministic",
+            "model_assisted",
+            "hybrid"
+          ]
+        },
+        "stop_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "rationale": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "matched_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rule_id",
+          "layer",
+          "outcome",
+          "reason"
+        ],
+        "properties": {
+          "rule_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "layer": {
+            "enum": [
+              "openhands_policy_rail",
+              "external_policy",
+              "evidence_gate"
+            ]
+          },
+          "outcome": {
+            "enum": [
+              "PASS",
+              "FAIL",
+              "REQUIRE_APPROVAL"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "evidence_id",
+          "evidence_type",
+          "status"
+        ],
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "enum": [
+              "PRESENT",
+              "MISSING",
+              "STALE",
+              "REDACTED"
+            ]
+          },
+          "digest": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "policy_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_id",
+        "policy_version",
+        "policy_hash"
+      ],
+      "properties": {
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "evaluator_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "replayable",
+        "canonical_input_digest",
+        "decision_digest"
+      ],
+      "properties": {
+        "replayable": {
+          "type": "boolean"
+        },
+        "canonical_input_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "decision_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "sensitive_data_redacted": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/schemas/integrations/openhands_evidence_gate_receipt.schema.json
+++ b/schemas/integrations/openhands_evidence_gate_receipt.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence Gate Reviewer Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_type",
+    "receipt_id",
+    "generated_at",
+    "action",
+    "decision",
+    "verification",
+    "trace_chain",
+    "complete"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pythia.openhands.evidence_gate_receipt.v0.1"
+    },
+    "event_type": {
+      "const": "evidence_gate_receipt"
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_event_id",
+        "tool_call_id",
+        "tool_name"
+      ],
+      "properties": {
+        "action_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tool_call_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observation_event_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action_summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "final_artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "ref_id",
+              "ref_type"
+            ],
+            "properties": {
+              "ref_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ref_type": {
+                "enum": [
+                  "observation",
+                  "artifact",
+                  "log",
+                  "diff",
+                  "report"
+                ]
+              },
+              "digest": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "pattern": "^[a-f0-9]{64}$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gate_event_id",
+        "decision",
+        "stop_reasons",
+        "policy_id",
+        "policy_version",
+        "policy_hash",
+        "event_digest"
+      ],
+      "properties": {
+        "gate_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "decision": {
+          "enum": [
+            "ALLOW",
+            "BLOCK",
+            "ESCALATE"
+          ]
+        },
+        "runtime_interaction": {
+          "enum": [
+            "NONE",
+            "CONFIRM",
+            "DENY"
+          ]
+        },
+        "stop_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "event_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "verification": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "required": [
+        "verification_event_id",
+        "status",
+        "verifier_id",
+        "result_digest",
+        "event_digest"
+      ],
+      "properties": {
+        "verification_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": [
+            "PASS",
+            "FAIL",
+            "ERROR",
+            "SKIPPED"
+          ]
+        },
+        "verifier_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verifier_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "result_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "event_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "trace_chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "stage",
+          "event_id",
+          "event_digest"
+        ],
+        "properties": {
+          "stage": {
+            "enum": [
+              "DECISION",
+              "ACTION",
+              "OBSERVATION",
+              "VERIFICATION",
+              "ARTIFACT"
+            ]
+          },
+          "event_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "event_digest": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "complete": {
+      "type": "boolean"
+    },
+    "sensitive_data_redacted": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/schemas/integrations/openhands_evidence_gate_verification_event.schema.json
+++ b/schemas/integrations/openhands_evidence_gate_verification_event.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence Gate Verification Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_type",
+    "event_id",
+    "receipt_id",
+    "timestamp",
+    "gate_event_id",
+    "action_event_id",
+    "tool_call_id",
+    "observation_event_id",
+    "verifier",
+    "verification_command",
+    "result"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pythia.openhands.evidence_gate_verification.v0.1"
+    },
+    "event_type": {
+      "const": "evidence_gate_verification"
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "gate_event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tool_call_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observation_event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "command",
+            "tool",
+            "human",
+            "external_service"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identity_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "verification_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "display",
+        "normalized_digest"
+      ],
+      "properties": {
+        "display": {
+          "type": "string",
+          "minLength": 1
+        },
+        "normalized_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "environment_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "result_digest"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "PASS",
+            "FAIL",
+            "ERROR",
+            "SKIPPED"
+          ]
+        },
+        "exit_code": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_refs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "ref_id",
+              "ref_type"
+            ],
+            "properties": {
+              "ref_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "ref_type": {
+                "enum": [
+                  "observation",
+                  "artifact",
+                  "log",
+                  "diff",
+                  "report"
+                ]
+              },
+              "digest": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "pattern": "^[a-f0-9]{64}$"
+              }
+            }
+          }
+        },
+        "result_digest": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "evidence_id",
+          "status"
+        ],
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "enum": [
+              "PRESENT",
+              "MISSING",
+              "STALE",
+              "REDACTED"
+            ]
+          },
+          "digest": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "sensitive_data_redacted": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Introduces an append-only, two-phase reviewer receipt model for high-impact agent actions, based on the OpenHands interoperability discussion in OpenHands/OpenHands#14857.

### Added

- `EvidenceGateDecisionEvent` v0.2 with shared `receipt_id` and `verification_required`
- preserved decision schema v0.1 for compatibility
- post-action `EvidenceGateVerificationEvent` schema
- reviewer-facing `EvidenceGateReceipt` projection schema
- linked JSON examples for decision, verification, and receipt
- expanded OpenHands mapping and integrity/non-claim notes

## Event flow

```text
pre-action decision
-> action / observation
-> post-action verification
-> reviewer receipt projection
```

The original authorization record is not mutated after dispatch.

## Validation

The three example JSON documents were validated locally against their Draft-07 schemas.

## Scope

Experimental interoperability proposal only. This does not claim OpenHands endorsement, production authorization, cryptographic assurance, security certification, or compliance.