### PR TITLE
feat: prove external Silicon Evidence Gate v0.7.0 consumption

### DIFF
--- a/.github/workflows/silicon-gate-consumer.yml
+++ b/.github/workflows/silicon-gate-consumer.yml
@@ -1,0 +1,133 @@
+name: External Silicon Gate Consumer
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/silicon-gate-consumer.yml"
+      - "scripts/build_silicon_gate_consumer_demo.py"
+      - "docs/SILICON_GATE_EXTERNAL_CONSUMER.md"
+  pull_request:
+    paths:
+      - ".github/workflows/silicon-gate-consumer.yml"
+      - "scripts/build_silicon_gate_consumer_demo.py"
+      - "docs/SILICON_GATE_EXTERNAL_CONSUMER.md"
+
+permissions:
+  contents: read
+
+jobs:
+  consume-v0-7-0:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out PythiaLabs
+        uses: actions/checkout@v4
+
+      - name: Build consumer evidence inputs
+        run: |
+          python3 scripts/build_silicon_gate_consumer_demo.py \
+            --output artifacts/silicon-gate-consumer \
+            --candidate-commit "$GITHUB_SHA"
+
+      - name: External ALLOW decision
+        id: allow
+        uses: safal207/ibex-agent-verification@v0.7.0
+        with:
+          request: artifacts/silicon-gate-consumer/allow/gate-request.json
+          report: artifacts/silicon-gate-consumer/allow/gate-decision.json
+
+      - name: External BLOCK in observe-only mode
+        id: block_observe
+        uses: safal207/ibex-agent-verification@v0.7.0
+        with:
+          request: artifacts/silicon-gate-consumer/block/gate-request.json
+          report: artifacts/silicon-gate-consumer/block/gate-observe-decision.json
+          fail_on_block: "false"
+
+      - name: External BLOCK under enforcement
+        id: block_enforce
+        continue-on-error: true
+        uses: safal207/ibex-agent-verification@v0.7.0
+        with:
+          request: artifacts/silicon-gate-consumer/block/gate-request.json
+          report: artifacts/silicon-gate-consumer/block/gate-enforce-decision.json
+
+      - name: Verify external action contract
+        env:
+          ALLOW_DECISION: ${{ steps.allow.outputs.decision }}
+          ALLOW_REASONS: ${{ steps.allow.outputs.reason_codes }}
+          ALLOW_REPORT_SHA: ${{ steps.allow.outputs.report_sha256 }}
+          BLOCK_DECISION: ${{ steps.block_observe.outputs.decision }}
+          BLOCK_REASONS: ${{ steps.block_observe.outputs.reason_codes }}
+          BLOCK_REPORT_SHA: ${{ steps.block_observe.outputs.report_sha256 }}
+          ENFORCED_BLOCK_OUTCOME: ${{ steps.block_enforce.outcome }}
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("artifacts/silicon-gate-consumer")
+          allow_path = root / "allow/gate-decision.json"
+          block_observe_path = root / "block/gate-observe-decision.json"
+          block_enforce_path = root / "block/gate-enforce-decision.json"
+
+          def load(path):
+              return json.loads(path.read_text(encoding="utf-8"))
+
+          def sha256(path):
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          allow = load(allow_path)
+          block_observe = load(block_observe_path)
+          block_enforce = load(block_enforce_path)
+
+          assert os.environ["ALLOW_DECISION"] == "ALLOW"
+          assert "NO_EVIDENCE_REGRESSION" in os.environ["ALLOW_REASONS"]
+          assert allow["decision"] == "ALLOW"
+          assert sha256(allow_path) == os.environ["ALLOW_REPORT_SHA"]
+
+          assert os.environ["BLOCK_DECISION"] == "BLOCK"
+          assert "NEW_UNEXPLAINED_TIMING_ANOMALY" in os.environ["BLOCK_REASONS"]
+          assert block_observe["decision"] == "BLOCK"
+          assert block_enforce["decision"] == "BLOCK"
+          assert sha256(block_observe_path) == os.environ["BLOCK_REPORT_SHA"]
+          assert os.environ["ENFORCED_BLOCK_OUTCOME"] == "failure"
+
+          summary = {
+              "schema_version": 1,
+              "status": "EXTERNAL_CONSUMER_PASSED",
+              "consumer_repository": os.environ["GITHUB_REPOSITORY"],
+              "consumer_commit": os.environ["GITHUB_SHA"],
+              "action": "safal207/ibex-agent-verification@v0.7.0",
+              "allow": {
+                  "decision": allow["decision"],
+                  "reason_codes": [item["code"] for item in allow["reasons"]],
+                  "report_sha256": sha256(allow_path),
+              },
+              "block_observe": {
+                  "decision": block_observe["decision"],
+                  "reason_codes": [item["code"] for item in block_observe["reasons"]],
+                  "report_sha256": sha256(block_observe_path),
+              },
+              "block_enforcement_outcome": os.environ["ENFORCED_BLOCK_OUTCOME"],
+          }
+          (root / "external-consumer-summary.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(summary, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload external consumer evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pythialabs-external-silicon-gate-${{ github.sha }}
+          path: artifacts/silicon-gate-consumer/
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/SILICON_GATE_EXTERNAL_CONSUMER.md
+++ b/docs/SILICON_GATE_EXTERNAL_CONSUMER.md
@@ -1,0 +1,92 @@
+# External Silicon Evidence Gate Consumer
+
+This repository consumes the released PythiaLabs Silicon Evidence Gate from a separate repository and immutable tag:
+
+```yaml
+uses: safal207/ibex-agent-verification@v0.7.0
+```
+
+No gate implementation is copied into `pythiaLabs`. The consumer only creates evidence inputs and verifies the external action contract.
+
+## Why this matters
+
+A self-test inside `ibex-agent-verification` proves the action works in its source repository. This workflow proves the distribution boundary:
+
+- another public repository resolves the immutable release tag;
+- the released composite action runs from its own action path;
+- evidence paths remain relative to the consumer workspace;
+- outputs cross the repository boundary correctly;
+- observe-only and enforcing policies behave as documented;
+- the generated decision reports remain independently hashable.
+
+## Scenarios
+
+The consumer fixture builder creates two commit-bound requests.
+
+### ALLOW
+
+Evidence contains:
+
+- architectural trace status `MATCH`;
+- no timing regressions;
+- no delayed redirect regressions;
+- a manifest bound to the PythiaLabs workflow commit.
+
+Expected result:
+
+```text
+ALLOW / NO_EVIDENCE_REGRESSION
+```
+
+### BLOCK
+
+The architectural trace still matches and the manifest remains correctly bound. The only intentional defect is one new timing anomaly with `primary_cause: UNKNOWN`.
+
+Expected result:
+
+```text
+BLOCK / NEW_UNEXPLAINED_TIMING_ANOMALY
+```
+
+The same BLOCK request is executed twice:
+
+1. observe-only with `fail_on_block: "false"`, which publishes outputs without failing;
+2. enforcing mode, which publishes the decision and then fails the composite action policy step.
+
+## Workflow contract
+
+The workflow verifies:
+
+- `decision` and `reason_codes` outputs;
+- SHA-256 of the generated reports;
+- successful ALLOW execution;
+- successful observe-only BLOCK execution;
+- failed enforcing BLOCK execution;
+- JSON reports for all three action calls.
+
+It writes:
+
+```text
+artifacts/silicon-gate-consumer/
+├── allow/
+│   ├── evidence/
+│   ├── gate-request.json
+│   └── gate-decision.json
+├── block/
+│   ├── evidence/
+│   ├── gate-request.json
+│   ├── gate-observe-decision.json
+│   └── gate-enforce-decision.json
+├── consumer-input-summary.json
+└── external-consumer-summary.json
+```
+
+The complete directory is uploaded for 14 days as:
+
+```text
+pythialabs-external-silicon-gate-<consumer-commit>
+```
+
+## Boundary
+
+These generated fixtures validate packaging, distribution, policy behavior, outputs, and evidence integrity. They are not a hardware simulation and do not replace the real firmware and RTL demonstrations maintained in `ibex-agent-verification`.

--- a/scripts/build_silicon_gate_consumer_demo.py
+++ b/scripts/build_silicon_gate_consumer_demo.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def timing_report(*causes: str) -> dict[str, Any]:
+    findings = [
+        {
+            "step": index,
+            "status": "DELAY_ANOMALY",
+            "primary_cause": cause,
+        }
+        for index, cause in enumerate(causes, start=1)
+    ]
+    return {
+        "status": "ANOMALY_DETECTED" if findings else "ON_TIME",
+        "samples": max(1, len(findings)),
+        "anomalies": len(findings),
+        "findings": findings,
+    }
+
+
+def build_scenario(
+    root: Path,
+    name: str,
+    *,
+    candidate_commit: str,
+    candidate_causes: tuple[str, ...],
+) -> None:
+    scenario = root / name
+    evidence = scenario / "evidence"
+
+    write_json(
+        evidence / "trace-comparison.json",
+        {
+            "status": "MATCH",
+            "expected_events": 12,
+            "actual_events": 12,
+            "first_mismatch_index": None,
+            "differences": {},
+        },
+    )
+    write_json(evidence / "baseline-timing.json", timing_report())
+    write_json(
+        evidence / "candidate-timing.json",
+        timing_report(*candidate_causes),
+    )
+
+    control_flow = {
+        "status": "NO_REDIRECTS_FOUND",
+        "redirects": 0,
+        "delayed_redirects": 0,
+        "pipeline_flush_claims": 0,
+    }
+    write_json(evidence / "baseline-control-flow.json", control_flow)
+    write_json(evidence / "candidate-control-flow.json", control_flow)
+
+    write_json(
+        evidence / "manifest.json",
+        {
+            "schema_version": 1,
+            "project": {
+                "repository": "safal207/pythiaLabs",
+                "commit": candidate_commit,
+            },
+            "producer": {
+                "kind": "external-consumer-demo",
+                "gate_action": "safal207/ibex-agent-verification@v0.7.0",
+            },
+        },
+    )
+
+    write_json(
+        scenario / "gate-request.json",
+        {
+            "schema_version": 1,
+            "change": {
+                "request_id": f"pythialabs-external-consumer-{name}",
+                "actor": {
+                    "type": "ai_agent",
+                    "name": "pythialabs-consumer-demo",
+                    "model": "deterministic-fixture-producer",
+                },
+                "base_commit": "consumer-baseline",
+                "candidate_commit": candidate_commit,
+                "changed_files": [
+                    "examples/external_silicon_gate_candidate.ex"
+                ],
+                "risk_tags": ["external_action_consumer"],
+            },
+            "evidence": {
+                "trace_comparison": "evidence/trace-comparison.json",
+                "baseline_timing": "evidence/baseline-timing.json",
+                "candidate_timing": "evidence/candidate-timing.json",
+                "baseline_control_flow": "evidence/baseline-control-flow.json",
+                "candidate_control_flow": "evidence/candidate-control-flow.json",
+                "manifest": "evidence/manifest.json",
+            },
+            "policy": {
+                "max_new_explained_timing_anomalies": 0,
+                "max_new_delayed_redirects": 0,
+                "manual_review_tags": [],
+                "require_ai_model": True,
+            },
+        },
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build evidence inputs for the external Silicon Gate consumer demo."
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--candidate-commit", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    candidate_commit = args.candidate_commit.strip()
+    if not candidate_commit:
+        raise SystemExit("--candidate-commit must not be empty")
+
+    output = args.output.resolve()
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    build_scenario(
+        output,
+        "allow",
+        candidate_commit=candidate_commit,
+        candidate_causes=(),
+    )
+    build_scenario(
+        output,
+        "block",
+        candidate_commit=candidate_commit,
+        candidate_causes=("UNKNOWN",),
+    )
+
+    write_json(
+        output / "consumer-input-summary.json",
+        {
+            "schema_version": 1,
+            "status": "INPUTS_READY",
+            "consumer_repository": "safal207/pythiaLabs",
+            "candidate_commit": candidate_commit,
+            "gate_action": "safal207/ibex-agent-verification@v0.7.0",
+            "scenarios": {
+                "allow": "expected ALLOW / NO_EVIDENCE_REGRESSION",
+                "block": "expected BLOCK / NEW_UNEXPLAINED_TIMING_ANOMALY",
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a cross-repository consumer proof for the released PythiaLabs Silicon Evidence Gate.

This repository does not copy gate implementation code. It generates commit-bound evidence inputs and calls:

```yaml
uses: safal207/ibex-agent-verification@v0.7.0
```

## Scenarios

- clean evidence -> `ALLOW / NO_EVIDENCE_REGRESSION`;
- one new unexplained timing anomaly -> `BLOCK / NEW_UNEXPLAINED_TIMING_ANOMALY`;
- the same BLOCK request is executed in observe-only and enforcing modes.

## What the workflow verifies

- immutable tag resolution from another repository;
- correct `decision`, `reason_codes`, and `report_sha256` outputs;
- ALLOW succeeds;
- observe-only BLOCK publishes evidence without failing;
- enforcing BLOCK publishes its report and then fails policy enforcement;
- all decision JSON files are present and independently hashed.

## Artifact

The workflow uploads the complete consumer bundle for 14 days as:

```text
pythialabs-external-silicon-gate-<consumer-commit>
```

## Boundary

This validates packaging, distribution, workspace-relative evidence paths, outputs, and policy behavior across a repository boundary. It is not a hardware simulation; hardware-backed firmware and RTL demonstrations remain in `ibex-agent-verification`.