### PR TITLE
feat: export canonical authorization records v0.1

### DIFF
--- a/.github/workflows/authorization-export.yml
+++ b/.github/workflows/authorization-export.yml
@@ -1,0 +1,42 @@
+name: Authorization Export
+
+on:
+  pull_request:
+    paths:
+      - "conformance/pythialabs-authorization-export-v0.1.json"
+      - "docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md"
+      - "schemas/interop/pythialabs-authorization-record-v0.1.schema.json"
+      - "scripts/check_pythialabs_authorization_export.py"
+      - "scripts/test_pythialabs_authorization_export.py"
+      - "scripts/requirements-pythialabs-authorization-export.txt"
+      - ".github/workflows/authorization-export.yml"
+  push:
+    branches: [main]
+    paths:
+      - "conformance/pythialabs-authorization-export-v0.1.json"
+      - "docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md"
+      - "schemas/interop/pythialabs-authorization-record-v0.1.schema.json"
+      - "scripts/check_pythialabs_authorization_export.py"
+      - "scripts/test_pythialabs_authorization_export.py"
+      - "scripts/requirements-pythialabs-authorization-export.txt"
+      - ".github/workflows/authorization-export.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install verifier dependencies
+        run: python -m pip install -r scripts/requirements-pythialabs-authorization-export.txt
+      - name: Verify canonical records
+        run: python scripts/check_pythialabs_authorization_export.py
+      - name: Run adversarial checks
+        run: python scripts/test_pythialabs_authorization_export.py

--- a/conformance/pythialabs-authorization-export-v0.1.json
+++ b/conformance/pythialabs-authorization-export-v0.1.json
@@ -1,0 +1,444 @@
+{
+  "fixture_version": "0.1",
+  "revision": "2026-06-29.1",
+  "title": "PythiaLabs canonical authorization export conformance fixtures",
+  "canonicalization": "RFC8785-JCS",
+  "hash_algorithm": "sha256",
+  "schema_path": "schemas/interop/pythialabs-authorization-record-v0.1.schema.json",
+  "profile": "org.pythialabs.authorization-export.v0.1",
+  "showcase_adapters": {
+    "infrastructure": "pythia.infrastructure.pre_execution.v1",
+    "banking-risk": "pythia.banking_risk.pre_execution.v1",
+    "web3-treasury": "pythia.web3_treasury.pre_execution.v1"
+  },
+  "cases": [
+    {
+      "case_id": "accepted_reversible_infrastructure",
+      "input": {
+        "transition_id": "transition-accepted_reversible_infrastructure",
+        "subject_id": "agent:infra",
+        "source_showcase": "infrastructure",
+        "action": {
+          "identity": {
+            "caller_id": "agent:infra",
+            "tool_id": "tool:kubernetes.apply",
+            "resource_scope": "cluster:staging/namespace:payments"
+          },
+          "arguments_schema": "pythia.infrastructure.action.v1",
+          "arguments": {
+            "change_id": "chg-001",
+            "operation": "apply",
+            "resource": "deployment/api",
+            "desired_replicas": 4
+          }
+        },
+        "gate": {
+          "profile": "pythia.infrastructure.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "ALLOW",
+          "reason_codes": [
+            "EVIDENCE_COMPLETE",
+            "REVERSIBLE_CHANGE"
+          ],
+          "decision_time": "2030-01-01T00:00:00Z",
+          "evaluation_clock": "2030-01-01T00:00:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "NOT_REQUIRED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "evidence_refs": [
+            "evidence:change/chg-001",
+            "evidence:cluster/staging-snapshot-001"
+          ],
+          "environment_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "target_state_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "continuation_requirement": "NONE",
+          "revalidation_requirements": [],
+          "artifact_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": true,
+        "authority_state": "ACTIVE",
+        "expected_additional_side_effects": 1,
+        "authorization_ref": "sha256:005a1da162e97f7eaa75187096d8fa77bd2876594f53d63f9c3bc948e4ab7f4c"
+      },
+      "handoff": null
+    },
+    {
+      "case_id": "blocked_destructive_without_approval",
+      "input": {
+        "transition_id": "transition-blocked_destructive_without_approval",
+        "subject_id": "agent:infra",
+        "source_showcase": "infrastructure",
+        "action": {
+          "identity": {
+            "caller_id": "agent:infra",
+            "tool_id": "tool:kubernetes.delete",
+            "resource_scope": "cluster:staging/namespace:payments"
+          },
+          "arguments_schema": "pythia.infrastructure.action.v1",
+          "arguments": {
+            "change_id": "chg-001",
+            "operation": "delete",
+            "resource": "namespace:payments",
+            "desired_replicas": 4
+          }
+        },
+        "gate": {
+          "profile": "pythia.infrastructure.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "BLOCK",
+          "reason_codes": [
+            "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"
+          ],
+          "decision_time": "2030-01-01T00:00:00Z",
+          "evaluation_clock": "2030-01-01T00:00:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "MISSING",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "evidence_refs": [
+            "evidence:change/chg-001",
+            "evidence:cluster/staging-snapshot-001"
+          ],
+          "environment_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "target_state_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "continuation_requirement": "AWAITING_APPROVAL",
+          "revalidation_requirements": [],
+          "artifact_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": false,
+        "authority_state": "BLOCKED",
+        "expected_additional_side_effects": 0,
+        "authorization_ref": "sha256:5c7edf39a3c3799edc3f20a0a1dae7e186227a0d9517367bb1928cf9839d7e60"
+      },
+      "handoff": null
+    },
+    {
+      "case_id": "expired_temporal_authorization",
+      "input": {
+        "transition_id": "transition-expired_temporal_authorization",
+        "subject_id": "agent:banking",
+        "source_showcase": "banking-risk",
+        "action": {
+          "identity": {
+            "caller_id": "agent:banking",
+            "tool_id": "tool:risk.limit_update",
+            "resource_scope": "bank:demo/portfolio:retail"
+          },
+          "arguments_schema": "pythia.banking_risk.action.v1",
+          "arguments": {
+            "customer_segment": "retail",
+            "limit_type": "daily_transfer",
+            "new_limit_minor": 500000
+          }
+        },
+        "gate": {
+          "profile": "pythia.banking_risk.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "BLOCK",
+          "reason_codes": [
+            "TEMPORAL_AUTHORIZATION_EXPIRED"
+          ],
+          "decision_time": "2030-01-01T00:11:00Z",
+          "evaluation_clock": "2030-01-01T00:11:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "VERIFIED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "evidence_refs": [
+            "evidence:risk-policy/v7",
+            "evidence:approval/apr-201"
+          ],
+          "environment_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "target_state_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+          "continuation_requirement": "REAUTHORIZE",
+          "revalidation_requirements": [
+            "TEMPORAL_AUTHORIZATION"
+          ],
+          "artifact_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": false,
+        "authority_state": "EXPIRED",
+        "expected_additional_side_effects": 0,
+        "authorization_ref": "sha256:d2ad59397c87fa49d32e1537a02296598d7c74d6ad60347f53e87cb18a4e349d"
+      },
+      "handoff": null
+    },
+    {
+      "case_id": "target_state_drift_after_decision",
+      "input": {
+        "transition_id": "transition-target_state_drift_after_decision",
+        "subject_id": "agent:infra",
+        "source_showcase": "infrastructure",
+        "action": {
+          "identity": {
+            "caller_id": "agent:infra",
+            "tool_id": "tool:kubernetes.apply",
+            "resource_scope": "cluster:staging/namespace:payments"
+          },
+          "arguments_schema": "pythia.infrastructure.action.v1",
+          "arguments": {
+            "change_id": "chg-001",
+            "operation": "apply",
+            "resource": "deployment/api",
+            "desired_replicas": 4
+          }
+        },
+        "gate": {
+          "profile": "pythia.infrastructure.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "BLOCK",
+          "reason_codes": [
+            "TARGET_STATE_DRIFT"
+          ],
+          "decision_time": "2030-01-01T00:00:00Z",
+          "evaluation_clock": "2030-01-01T00:00:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "NOT_REQUIRED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "evidence_refs": [
+            "evidence:change/chg-001",
+            "evidence:cluster/staging-snapshot-001"
+          ],
+          "environment_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "target_state_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+          "continuation_requirement": "REVALIDATE_TARGET_STATE",
+          "revalidation_requirements": [
+            "TARGET_STATE_DIGEST"
+          ],
+          "artifact_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": false,
+        "authority_state": "REVALIDATION_REQUIRED",
+        "expected_additional_side_effects": 0,
+        "authorization_ref": "sha256:88cfbd3a26662a35eedf17915a3aa2df45cf0c567490ea7aaac9b1325eaecbcb"
+      },
+      "handoff": null
+    },
+    {
+      "case_id": "evidence_updated_before_execution",
+      "input": {
+        "transition_id": "transition-evidence_updated_before_execution",
+        "subject_id": "agent:banking",
+        "source_showcase": "banking-risk",
+        "action": {
+          "identity": {
+            "caller_id": "agent:banking",
+            "tool_id": "tool:risk.limit_update",
+            "resource_scope": "bank:demo/portfolio:retail"
+          },
+          "arguments_schema": "pythia.banking_risk.action.v1",
+          "arguments": {
+            "customer_segment": "retail",
+            "limit_type": "daily_transfer",
+            "new_limit_minor": 500000
+          }
+        },
+        "gate": {
+          "profile": "pythia.banking_risk.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "BLOCK",
+          "reason_codes": [
+            "EVIDENCE_SNAPSHOT_STALE"
+          ],
+          "decision_time": "2030-01-01T00:05:00Z",
+          "evaluation_clock": "2030-01-01T00:05:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:20:00Z",
+          "approval_state": "VERIFIED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "evidence_refs": [
+            "evidence:risk-policy/v7",
+            "evidence:approval/apr-201"
+          ],
+          "environment_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "target_state_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+          "continuation_requirement": "REVALIDATE_EVIDENCE",
+          "revalidation_requirements": [
+            "EVIDENCE_SNAPSHOT_DIGEST"
+          ],
+          "artifact_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": false,
+        "authority_state": "REVALIDATION_REQUIRED",
+        "expected_additional_side_effects": 0,
+        "authorization_ref": "sha256:41bfa0b44e0f079d0ec68c6ff932c5debbaa1327b784cd5b4722d58d1426bfc0"
+      },
+      "handoff": null
+    },
+    {
+      "case_id": "accepted_with_matching_observation",
+      "input": {
+        "transition_id": "transition-accepted_with_matching_observation",
+        "subject_id": "agent:treasury",
+        "source_showcase": "web3-treasury",
+        "action": {
+          "identity": {
+            "caller_id": "agent:treasury",
+            "tool_id": "tool:treasury.transfer",
+            "resource_scope": "dao:demo/treasury:primary"
+          },
+          "arguments_schema": "pythia.web3_treasury.action.v1",
+          "arguments": {
+            "proposal_id": "prop-001",
+            "asset": "USDC",
+            "amount_minor": 25000000000,
+            "recipient": "wallet:vendor-001"
+          }
+        },
+        "gate": {
+          "profile": "pythia.web3_treasury.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "ALLOW",
+          "reason_codes": [
+            "QUORUM_MET",
+            "TIMELOCK_SATISFIED",
+            "TRANSFER_WINDOW_ACTIVE"
+          ],
+          "decision_time": "2030-01-01T00:02:00Z",
+          "evaluation_clock": "2030-01-01T00:02:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "VERIFIED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "evidence_refs": [
+            "evidence:proposal/prop-001",
+            "evidence:quorum/prop-001",
+            "evidence:timelock/prop-001"
+          ],
+          "environment_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "target_state_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "continuation_requirement": "NONE",
+          "revalidation_requirements": [],
+          "artifact_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": true,
+        "authority_state": "ACTIVE",
+        "expected_additional_side_effects": 1,
+        "authorization_ref": "sha256:49a639c20bf08eb2b82756cd6334c996c8c00acb62fe2ed2cc06319afbafbd96",
+        "observation_ref": "sha256:b6eba3b888f17bd55ff322aac40e16d679e4cd454536c78e3742674364778bc7"
+      },
+      "handoff": {
+        "observation": {
+          "execution_status": "EXECUTED",
+          "observed_at": "2030-01-01T00:03:00Z",
+          "result_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "issuer": "runtime:mock-treasury-rail"
+        },
+        "expected_join": "MATCH"
+      }
+    },
+    {
+      "case_id": "accepted_with_contradicted_external_response",
+      "input": {
+        "transition_id": "transition-accepted_with_contradicted_external_response",
+        "subject_id": "agent:treasury",
+        "source_showcase": "web3-treasury",
+        "action": {
+          "identity": {
+            "caller_id": "agent:treasury",
+            "tool_id": "tool:treasury.transfer",
+            "resource_scope": "dao:demo/treasury:primary"
+          },
+          "arguments_schema": "pythia.web3_treasury.action.v1",
+          "arguments": {
+            "proposal_id": "prop-001",
+            "asset": "USDC",
+            "amount_minor": 25000000000,
+            "recipient": "wallet:vendor-001"
+          }
+        },
+        "gate": {
+          "profile": "pythia.web3_treasury.pre_execution.v1",
+          "version": "1.0.0",
+          "decision": "ALLOW",
+          "reason_codes": [
+            "QUORUM_MET",
+            "TIMELOCK_SATISFIED",
+            "TRANSFER_WINDOW_ACTIVE"
+          ],
+          "decision_time": "2030-01-01T00:02:00Z",
+          "evaluation_clock": "2030-01-01T00:02:00Z",
+          "valid_from": "2030-01-01T00:00:00Z",
+          "expires_at": "2030-01-01T00:10:00Z",
+          "approval_state": "VERIFIED",
+          "credential_state": "VALID",
+          "evidence_snapshot_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "evidence_refs": [
+            "evidence:proposal/prop-001",
+            "evidence:quorum/prop-001",
+            "evidence:timelock/prop-001"
+          ],
+          "environment_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "target_state_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "continuation_requirement": "NONE",
+          "revalidation_requirements": [],
+          "artifact_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "verification_status": "VERIFIED",
+          "verifier": "pythia:local-demo"
+        }
+      },
+      "expected": {
+        "execution_allowed": true,
+        "authority_state": "ACTIVE",
+        "expected_additional_side_effects": 1,
+        "authorization_ref": "sha256:45c84a874da60ce4edeea28ef7e5f0a6dd477aa220bf28fe19a4a31824bf7fbc",
+        "observation_ref": "sha256:b9a1d5bd52a37e31e9c83a0b90e57465f0e96aa9b7a968f0b8834579c3a9c689",
+        "response_integrity_ref": "sha256:d6b53dcd1b22a1f5cc1e637d7b7a7704ba55fe3877eaa849338138719e31d2bc"
+      },
+      "handoff": {
+        "observation": {
+          "execution_status": "EXECUTED",
+          "observed_at": "2030-01-01T00:03:00Z",
+          "result_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "issuer": "runtime:mock-treasury-rail"
+        },
+        "expected_join": "MATCH_WITH_INTEGRITY_FAILURE",
+        "response_integrity": {
+          "overall_verdict": "FAILED",
+          "verifier": "ltp:external-demo",
+          "claim_boundary": "External verifier result; PythiaLabs did not author this semantic verdict."
+        }
+      }
+    }
+  ],
+  "invariants": [
+    "Only ALLOW records with ACTIVE authority permit execution.",
+    "BLOCK and ESCALATE records expect zero additional side effects.",
+    "Decision-time evidence, environment, and target-state digests remain explicit.",
+    "Observation and response-integrity records remain independently attributed.",
+    "A downstream integrity failure does not rewrite the original authorization decision.",
+    "Expired or drifted authority requires reauthorization or deterministic revalidation."
+  ]
+}

--- a/docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md
+++ b/docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md
@@ -25,11 +25,15 @@ is uncompromised, or that a model later described the result honestly.
 - Schema: [`schemas/interop/pythialabs-authorization-record-v0.1.schema.json`](../../schemas/interop/pythialabs-authorization-record-v0.1.schema.json)
 - Fixtures: [`conformance/pythialabs-authorization-export-v0.1.json`](../../conformance/pythialabs-authorization-export-v0.1.json)
 - Exporter/verifier: [`scripts/check_pythialabs_authorization_export.py`](../../scripts/check_pythialabs_authorization_export.py)
+- Adversarial tests: [`scripts/test_pythialabs_authorization_export.py`](../../scripts/test_pythialabs_authorization_export.py)
+- Pinned dependencies: [`scripts/requirements-pythialabs-authorization-export.txt`](../../scripts/requirements-pythialabs-authorization-export.txt)
 
 Run:
 
 ```bash
+python3 -m pip install -r scripts/requirements-pythialabs-authorization-export.txt
 python3 scripts/check_pythialabs_authorization_export.py
+python3 scripts/test_pythialabs_authorization_export.py
 ```
 
 Emit one derived record and its optional handoff:
@@ -80,8 +84,17 @@ The record is wrapped with canonical bytes and a SHA-256 reference:
 record_ref = "sha256:" + SHA256(RFC8785-JCS(record))
 ```
 
-The published vector contains no floating-point values, so standard-library
-sorted minimal JSON is equivalent to RFC 8785 JCS for this fixture domain.
+The checker uses the `rfc8785` implementation directly, so hashes follow JCS
+number, string, and object-key serialization rules rather than Python-specific
+`json.dumps` behavior. The adversarial suite includes a number-serialization
+case that differs from ordinary Python JSON output.
+
+## Schema enforcement
+
+Every derived authorization record is validated against the published Draft
+2020-12 JSON Schema with format checking enabled. This validation runs before
+pinned record-reference comparison, so malformed values cannot be hidden by
+updating the expected hash.
 
 ## Showcase adapters
 
@@ -96,7 +109,8 @@ PythiaLabs domains:
 
 `source_showcase` and `gate_profile` preserve provenance, but Elixir module
 names, atoms, structs, or function names are not normative interoperability
-fields.
+fields. The checker also verifies that each showcase maps to its declared gate
+profile.
 
 ## Decision-time bindings
 
@@ -133,7 +147,7 @@ artifact_digest
 This separation makes evidence refresh, environment drift, and target-state
 drift visible instead of hiding all context behind one generic hash.
 
-## Decisions
+## Decisions and derived authority
 
 The portable decision values are:
 
@@ -143,19 +157,28 @@ BLOCK
 ESCALATE
 ```
 
+The verifier derives the effective authority state from the actual gate fields.
+It does not trust `expected.authority_state` as input. Derivation considers:
+
+- `evaluation_clock` relative to `valid_from` and `expires_at`;
+- `revalidation_requirements`;
+- `continuation_requirement`;
+- decision, approval, credential, and verification status.
+
 Only an `ALLOW` record whose derived authority state is `ACTIVE` permits the
 fixture's one expected side effect. `BLOCK`, `ESCALATE`, expired, or
 revalidation-required cases expect zero additional side effects.
 
 ## Temporal and drift semantics
 
-A decision may become unusable after it was created because:
+A decision may be unusable because:
 
 - its temporal authorization expired;
-- the target-state digest changed;
-- the evidence snapshot changed;
-- credentials or approval changed;
-- an explicit revalidation requirement became active.
+- the evaluation clock precedes its validity window;
+- target-state revalidation is required;
+- evidence-snapshot revalidation is required;
+- credentials or approval are not valid;
+- the decision artifact is not verified.
 
 The record retains the original decision-time evidence for audit, but stale
 evidence does not remain live authority.
@@ -179,6 +202,13 @@ authorization and observation records. Imported records keep their own issuer,
 verifier, and claim boundary. PythiaLabs does not adopt their semantic verdicts
 as its own.
 
+The checker derives the join result instead of merely carrying fixture text:
+
+- `MATCH` when authorization and observation bind correctly and no supplied
+  integrity record reports failure;
+- `MATCH_WITH_INTEGRITY_FAILURE` when the joins are intact but the independently
+  attributed response-integrity verdict is not `VERIFIED`.
+
 ## Fixture coverage
 
 The conformance vector covers:
@@ -191,11 +221,14 @@ The conformance vector covers:
 6. accepted Web3 action with matching observation;
 7. accepted Web3 action with a contradicted external response claim.
 
+The adversarial suite additionally proves rejection of a forged authority
+expectation, a forged join expectation, and a schema-invalid showcase value.
+
 ## Claim boundary
 
-This profile proves deterministic export, canonicalization, digest stability,
-decision-time context binding, and record-join consistency for the fixture
-domain.
+This profile proves deterministic export, RFC 8785 canonicalization, schema
+validation, authority-state derivation, digest stability, decision-time context
+binding, and record-join consistency for the fixture domain.
 
 It does not by itself prove:
 

--- a/docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md
+++ b/docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md
@@ -1,0 +1,215 @@
+# PythiaLabs Canonical Authorization Export Profile v0.1
+
+**Status:** Draft interoperability profile  
+**Issue:** [PythiaLabs #204](https://github.com/safal207/pythiaLabs/issues/204)  
+**Canonical ecosystem profile:** [Liminal #108](https://github.com/safal207/Liminal/issues/108)
+
+## Purpose
+
+PythiaLabs evaluates proposed high-risk agent actions before tool execution.
+This profile exports those deterministic gate decisions as provider-neutral
+`authorization_record` artifacts that can later be joined to an
+`observation_record` and a separately issued `response_integrity_record`.
+
+The record answers:
+
+> What exact action was evaluated, against which decision-time evidence,
+> environment, target state, credentials, approval state, and temporal window,
+> and what deterministic gate decision was returned?
+
+It does not prove that a downstream tool executed, that an observation source
+is uncompromised, or that a model later described the result honestly.
+
+## Files
+
+- Schema: [`schemas/interop/pythialabs-authorization-record-v0.1.schema.json`](../../schemas/interop/pythialabs-authorization-record-v0.1.schema.json)
+- Fixtures: [`conformance/pythialabs-authorization-export-v0.1.json`](../../conformance/pythialabs-authorization-export-v0.1.json)
+- Exporter/verifier: [`scripts/check_pythialabs_authorization_export.py`](../../scripts/check_pythialabs_authorization_export.py)
+
+Run:
+
+```bash
+python3 scripts/check_pythialabs_authorization_export.py
+```
+
+Emit one derived record and its optional handoff:
+
+```bash
+python3 scripts/check_pythialabs_authorization_export.py \
+  --emit-case accepted_with_matching_observation
+```
+
+## Portable record
+
+A conforming record includes:
+
+```text
+schema
+profile
+transition_id
+subject_id
+source_showcase
+gate_profile
+gate_version
+action_identity_profile
+action_identity_digest
+arguments_profile
+arguments_digest
+decision
+reason_codes
+decision_time
+evaluation_clock
+valid_from
+expires_at
+approval_state
+credential_state
+evidence_snapshot_digest
+evidence_refs
+environment_digest
+target_state_digest
+continuation_requirement
+revalidation_requirements
+artifact_digest
+verification
+claim_boundary
+```
+
+The record is wrapped with canonical bytes and a SHA-256 reference:
+
+```text
+record_ref = "sha256:" + SHA256(RFC8785-JCS(record))
+```
+
+The published vector contains no floating-point values, so standard-library
+sorted minimal JSON is equivalent to RFC 8785 JCS for this fixture domain.
+
+## Showcase adapters
+
+The fixture pack demonstrates one portable shape across three existing
+PythiaLabs domains:
+
+| Source showcase | Gate profile |
+| --- | --- |
+| Infrastructure | `pythia.infrastructure.pre_execution.v1` |
+| Banking risk | `pythia.banking_risk.pre_execution.v1` |
+| Web3 treasury | `pythia.web3_treasury.pre_execution.v1` |
+
+`source_showcase` and `gate_profile` preserve provenance, but Elixir module
+names, atoms, structs, or function names are not normative interoperability
+fields.
+
+## Decision-time bindings
+
+### Action identity
+
+The action identity digest binds:
+
+```text
+caller_id
+tool_id
+resource_scope
+```
+
+### Arguments
+
+The arguments digest binds:
+
+```text
+arguments_schema
+arguments
+```
+
+### Evidence and environment
+
+The record separately preserves:
+
+```text
+evidence_snapshot_digest
+environment_digest
+target_state_digest
+artifact_digest
+```
+
+This separation makes evidence refresh, environment drift, and target-state
+drift visible instead of hiding all context behind one generic hash.
+
+## Decisions
+
+The portable decision values are:
+
+```text
+ALLOW
+BLOCK
+ESCALATE
+```
+
+Only an `ALLOW` record whose derived authority state is `ACTIVE` permits the
+fixture's one expected side effect. `BLOCK`, `ESCALATE`, expired, or
+revalidation-required cases expect zero additional side effects.
+
+## Temporal and drift semantics
+
+A decision may become unusable after it was created because:
+
+- its temporal authorization expired;
+- the target-state digest changed;
+- the evidence snapshot changed;
+- credentials or approval changed;
+- an explicit revalidation requirement became active.
+
+The record retains the original decision-time evidence for audit, but stale
+evidence does not remain live authority.
+
+## Downstream handoff
+
+A downstream runtime may issue an `observation_record` that repeats:
+
+```text
+transition_id
+subject_id
+authorization_ref
+action_identity_digest
+binding_digest
+```
+
+where `binding_digest` equals the PythiaLabs `arguments_digest`.
+
+A separate verifier may issue a `response_integrity_record` that references the
+authorization and observation records. Imported records keep their own issuer,
+verifier, and claim boundary. PythiaLabs does not adopt their semantic verdicts
+as its own.
+
+## Fixture coverage
+
+The conformance vector covers:
+
+1. accepted reversible infrastructure action;
+2. blocked destructive infrastructure action without approval;
+3. expired banking-risk temporal authorization;
+4. target-state drift after decision;
+5. evidence updated before execution;
+6. accepted Web3 action with matching observation;
+7. accepted Web3 action with a contradicted external response claim.
+
+## Claim boundary
+
+This profile proves deterministic export, canonicalization, digest stability,
+decision-time context binding, and record-join consistency for the fixture
+domain.
+
+It does not by itself prove:
+
+- production security;
+- policy correctness;
+- signer or credential identity;
+- observation-source integrity;
+- financial settlement;
+- regulatory compliance;
+- complete agent safety;
+- truthfulness of a later model response.
+
+## Canonical invariant
+
+> PythiaLabs decides before action and exports exactly what it decided against.
+> Execution evidence and response honesty may be attached later, but their
+> verdicts remain independent.

--- a/schemas/interop/pythialabs-authorization-record-v0.1.schema.json
+++ b/schemas/interop/pythialabs-authorization-record-v0.1.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pythialabs.example/schemas/interop/pythialabs-authorization-record-v0.1.schema.json",
+  "title": "PythiaLabs Provider-Neutral Authorization Record v0.1",
+  "type": "object",
+  "required": [
+    "schema",
+    "profile",
+    "transition_id",
+    "subject_id",
+    "source_showcase",
+    "gate_profile",
+    "gate_version",
+    "action_identity_profile",
+    "action_identity_digest",
+    "arguments_profile",
+    "arguments_digest",
+    "decision",
+    "reason_codes",
+    "decision_time",
+    "evaluation_clock",
+    "valid_from",
+    "expires_at",
+    "approval_state",
+    "credential_state",
+    "evidence_snapshot_digest",
+    "evidence_refs",
+    "environment_digest",
+    "target_state_digest",
+    "continuation_requirement",
+    "revalidation_requirements",
+    "artifact_digest",
+    "verification",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "org.pythialabs.authorization-record.v0.1"
+    },
+    "profile": {
+      "const": "org.pythialabs.authorization-export.v0.1"
+    },
+    "transition_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_showcase": {
+      "enum": [
+        "infrastructure",
+        "banking-risk",
+        "web3-treasury"
+      ]
+    },
+    "gate_profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "gate_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_identity_profile": {
+      "const": "org.liminal.trustworthy-transition.action-identity.v0.1"
+    },
+    "action_identity_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "arguments_profile": {
+      "const": "org.pythialabs.authorization-arguments.v0.1"
+    },
+    "arguments_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "decision": {
+      "enum": [
+        "ALLOW",
+        "BLOCK",
+        "ESCALATE"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "decision_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evaluation_clock": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "valid_from": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "approval_state": {
+      "type": "string",
+      "minLength": 1
+    },
+    "credential_state": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_snapshot_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "environment_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "target_state_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "continuation_requirement": {
+      "type": "string",
+      "minLength": 1
+    },
+    "revalidation_requirements": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "artifact_digest": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "verification": {
+      "type": "object",
+      "required": [
+        "algorithm",
+        "status",
+        "verifier"
+      ],
+      "properties": {
+        "algorithm": {
+          "const": "sha256"
+        },
+        "status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verifier": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "sha256Ref": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/scripts/check_pythialabs_authorization_export.py
+++ b/scripts/check_pythialabs_authorization_export.py
@@ -50,7 +50,9 @@ def canonical(value: Any) -> bytes:
     try:
         return rfc8785.dumps(value)
     except rfc8785.CanonicalizationError as error:
-        raise FixtureError(f"value cannot be canonicalized with RFC 8785: {error}") from error
+        raise FixtureError(
+            f"value cannot be canonicalized with RFC 8785: {error}"
+        ) from error
 
 
 def digest(value: Any) -> str:
@@ -80,7 +82,7 @@ def strings(
         raise FixtureError(f"{label} must be a string array")
     if len(value) != len(set(value)):
         raise FixtureError(f"{label} must not contain duplicates")
-    return value
+    return list(value)
 
 
 def sha256_ref(value: Any, label: str) -> str:
@@ -279,7 +281,11 @@ def derive_authority_state(record: dict[str, Any]) -> str:
 
     requirements = record["revalidation_requirements"]
     continuation = record["continuation_requirement"]
-    if requirements or continuation.startswith("REVALIDATE") or continuation == "REAUTHORIZE":
+    if (
+        requirements
+        or continuation.startswith("REVALIDATE")
+        or continuation == "REAUTHORIZE"
+    ):
         return "REVALIDATION_REQUIRED"
     if record["decision"] != "ALLOW":
         return "BLOCKED"
@@ -301,7 +307,9 @@ def handoff(
     if source is None:
         return None
     case_id = case["case_id"]
-    if not isinstance(source, dict) or not isinstance(source.get("observation"), dict):
+    if not isinstance(source, dict) or not isinstance(
+        source.get("observation"), dict
+    ):
         raise FixtureError(f"{case_id} has invalid handoff")
     if not {"observation", "expected_join"}.issubset(source):
         raise FixtureError(f"{case_id} handoff is incomplete")
@@ -340,7 +348,10 @@ def handoff(
         "issuer": text(observation_input.get("issuer"), f"{case_id}.issuer"),
     }
     if observation["execution_status"] not in {
-        "EXECUTED", "BLOCKED", "ERRORED", "REFUSED"
+        "EXECUTED",
+        "BLOCKED",
+        "ERRORED",
+        "REFUSED",
     }:
         raise FixtureError(f"{case_id} has invalid execution_status")
     result: dict[str, Any] = {
@@ -371,7 +382,8 @@ def handoff(
                 f"{case_id}.overall_verdict",
             ),
             "verifier": text(
-                integrity_input.get("verifier"), f"{case_id}.integrity.verifier"
+                integrity_input.get("verifier"),
+                f"{case_id}.integrity.verifier",
             ),
             "claim_boundary": text(
                 integrity_input.get("claim_boundary"),
@@ -391,7 +403,11 @@ def derive_join(joined: dict[str, Any]) -> str:
     if integrity is None:
         return "MATCH"
     verdict = integrity["record"]["overall_verdict"]
-    return "MATCH" if verdict == "VERIFIED" else "MATCH_WITH_INTEGRITY_FAILURE"
+    return (
+        "MATCH"
+        if verdict == "VERIFIED"
+        else "MATCH_WITH_INTEGRITY_FAILURE"
+    )
 
 
 def verify(
@@ -437,7 +453,10 @@ def verify(
         observation_record = observation["record"]
         if observation_record["authorization_ref"] != authorization["record_ref"]:
             raise FixtureError(f"{case_id} authorization join mismatch")
-        if observation_record["action_identity_digest"] != record["action_identity_digest"]:
+        if (
+            observation_record["action_identity_digest"]
+            != record["action_identity_digest"]
+        ):
             raise FixtureError(f"{case_id} action identity join mismatch")
         if observation_record["binding_digest"] != record["arguments_digest"]:
             raise FixtureError(f"{case_id} arguments binding join mismatch")
@@ -450,12 +469,18 @@ def verify(
         integrity = joined.get("response_integrity_record")
         if integrity is not None:
             if integrity["record_ref"] != expected.get("response_integrity_ref"):
-                raise FixtureError(f"{case_id} response_integrity_ref regression")
+                raise FixtureError(
+                    f"{case_id} response_integrity_ref regression"
+                )
             integrity_record = integrity["record"]
             if integrity_record["authorization_ref"] != authorization["record_ref"]:
-                raise FixtureError(f"{case_id} integrity authorization join mismatch")
+                raise FixtureError(
+                    f"{case_id} integrity authorization join mismatch"
+                )
             if integrity_record["observation_refs"] != [observation["record_ref"]]:
-                raise FixtureError(f"{case_id} integrity observation join mismatch")
+                raise FixtureError(
+                    f"{case_id} integrity observation join mismatch"
+                )
 
         derived_join = derive_join(joined)
         if joined["expected_join"] != derived_join:
@@ -484,7 +509,9 @@ def main() -> int:
         "fixture",
         nargs="?",
         type=Path,
-        default=Path("conformance/pythialabs-authorization-export-v0.1.json"),
+        default=Path(
+            "conformance/pythialabs-authorization-export-v0.1.json"
+        ),
     )
     parser.add_argument("--emit-case")
     args = parser.parse_args()
@@ -529,7 +556,9 @@ def main() -> int:
             if selected is None:
                 raise FixtureError(f"unknown case_id: {args.emit_case}")
             print(json.dumps(selected, ensure_ascii=False, indent=2))
-        print(f"\nPythiaLabs authorization export fixtures passed: {len(seen)}")
+        print(
+            f"\nPythiaLabs authorization export fixtures passed: {len(seen)}"
+        )
         return 0
     except (OSError, json.JSONDecodeError, FixtureError) as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/scripts/check_pythialabs_authorization_export.py
+++ b/scripts/check_pythialabs_authorization_export.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Check PythiaLabs canonical authorization export fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+AUTH_SCHEMA = "org.pythialabs.authorization-record.v0.1"
+EXPORT_PROFILE = "org.pythialabs.authorization-export.v0.1"
+ACTION_PROFILE = "org.liminal.trustworthy-transition.action-identity.v0.1"
+ARGS_PROFILE = "org.pythialabs.authorization-arguments.v0.1"
+OBS_SCHEMA = "org.liminal.trustworthy-transition.observation.v0.1"
+INTEGRITY_SCHEMA = "org.liminal.trustworthy-transition.response-integrity.v0.1"
+CLAIM_BOUNDARY = (
+    "PythiaLabs proves the deterministic pre-execution gate decision and the "
+    "decision-time evidence bindings in this record; it does not prove "
+    "downstream execution, observation-source truth, or response honesty."
+)
+VALID_STATES = {"ACTIVE", "BLOCKED", "EXPIRED", "REVALIDATION_REQUIRED"}
+
+
+class FixtureError(ValueError):
+    pass
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True,
+                      separators=(",", ":"), allow_nan=False)
+
+
+def digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical(value).encode()).hexdigest()
+
+
+def text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise FixtureError(f"{label} must be a non-empty string")
+    return value
+
+
+def strings(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(x, str) or not x for x in value):
+        raise FixtureError(f"{label} must be a string array")
+    if len(value) != len(set(value)):
+        raise FixtureError(f"{label} must not contain duplicates")
+    return value
+
+
+def wrap(record: dict[str, Any]) -> dict[str, Any]:
+    body = canonical(record)
+    return {
+        "record": record,
+        "canonical_bytes_utf8": body,
+        "record_ref": "sha256:" + hashlib.sha256(body.encode()).hexdigest(),
+    }
+
+
+def export(case: dict[str, Any]) -> dict[str, Any]:
+    case_id = text(case.get("case_id"), "case_id")
+    source = case.get("input")
+    if not isinstance(source, dict):
+        raise FixtureError(f"{case_id}.input must be an object")
+    action = source.get("action")
+    gate = source.get("gate")
+    if not isinstance(action, dict) or not isinstance(gate, dict):
+        raise FixtureError(f"{case_id} requires action and gate objects")
+    identity = action.get("identity")
+    arguments = action.get("arguments")
+    if not isinstance(identity, dict) or not isinstance(arguments, dict):
+        raise FixtureError(f"{case_id} requires identity and arguments objects")
+    if set(identity) != {"caller_id", "tool_id", "resource_scope"}:
+        raise FixtureError(f"{case_id} has invalid action identity")
+
+    action_preimage = {"profile_id": ACTION_PROFILE, **identity}
+    arguments_preimage = {
+        "profile_id": ARGS_PROFILE,
+        "arguments_schema": text(action.get("arguments_schema"), "arguments_schema"),
+        "arguments": arguments,
+    }
+    record = {
+        "schema": AUTH_SCHEMA,
+        "profile": EXPORT_PROFILE,
+        "transition_id": text(source.get("transition_id"), "transition_id"),
+        "subject_id": text(source.get("subject_id"), "subject_id"),
+        "source_showcase": text(source.get("source_showcase"), "source_showcase"),
+        "gate_profile": text(gate.get("profile"), "gate.profile"),
+        "gate_version": text(gate.get("version"), "gate.version"),
+        "action_identity_profile": ACTION_PROFILE,
+        "action_identity_digest": digest(action_preimage),
+        "arguments_profile": ARGS_PROFILE,
+        "arguments_digest": digest(arguments_preimage),
+        "decision": text(gate.get("decision"), "decision"),
+        "reason_codes": strings(gate.get("reason_codes"), "reason_codes"),
+        "decision_time": text(gate.get("decision_time"), "decision_time"),
+        "evaluation_clock": text(gate.get("evaluation_clock"), "evaluation_clock"),
+        "valid_from": text(gate.get("valid_from"), "valid_from"),
+        "expires_at": gate.get("expires_at"),
+        "approval_state": text(gate.get("approval_state"), "approval_state"),
+        "credential_state": text(gate.get("credential_state"), "credential_state"),
+        "evidence_snapshot_digest": text(gate.get("evidence_snapshot_digest"), "evidence_snapshot_digest"),
+        "evidence_refs": strings(gate.get("evidence_refs"), "evidence_refs"),
+        "environment_digest": text(gate.get("environment_digest"), "environment_digest"),
+        "target_state_digest": text(gate.get("target_state_digest"), "target_state_digest"),
+        "continuation_requirement": text(gate.get("continuation_requirement"), "continuation_requirement"),
+        "revalidation_requirements": strings(gate.get("revalidation_requirements"), "revalidation_requirements"),
+        "artifact_digest": text(gate.get("artifact_digest"), "artifact_digest"),
+        "verification": {
+            "algorithm": "sha256",
+            "status": text(gate.get("verification_status"), "verification_status"),
+            "verifier": text(gate.get("verifier"), "verifier"),
+        },
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if record["decision"] not in {"ALLOW", "BLOCK", "ESCALATE"}:
+        raise FixtureError(f"{case_id} has invalid decision")
+    return wrap(record)
+
+
+def handoff(case: dict[str, Any], authorization: dict[str, Any]) -> dict[str, Any] | None:
+    source = case.get("handoff")
+    if source is None:
+        return None
+    if not isinstance(source, dict) or not isinstance(source.get("observation"), dict):
+        raise FixtureError(f"{case['case_id']} has invalid handoff")
+    record = authorization["record"]
+    observation_input = source["observation"]
+    observation = {
+        "schema": OBS_SCHEMA,
+        "transition_id": record["transition_id"],
+        "subject_id": record["subject_id"],
+        "authorization_ref": authorization["record_ref"],
+        "action_identity_digest": record["action_identity_digest"],
+        "binding_digest": record["arguments_digest"],
+        "execution_status": text(observation_input.get("execution_status"), "execution_status"),
+        "observed_at": text(observation_input.get("observed_at"), "observed_at"),
+        "result_digest": text(observation_input.get("result_digest"), "result_digest"),
+        "issuer": text(observation_input.get("issuer"), "issuer"),
+    }
+    result: dict[str, Any] = {
+        "observation_record": {"record": observation, "record_ref": digest(observation)},
+        "expected_join": text(source.get("expected_join"), "expected_join"),
+    }
+    integrity_input = source.get("response_integrity")
+    if isinstance(integrity_input, dict):
+        integrity = {
+            "schema": INTEGRITY_SCHEMA,
+            "transition_id": record["transition_id"],
+            "subject_id": record["subject_id"],
+            "authorization_ref": authorization["record_ref"],
+            "observation_refs": [result["observation_record"]["record_ref"]],
+            "overall_verdict": text(integrity_input.get("overall_verdict"), "overall_verdict"),
+            "verifier": text(integrity_input.get("verifier"), "integrity.verifier"),
+            "claim_boundary": text(integrity_input.get("claim_boundary"), "integrity.claim_boundary"),
+        }
+        result["response_integrity_record"] = {"record": integrity, "record_ref": digest(integrity)}
+    return result
+
+
+def verify(case: dict[str, Any]) -> dict[str, Any]:
+    case_id = text(case.get("case_id"), "case_id")
+    expected = case.get("expected")
+    if not isinstance(expected, dict):
+        raise FixtureError(f"{case_id}.expected must be an object")
+    authorization = export(case)
+    if authorization["record_ref"] != expected.get("authorization_ref"):
+        raise FixtureError(f"{case_id} authorization_ref regression")
+    state = expected.get("authority_state")
+    if state not in VALID_STATES:
+        raise FixtureError(f"{case_id} has invalid authority_state")
+    allowed = authorization["record"]["decision"] == "ALLOW" and state == "ACTIVE"
+    if expected.get("execution_allowed") is not allowed:
+        raise FixtureError(f"{case_id} execution_allowed mismatch")
+    if expected.get("expected_additional_side_effects") != (1 if allowed else 0):
+        raise FixtureError(f"{case_id} side-effect expectation mismatch")
+
+    joined = handoff(case, authorization)
+    if joined:
+        observation = joined["observation_record"]
+        if observation["record_ref"] != expected.get("observation_ref"):
+            raise FixtureError(f"{case_id} observation_ref regression")
+        if observation["record"]["authorization_ref"] != authorization["record_ref"]:
+            raise FixtureError(f"{case_id} authorization join mismatch")
+        integrity = joined.get("response_integrity_record")
+        if integrity and integrity["record_ref"] != expected.get("response_integrity_ref"):
+            raise FixtureError(f"{case_id} response_integrity_ref regression")
+    return {"authorization_record": authorization, "handoff": joined}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture", nargs="?", type=Path,
+                        default=Path("conformance/pythialabs-authorization-export-v0.1.json"))
+    parser.add_argument("--emit-case")
+    args = parser.parse_args()
+    try:
+        data = json.loads(args.fixture.read_text(encoding="utf-8"))
+        if data.get("profile") != EXPORT_PROFILE:
+            raise FixtureError("fixture profile mismatch")
+        seen: set[str] = set()
+        selected = None
+        for case in data.get("cases", []):
+            case_id = text(case.get("case_id"), "case_id")
+            if case_id in seen:
+                raise FixtureError(f"duplicate case_id: {case_id}")
+            seen.add(case_id)
+            derived = verify(case)
+            if case_id == args.emit_case:
+                selected = derived
+            record = derived["authorization_record"]["record"]
+            print(f"PASS {case_id} -> {record['source_showcase']} / {record['decision']} / {case['expected']['authority_state']}")
+        if args.emit_case:
+            if selected is None:
+                raise FixtureError(f"unknown case_id: {args.emit_case}")
+            print(json.dumps(selected, ensure_ascii=False, indent=2))
+        print(f"\nPythiaLabs authorization export fixtures passed: {len(seen)}")
+        return 0
+    except (OSError, json.JSONDecodeError, FixtureError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pythialabs_authorization_export.py
+++ b/scripts/check_pythialabs_authorization_export.py
@@ -7,8 +7,20 @@ import argparse
 import hashlib
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+try:
+    import rfc8785
+    from jsonschema import Draft202012Validator, FormatChecker
+    from jsonschema.exceptions import SchemaError
+except ImportError as error:  # pragma: no cover - exercised by local misuse
+    print(
+        "ERROR: install scripts/requirements-pythialabs-authorization-export.txt",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from error
 
 AUTH_SCHEMA = "org.pythialabs.authorization-record.v0.1"
 EXPORT_PROFILE = "org.pythialabs.authorization-export.v0.1"
@@ -16,51 +28,129 @@ ACTION_PROFILE = "org.liminal.trustworthy-transition.action-identity.v0.1"
 ARGS_PROFILE = "org.pythialabs.authorization-arguments.v0.1"
 OBS_SCHEMA = "org.liminal.trustworthy-transition.observation.v0.1"
 INTEGRITY_SCHEMA = "org.liminal.trustworthy-transition.response-integrity.v0.1"
+SCHEMA_PATH = Path(
+    "schemas/interop/pythialabs-authorization-record-v0.1.schema.json"
+)
 CLAIM_BOUNDARY = (
     "PythiaLabs proves the deterministic pre-execution gate decision and the "
     "decision-time evidence bindings in this record; it does not prove "
     "downstream execution, observation-source truth, or response honesty."
 )
 VALID_STATES = {"ACTIVE", "BLOCKED", "EXPIRED", "REVALIDATION_REQUIRED"}
+VALID_JOINS = {"MATCH", "MATCH_WITH_INTEGRITY_FAILURE"}
+SHA256_PREFIX = "sha256:"
 
 
 class FixtureError(ValueError):
-    pass
+    """Raised when a conformance fixture violates the export contract."""
 
 
-def canonical(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True,
-                      separators=(",", ":"), allow_nan=False)
+def canonical(value: Any) -> bytes:
+    """Return RFC 8785/JCS canonical UTF-8 bytes for a JSON value."""
+    try:
+        return rfc8785.dumps(value)
+    except rfc8785.CanonicalizationError as error:
+        raise FixtureError(f"value cannot be canonicalized with RFC 8785: {error}") from error
 
 
 def digest(value: Any) -> str:
-    return "sha256:" + hashlib.sha256(canonical(value).encode()).hexdigest()
+    """Return a lowercase SHA-256 reference over canonical JCS bytes."""
+    return SHA256_PREFIX + hashlib.sha256(canonical(value)).hexdigest()
 
 
 def text(value: Any, label: str) -> str:
+    """Require a non-empty string."""
     if not isinstance(value, str) or not value:
         raise FixtureError(f"{label} must be a non-empty string")
     return value
 
 
-def strings(value: Any, label: str) -> list[str]:
-    if not isinstance(value, list) or any(not isinstance(x, str) or not x for x in value):
+def strings(
+    value: Any,
+    label: str,
+    *,
+    allow_empty: bool = False,
+) -> list[str]:
+    """Require a unique array of non-empty strings."""
+    if not isinstance(value, list):
+        raise FixtureError(f"{label} must be a string array")
+    if not allow_empty and not value:
+        raise FixtureError(f"{label} must not be empty")
+    if any(not isinstance(item, str) or not item for item in value):
         raise FixtureError(f"{label} must be a string array")
     if len(value) != len(set(value)):
         raise FixtureError(f"{label} must not contain duplicates")
     return value
 
 
+def sha256_ref(value: Any, label: str) -> str:
+    """Require a portable sha256:<64 lowercase hex> reference."""
+    value = text(value, label)
+    if len(value) != 71 or not value.startswith(SHA256_PREFIX):
+        raise FixtureError(f"{label} must be sha256:<64 lowercase hex>")
+    suffix = value[len(SHA256_PREFIX):]
+    if any(character not in "0123456789abcdef" for character in suffix):
+        raise FixtureError(f"{label} must be sha256:<64 lowercase hex>")
+    return value
+
+
+def timestamp(value: Any, label: str) -> datetime:
+    """Parse a timezone-aware ISO-8601 timestamp."""
+    value = text(value, label)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise FixtureError(f"{label} must be ISO-8601") from error
+    if parsed.tzinfo is None:
+        raise FixtureError(f"{label} must include a timezone")
+    return parsed
+
+
+def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    """Reject missing and unknown object fields."""
+    if set(value) != expected:
+        raise FixtureError(f"{label} must contain exactly {sorted(expected)}")
+
+
 def wrap(record: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a record with canonical text and its content-addressed reference."""
     body = canonical(record)
     return {
         "record": record,
-        "canonical_bytes_utf8": body,
-        "record_ref": "sha256:" + hashlib.sha256(body.encode()).hexdigest(),
+        "canonical_bytes_utf8": body.decode("utf-8"),
+        "record_ref": SHA256_PREFIX + hashlib.sha256(body).hexdigest(),
     }
 
 
+def load_schema_validator() -> Draft202012Validator:
+    """Load and compile the published authorization-record schema."""
+    try:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+    except (OSError, json.JSONDecodeError, SchemaError) as error:
+        raise FixtureError(f"cannot load authorization schema: {error}") from error
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def validate_record(
+    case_id: str,
+    record: dict[str, Any],
+    validator: Draft202012Validator,
+) -> None:
+    """Validate a derived record against the published Draft 2020-12 schema."""
+    errors = sorted(
+        validator.iter_errors(record),
+        key=lambda error: [str(part) for part in error.absolute_path],
+    )
+    if not errors:
+        return
+    error = errors[0]
+    path = ".".join(str(part) for part in error.absolute_path) or "<record>"
+    raise FixtureError(f"{case_id} schema violation at {path}: {error.message}")
+
+
 def export(case: dict[str, Any]) -> dict[str, Any]:
+    """Derive one canonical provider-neutral authorization record."""
     case_id = text(case.get("case_id"), "case_id")
     source = case.get("input")
     if not isinstance(source, dict):
@@ -73,46 +163,93 @@ def export(case: dict[str, Any]) -> dict[str, Any]:
     arguments = action.get("arguments")
     if not isinstance(identity, dict) or not isinstance(arguments, dict):
         raise FixtureError(f"{case_id} requires identity and arguments objects")
-    if set(identity) != {"caller_id", "tool_id", "resource_scope"}:
-        raise FixtureError(f"{case_id} has invalid action identity")
+    exact_keys(
+        identity,
+        {"caller_id", "tool_id", "resource_scope"},
+        f"{case_id}.action.identity",
+    )
+    for key in ("caller_id", "tool_id", "resource_scope"):
+        text(identity.get(key), f"{case_id}.action.identity.{key}")
 
     action_preimage = {"profile_id": ACTION_PROFILE, **identity}
     arguments_preimage = {
         "profile_id": ARGS_PROFILE,
-        "arguments_schema": text(action.get("arguments_schema"), "arguments_schema"),
+        "arguments_schema": text(
+            action.get("arguments_schema"),
+            f"{case_id}.arguments_schema",
+        ),
         "arguments": arguments,
     }
+    expires_at = gate.get("expires_at")
+    if expires_at is not None:
+        text(expires_at, f"{case_id}.expires_at")
+
     record = {
         "schema": AUTH_SCHEMA,
         "profile": EXPORT_PROFILE,
-        "transition_id": text(source.get("transition_id"), "transition_id"),
-        "subject_id": text(source.get("subject_id"), "subject_id"),
-        "source_showcase": text(source.get("source_showcase"), "source_showcase"),
-        "gate_profile": text(gate.get("profile"), "gate.profile"),
-        "gate_version": text(gate.get("version"), "gate.version"),
+        "transition_id": text(
+            source.get("transition_id"), f"{case_id}.transition_id"
+        ),
+        "subject_id": text(source.get("subject_id"), f"{case_id}.subject_id"),
+        "source_showcase": text(
+            source.get("source_showcase"), f"{case_id}.source_showcase"
+        ),
+        "gate_profile": text(gate.get("profile"), f"{case_id}.gate.profile"),
+        "gate_version": text(gate.get("version"), f"{case_id}.gate.version"),
         "action_identity_profile": ACTION_PROFILE,
         "action_identity_digest": digest(action_preimage),
         "arguments_profile": ARGS_PROFILE,
         "arguments_digest": digest(arguments_preimage),
-        "decision": text(gate.get("decision"), "decision"),
-        "reason_codes": strings(gate.get("reason_codes"), "reason_codes"),
-        "decision_time": text(gate.get("decision_time"), "decision_time"),
-        "evaluation_clock": text(gate.get("evaluation_clock"), "evaluation_clock"),
-        "valid_from": text(gate.get("valid_from"), "valid_from"),
-        "expires_at": gate.get("expires_at"),
-        "approval_state": text(gate.get("approval_state"), "approval_state"),
-        "credential_state": text(gate.get("credential_state"), "credential_state"),
-        "evidence_snapshot_digest": text(gate.get("evidence_snapshot_digest"), "evidence_snapshot_digest"),
-        "evidence_refs": strings(gate.get("evidence_refs"), "evidence_refs"),
-        "environment_digest": text(gate.get("environment_digest"), "environment_digest"),
-        "target_state_digest": text(gate.get("target_state_digest"), "target_state_digest"),
-        "continuation_requirement": text(gate.get("continuation_requirement"), "continuation_requirement"),
-        "revalidation_requirements": strings(gate.get("revalidation_requirements"), "revalidation_requirements"),
-        "artifact_digest": text(gate.get("artifact_digest"), "artifact_digest"),
+        "decision": text(gate.get("decision"), f"{case_id}.decision"),
+        "reason_codes": strings(
+            gate.get("reason_codes"), f"{case_id}.reason_codes"
+        ),
+        "decision_time": text(
+            gate.get("decision_time"), f"{case_id}.decision_time"
+        ),
+        "evaluation_clock": text(
+            gate.get("evaluation_clock"), f"{case_id}.evaluation_clock"
+        ),
+        "valid_from": text(gate.get("valid_from"), f"{case_id}.valid_from"),
+        "expires_at": expires_at,
+        "approval_state": text(
+            gate.get("approval_state"), f"{case_id}.approval_state"
+        ),
+        "credential_state": text(
+            gate.get("credential_state"), f"{case_id}.credential_state"
+        ),
+        "evidence_snapshot_digest": sha256_ref(
+            gate.get("evidence_snapshot_digest"),
+            f"{case_id}.evidence_snapshot_digest",
+        ),
+        "evidence_refs": strings(
+            gate.get("evidence_refs"), f"{case_id}.evidence_refs"
+        ),
+        "environment_digest": sha256_ref(
+            gate.get("environment_digest"), f"{case_id}.environment_digest"
+        ),
+        "target_state_digest": sha256_ref(
+            gate.get("target_state_digest"), f"{case_id}.target_state_digest"
+        ),
+        "continuation_requirement": text(
+            gate.get("continuation_requirement"),
+            f"{case_id}.continuation_requirement",
+        ),
+        "revalidation_requirements": strings(
+            gate.get("revalidation_requirements"),
+            f"{case_id}.revalidation_requirements",
+            allow_empty=True,
+        ),
+        "artifact_digest": sha256_ref(
+            gate.get("artifact_digest"), f"{case_id}.artifact_digest"
+        ),
         "verification": {
             "algorithm": "sha256",
-            "status": text(gate.get("verification_status"), "verification_status"),
-            "verifier": text(gate.get("verifier"), "verifier"),
+            "status": text(
+                gate.get("verification_status"),
+                f"{case_id}.verification_status",
+            ),
+            "verifier": text(gate.get("verifier"), f"{case_id}.verifier"),
         },
         "claim_boundary": CLAIM_BOUNDARY,
     }
@@ -121,14 +258,68 @@ def export(case: dict[str, Any]) -> dict[str, Any]:
     return wrap(record)
 
 
-def handoff(case: dict[str, Any], authorization: dict[str, Any]) -> dict[str, Any] | None:
+def derive_authority_state(record: dict[str, Any]) -> str:
+    """Derive effective authority from decision-time temporal and drift fields."""
+    decision_time = timestamp(record["decision_time"], "decision_time")
+    evaluation_clock = timestamp(record["evaluation_clock"], "evaluation_clock")
+    valid_from = timestamp(record["valid_from"], "valid_from")
+    expires_at = (
+        None
+        if record["expires_at"] is None
+        else timestamp(record["expires_at"], "expires_at")
+    )
+    if decision_time > evaluation_clock:
+        raise FixtureError("decision_time must not follow evaluation_clock")
+    if expires_at is not None and expires_at < valid_from:
+        raise FixtureError("expires_at must not precede valid_from")
+    if expires_at is not None and evaluation_clock > expires_at:
+        return "EXPIRED"
+    if evaluation_clock < valid_from:
+        return "REVALIDATION_REQUIRED"
+
+    requirements = record["revalidation_requirements"]
+    continuation = record["continuation_requirement"]
+    if requirements or continuation.startswith("REVALIDATE") or continuation == "REAUTHORIZE":
+        return "REVALIDATION_REQUIRED"
+    if record["decision"] != "ALLOW":
+        return "BLOCKED"
+    if record["credential_state"] != "VALID":
+        return "BLOCKED"
+    if record["approval_state"] == "MISSING":
+        return "BLOCKED"
+    if record["verification"]["status"] != "VERIFIED":
+        return "BLOCKED"
+    return "ACTIVE"
+
+
+def handoff(
+    case: dict[str, Any],
+    authorization: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build downstream observation and optional external integrity records."""
     source = case.get("handoff")
     if source is None:
         return None
+    case_id = case["case_id"]
     if not isinstance(source, dict) or not isinstance(source.get("observation"), dict):
-        raise FixtureError(f"{case['case_id']} has invalid handoff")
+        raise FixtureError(f"{case_id} has invalid handoff")
+    if not {"observation", "expected_join"}.issubset(source):
+        raise FixtureError(f"{case_id} handoff is incomplete")
+    if not set(source).issubset(
+        {"observation", "expected_join", "response_integrity"}
+    ):
+        raise FixtureError(f"{case_id} handoff has unknown fields")
+    expected_join = text(source.get("expected_join"), f"{case_id}.expected_join")
+    if expected_join not in VALID_JOINS:
+        raise FixtureError(f"{case_id} has invalid expected_join")
+
     record = authorization["record"]
     observation_input = source["observation"]
+    exact_keys(
+        observation_input,
+        {"execution_status", "observed_at", "result_digest", "issuer"},
+        f"{case_id}.observation",
+    )
     observation = {
         "schema": OBS_SCHEMA,
         "transition_id": record["transition_id"],
@@ -136,83 +327,204 @@ def handoff(case: dict[str, Any], authorization: dict[str, Any]) -> dict[str, An
         "authorization_ref": authorization["record_ref"],
         "action_identity_digest": record["action_identity_digest"],
         "binding_digest": record["arguments_digest"],
-        "execution_status": text(observation_input.get("execution_status"), "execution_status"),
-        "observed_at": text(observation_input.get("observed_at"), "observed_at"),
-        "result_digest": text(observation_input.get("result_digest"), "result_digest"),
-        "issuer": text(observation_input.get("issuer"), "issuer"),
+        "execution_status": text(
+            observation_input.get("execution_status"),
+            f"{case_id}.execution_status",
+        ),
+        "observed_at": text(
+            observation_input.get("observed_at"), f"{case_id}.observed_at"
+        ),
+        "result_digest": sha256_ref(
+            observation_input.get("result_digest"), f"{case_id}.result_digest"
+        ),
+        "issuer": text(observation_input.get("issuer"), f"{case_id}.issuer"),
     }
+    if observation["execution_status"] not in {
+        "EXECUTED", "BLOCKED", "ERRORED", "REFUSED"
+    }:
+        raise FixtureError(f"{case_id} has invalid execution_status")
     result: dict[str, Any] = {
-        "observation_record": {"record": observation, "record_ref": digest(observation)},
-        "expected_join": text(source.get("expected_join"), "expected_join"),
+        "observation_record": {
+            "record": observation,
+            "record_ref": digest(observation),
+        },
+        "expected_join": expected_join,
     }
+
     integrity_input = source.get("response_integrity")
-    if isinstance(integrity_input, dict):
+    if integrity_input is not None:
+        if not isinstance(integrity_input, dict):
+            raise FixtureError(f"{case_id}.response_integrity must be an object")
+        exact_keys(
+            integrity_input,
+            {"overall_verdict", "verifier", "claim_boundary"},
+            f"{case_id}.response_integrity",
+        )
         integrity = {
             "schema": INTEGRITY_SCHEMA,
             "transition_id": record["transition_id"],
             "subject_id": record["subject_id"],
             "authorization_ref": authorization["record_ref"],
             "observation_refs": [result["observation_record"]["record_ref"]],
-            "overall_verdict": text(integrity_input.get("overall_verdict"), "overall_verdict"),
-            "verifier": text(integrity_input.get("verifier"), "integrity.verifier"),
-            "claim_boundary": text(integrity_input.get("claim_boundary"), "integrity.claim_boundary"),
+            "overall_verdict": text(
+                integrity_input.get("overall_verdict"),
+                f"{case_id}.overall_verdict",
+            ),
+            "verifier": text(
+                integrity_input.get("verifier"), f"{case_id}.integrity.verifier"
+            ),
+            "claim_boundary": text(
+                integrity_input.get("claim_boundary"),
+                f"{case_id}.integrity.claim_boundary",
+            ),
         }
-        result["response_integrity_record"] = {"record": integrity, "record_ref": digest(integrity)}
+        result["response_integrity_record"] = {
+            "record": integrity,
+            "record_ref": digest(integrity),
+        }
     return result
 
 
-def verify(case: dict[str, Any]) -> dict[str, Any]:
+def derive_join(joined: dict[str, Any]) -> str:
+    """Derive the handoff join outcome from independently attributed records."""
+    integrity = joined.get("response_integrity_record")
+    if integrity is None:
+        return "MATCH"
+    verdict = integrity["record"]["overall_verdict"]
+    return "MATCH" if verdict == "VERIFIED" else "MATCH_WITH_INTEGRITY_FAILURE"
+
+
+def verify(
+    case: dict[str, Any],
+    validator: Draft202012Validator,
+    showcase_adapters: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify one fixture without trusting expected authority or join verdicts."""
     case_id = text(case.get("case_id"), "case_id")
     expected = case.get("expected")
     if not isinstance(expected, dict):
         raise FixtureError(f"{case_id}.expected must be an object")
+
     authorization = export(case)
+    record = authorization["record"]
+    validate_record(case_id, record, validator)
+    expected_profile = showcase_adapters.get(record["source_showcase"])
+    if expected_profile != record["gate_profile"]:
+        raise FixtureError(f"{case_id} showcase adapter/profile mismatch")
     if authorization["record_ref"] != expected.get("authorization_ref"):
         raise FixtureError(f"{case_id} authorization_ref regression")
-    state = expected.get("authority_state")
+
+    state = derive_authority_state(record)
     if state not in VALID_STATES:
-        raise FixtureError(f"{case_id} has invalid authority_state")
-    allowed = authorization["record"]["decision"] == "ALLOW" and state == "ACTIVE"
+        raise FixtureError(f"{case_id} has invalid derived authority_state")
+    if expected.get("authority_state") != state:
+        raise FixtureError(
+            f"{case_id} authority_state mismatch: "
+            f"{expected.get('authority_state')} != {state}"
+        )
+    allowed = record["decision"] == "ALLOW" and state == "ACTIVE"
     if expected.get("execution_allowed") is not allowed:
         raise FixtureError(f"{case_id} execution_allowed mismatch")
     if expected.get("expected_additional_side_effects") != (1 if allowed else 0):
         raise FixtureError(f"{case_id} side-effect expectation mismatch")
 
     joined = handoff(case, authorization)
-    if joined:
+    derived_join = None
+    if joined is not None:
         observation = joined["observation_record"]
         if observation["record_ref"] != expected.get("observation_ref"):
             raise FixtureError(f"{case_id} observation_ref regression")
-        if observation["record"]["authorization_ref"] != authorization["record_ref"]:
+        observation_record = observation["record"]
+        if observation_record["authorization_ref"] != authorization["record_ref"]:
             raise FixtureError(f"{case_id} authorization join mismatch")
+        if observation_record["action_identity_digest"] != record["action_identity_digest"]:
+            raise FixtureError(f"{case_id} action identity join mismatch")
+        if observation_record["binding_digest"] != record["arguments_digest"]:
+            raise FixtureError(f"{case_id} arguments binding join mismatch")
+        observed_at = timestamp(observation_record["observed_at"], "observed_at")
+        if observed_at < timestamp(record["decision_time"], "decision_time"):
+            raise FixtureError(f"{case_id} observation predates decision")
+        if observation_record["execution_status"] == "EXECUTED" and not allowed:
+            raise FixtureError(f"{case_id} executed without active authority")
+
         integrity = joined.get("response_integrity_record")
-        if integrity and integrity["record_ref"] != expected.get("response_integrity_ref"):
-            raise FixtureError(f"{case_id} response_integrity_ref regression")
-    return {"authorization_record": authorization, "handoff": joined}
+        if integrity is not None:
+            if integrity["record_ref"] != expected.get("response_integrity_ref"):
+                raise FixtureError(f"{case_id} response_integrity_ref regression")
+            integrity_record = integrity["record"]
+            if integrity_record["authorization_ref"] != authorization["record_ref"]:
+                raise FixtureError(f"{case_id} integrity authorization join mismatch")
+            if integrity_record["observation_refs"] != [observation["record_ref"]]:
+                raise FixtureError(f"{case_id} integrity observation join mismatch")
+
+        derived_join = derive_join(joined)
+        if joined["expected_join"] != derived_join:
+            raise FixtureError(
+                f"{case_id} expected_join mismatch: "
+                f"{joined['expected_join']} != {derived_join}"
+            )
+    elif any(
+        key in expected
+        for key in ("observation_ref", "response_integrity_ref")
+    ):
+        raise FixtureError(f"{case_id} expected handoff references without handoff")
+
+    return {
+        "authorization_record": authorization,
+        "authority_state": state,
+        "derived_join": derived_join,
+        "handoff": joined,
+    }
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("fixture", nargs="?", type=Path,
-                        default=Path("conformance/pythialabs-authorization-export-v0.1.json"))
+    """Load fixtures, validate every case, and optionally emit one derivation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "fixture",
+        nargs="?",
+        type=Path,
+        default=Path("conformance/pythialabs-authorization-export-v0.1.json"),
+    )
     parser.add_argument("--emit-case")
     args = parser.parse_args()
     try:
         data = json.loads(args.fixture.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise FixtureError("fixture must contain an object")
         if data.get("profile") != EXPORT_PROFILE:
             raise FixtureError("fixture profile mismatch")
+        if data.get("canonicalization") != "RFC8785-JCS":
+            raise FixtureError("fixture canonicalization mismatch")
+        if data.get("hash_algorithm") != "sha256":
+            raise FixtureError("fixture hash algorithm mismatch")
+        if data.get("schema_path") != str(SCHEMA_PATH):
+            raise FixtureError("fixture schema path mismatch")
+        cases = data.get("cases")
+        showcase_adapters = data.get("showcase_adapters")
+        if not isinstance(cases, list) or not cases:
+            raise FixtureError("fixture cases must be a non-empty array")
+        if not isinstance(showcase_adapters, dict):
+            raise FixtureError("showcase_adapters must be an object")
+
+        validator = load_schema_validator()
         seen: set[str] = set()
         selected = None
-        for case in data.get("cases", []):
+        for case in cases:
+            if not isinstance(case, dict):
+                raise FixtureError("case entry must be an object")
             case_id = text(case.get("case_id"), "case_id")
             if case_id in seen:
                 raise FixtureError(f"duplicate case_id: {case_id}")
             seen.add(case_id)
-            derived = verify(case)
+            derived = verify(case, validator, showcase_adapters)
             if case_id == args.emit_case:
                 selected = derived
             record = derived["authorization_record"]["record"]
-            print(f"PASS {case_id} -> {record['source_showcase']} / {record['decision']} / {case['expected']['authority_state']}")
+            print(
+                f"PASS {case_id} -> {record['source_showcase']} / "
+                f"{record['decision']} / {derived['authority_state']}"
+            )
         if args.emit_case:
             if selected is None:
                 raise FixtureError(f"unknown case_id: {args.emit_case}")

--- a/scripts/pythialabs_authorization_export_requirements.txt
+++ b/scripts/pythialabs_authorization_export_requirements.txt
@@ -1,0 +1,2 @@
+rfc8785==0.1.4
+jsonschema[format]==4.26.0

--- a/scripts/pythialabs_authorization_export_requirements.txt
+++ b/scripts/pythialabs_authorization_export_requirements.txt
@@ -1,2 +1,0 @@
-rfc8785==0.1.4
-jsonschema[format]==4.26.0

--- a/scripts/requirements-pythialabs-authorization-export.txt
+++ b/scripts/requirements-pythialabs-authorization-export.txt
@@ -1,0 +1,2 @@
+rfc8785==0.1.4
+jsonschema[format]==4.26.0

--- a/scripts/test_pythialabs_authorization_export.py
+++ b/scripts/test_pythialabs_authorization_export.py
@@ -15,7 +15,9 @@ FIXTURE_PATH = Path("conformance/pythialabs-authorization-export-v0.1.json")
 
 def load_checker() -> Any:
     """Load the checker as a module without changing its CLI contract."""
-    spec = importlib.util.spec_from_file_location("pythia_export_checker", CHECKER_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "pythia_export_checker", CHECKER_PATH
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError("cannot load authorization export checker")
     module = importlib.util.module_from_spec(spec)
@@ -51,7 +53,7 @@ def require_failure(
 
 
 def main() -> int:
-    """Run canonicalization, state, join, and schema negative checks."""
+    """Run canonicalization, state, join, schema, and isolation checks."""
     checker = load_checker()
     data = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
     validator = checker.load_schema_validator()
@@ -70,7 +72,9 @@ def main() -> int:
         "authority_state mismatch",
     )
 
-    contradicted = find_case(data, "accepted_with_contradicted_external_response")
+    contradicted = find_case(
+        data, "accepted_with_contradicted_external_response"
+    )
     contradicted["handoff"]["expected_join"] = "MATCH"
     require_failure(
         checker,
@@ -90,7 +94,22 @@ def main() -> int:
         "schema violation",
     )
 
-    print("Adversarial PythiaLabs authorization export checks passed: 4")
+    source_case = find_case(data, "accepted_reversible_infrastructure")
+    authorization = checker.export(source_case)
+    original_ref = authorization["record_ref"]
+    original_bytes = authorization["canonical_bytes_utf8"]
+    source_case["input"]["gate"]["reason_codes"].append("LATE_CHANGE")
+    if "LATE_CHANGE" in authorization["record"]["reason_codes"]:
+        raise AssertionError("exported reason codes retained a source-list alias")
+    if checker.digest(authorization["record"]) != original_ref:
+        raise AssertionError("record reference changed after source-list edit")
+    if (
+        checker.canonical(authorization["record"]).decode("utf-8")
+        != original_bytes
+    ):
+        raise AssertionError("canonical bytes changed after source-list edit")
+
+    print("Adversarial PythiaLabs authorization export checks passed: 5")
     return 0
 
 

--- a/scripts/test_pythialabs_authorization_export.py
+++ b/scripts/test_pythialabs_authorization_export.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Adversarial checks for the PythiaLabs authorization export verifier."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+CHECKER_PATH = Path("scripts/check_pythialabs_authorization_export.py")
+FIXTURE_PATH = Path("conformance/pythialabs-authorization-export-v0.1.json")
+
+
+def load_checker() -> Any:
+    """Load the checker as a module without changing its CLI contract."""
+    spec = importlib.util.spec_from_file_location("pythia_export_checker", CHECKER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load authorization export checker")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def find_case(data: dict[str, Any], case_id: str) -> dict[str, Any]:
+    """Return a deep copy of one fixture case."""
+    for case in data["cases"]:
+        if case["case_id"] == case_id:
+            return copy.deepcopy(case)
+    raise AssertionError(f"missing case: {case_id}")
+
+
+def require_failure(
+    checker: Any,
+    case: dict[str, Any],
+    validator: Any,
+    adapters: dict[str, Any],
+    expected_fragment: str,
+) -> None:
+    """Assert that a tampered case is rejected for the intended reason."""
+    try:
+        checker.verify(case, validator, adapters)
+    except checker.FixtureError as error:
+        if expected_fragment not in str(error):
+            raise AssertionError(
+                f"unexpected rejection: {error}; wanted {expected_fragment!r}"
+            ) from error
+        return
+    raise AssertionError(f"tampered case unexpectedly passed: {case['case_id']}")
+
+
+def main() -> int:
+    """Run canonicalization, state, join, and schema negative checks."""
+    checker = load_checker()
+    data = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    validator = checker.load_schema_validator()
+    adapters = data["showcase_adapters"]
+
+    if checker.canonical({"x": 1e-7}) != b'{"x":1e-7}':
+        raise AssertionError("RFC 8785 number canonicalization regression")
+
+    expired = find_case(data, "expired_temporal_authorization")
+    expired["expected"]["authority_state"] = "ACTIVE"
+    require_failure(
+        checker,
+        expired,
+        validator,
+        adapters,
+        "authority_state mismatch",
+    )
+
+    contradicted = find_case(data, "accepted_with_contradicted_external_response")
+    contradicted["handoff"]["expected_join"] = "MATCH"
+    require_failure(
+        checker,
+        contradicted,
+        validator,
+        adapters,
+        "expected_join mismatch",
+    )
+
+    malformed = find_case(data, "accepted_reversible_infrastructure")
+    malformed["input"]["source_showcase"] = "unknown-showcase"
+    require_failure(
+        checker,
+        malformed,
+        validator,
+        adapters,
+        "schema violation",
+    )
+
+    print("Adversarial PythiaLabs authorization export checks passed: 4")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements PythiaLabs #204 as the pre-execution authority side of the three-record trustworthy-transition profile from safal207/Liminal#108.

This PR exports deterministic PythiaLabs gate decisions as provider-neutral `authorization_record` artifacts while preserving PythiaLabs' existing product boundary.

## Added

- `docs/interop/PYTHIALABS_AUTHORIZATION_EXPORT_V0_1.md`
- `schemas/interop/pythialabs-authorization-record-v0.1.schema.json`
- `conformance/pythialabs-authorization-export-v0.1.json`
- `scripts/check_pythialabs_authorization_export.py`

## Showcase adapters

The same portable record shape is demonstrated across:

- infrastructure actions;
- banking-risk actions;
- Web3 treasury actions.

Elixir module names and internal atoms are not normative interoperability fields.

## Fixture coverage

1. accepted reversible infrastructure action;
2. blocked destructive action without approval;
3. expired temporal authorization;
4. target-state drift after decision;
5. evidence snapshot updated before execution;
6. accepted action with a matching observation handoff;
7. accepted action with a contradicted external response-integrity record.

## Exported bindings

The record keeps separate digests for:

- action identity;
- canonical arguments;
- decision-time evidence snapshot;
- environment;
- target state;
- source evidence artifact.

This makes temporal expiry, target-state drift, and evidence drift explicit instead of hiding all context behind one generic digest.

## Boundary

- PythiaLabs issues deterministic pre-execution authority.
- A downstream runtime owns execution observations.
- A separate verifier owns response-integrity verdicts.
- Imported observation and integrity records remain independently attributed.
- A downstream integrity failure does not rewrite the original PythiaLabs decision.

## Validation

```bash
python3 scripts/check_pythialabs_authorization_export.py
```

The checker deterministically rebuilds canonical records and handoffs, verifies pinned SHA-256 references, enforces zero additional side effects for blocked/expired/drifted authority, and preserves the independent integrity verdict.

Relates to #204 and safal207/Liminal#108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for deterministic PythiaLabs authorization export records using RFC8785 canonical digests and a published JSON schema.
  * Introduced interoperability documentation and a conformance fixture covering multiple allowance/blocking, expiration/drift, and join/integrity scenarios.
* **Bug Fixes**
  * Strengthened checks for timestamp/digest consistency, join outcomes, and effective authority derivation to better detect stale, mismatched, or integrity-failing decisions.
* **Tests**
  * Added adversarial negative tests to ensure tampering and mismatches are rejected as expected.
  * Added a CI workflow to run authorization export verification and the adversarial test suite on relevant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->