### PR TITLE
feat: add GitHub Gmail event synchronizer v0.1

### DIFF
--- a/.github/workflows/github-gmail-sync.yml
+++ b/.github/workflows/github-gmail-sync.yml
@@ -1,0 +1,100 @@
+name: GitHub Gmail event sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: Notification source
+        required: true
+        type: choice
+        options:
+          - file
+          - gmail
+        default: file
+      candidate_file:
+        description: JSONL candidate file used in file mode
+        required: false
+        default: data/github-gmail-event-candidates.example.jsonl
+      gmail_query:
+        description: Gmail search query used in gmail mode
+        required: false
+        default: newer_than:1d from:notifications@github.com
+      apply:
+        description: Append verified, non-duplicate events to the journal
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -p 'test_sync_github_gmail_events.py' -v
+
+      - name: Validate Gmail secret configuration
+        if: inputs.source == 'gmail'
+        env:
+          GMAIL_ACCESS_TOKEN: ${{ secrets.GMAIL_ACCESS_TOKEN }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
+        run: |
+          if [[ -z "$GMAIL_ACCESS_TOKEN" && ( -z "$GMAIL_CLIENT_ID" || -z "$GMAIL_CLIENT_SECRET" || -z "$GMAIL_REFRESH_TOKEN" ) ]]; then
+            echo "Gmail mode needs GMAIL_ACCESS_TOKEN or GMAIL_CLIENT_ID/GMAIL_CLIENT_SECRET/GMAIL_REFRESH_TOKEN." >&2
+            exit 2
+          fi
+
+      - name: Build synchronized report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GMAIL_ACCESS_TOKEN: ${{ secrets.GMAIL_ACCESS_TOKEN }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
+        run: |
+          args=(
+            --source "${{ inputs.source }}"
+            --candidate-file "${{ inputs.candidate_file }}"
+            --gmail-query "${{ inputs.gmail_query }}"
+            --journal data/github-gmail-event-journal.jsonl
+            --report-jsonl artifacts/sync-report.jsonl
+            --report-md artifacts/sync-report.md
+          )
+          if [[ "${{ inputs.apply }}" == "true" ]]; then
+            args+=(--apply)
+          fi
+          python scripts/sync_github_gmail_events.py "${args[@]}"
+
+      - name: Show report
+        run: cat artifacts/sync-report.md
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-gmail-sync-report
+          path: artifacts/
+
+      - name: Commit journal changes
+        if: inputs.apply == true
+        run: |
+          if git diff --quiet -- data/github-gmail-event-journal.jsonl; then
+            echo "No new journal entries."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/github-gmail-event-journal.jsonl
+          git commit -m "data: sync GitHub Gmail event journal"
+          git push

--- a/data/github-gmail-event-candidates.example.jsonl
+++ b/data/github-gmail-event-candidates.example.jsonl
@@ -1,0 +1,1 @@
+{"gmail_message_id":"example-1","subject":"Re: [owner/repo] Example discussion (Issue #123)","snippet":"contributor left a comment","body":"contributor left a comment (https://github.com/owner/repo/issues/123#issuecomment-456789)\n\n@safal207 Example body.","detected_at":"2026-06-29T19:00:00Z"}

--- a/docs/GITHUB_GMAIL_SYNC_RUNBOOK.md
+++ b/docs/GITHUB_GMAIL_SYNC_RUNBOOK.md
@@ -1,0 +1,85 @@
+# GitHub ↔ Gmail Sync Runbook
+
+This runbook operationalizes [`GITHUB_GMAIL_SYNC_PROTOCOL.md`](./GITHUB_GMAIL_SYNC_PROTOCOL.md).
+
+## Safety model
+
+The workflow is manual and read-only by default.
+
+- It never posts GitHub comments or reactions.
+- Gmail only discovers candidate events.
+- GitHub verifies comment identity and current content.
+- Unverified events can appear in the report but cannot be appended to the journal.
+- The journal changes only when `apply=true` is explicitly selected.
+
+## Run with the example fixture
+
+1. Open **Actions**.
+2. Select **GitHub Gmail event sync**.
+3. Choose **Run workflow**.
+4. Keep:
+   - `source=file`
+   - `candidate_file=data/github-gmail-event-candidates.example.jsonl`
+   - `apply=false`
+5. Download the `github-gmail-sync-report` artifact.
+
+## Enable Gmail mode
+
+Configure either:
+
+- `GMAIL_ACCESS_TOKEN`, or
+- all three refresh-token secrets:
+  - `GMAIL_CLIENT_ID`
+  - `GMAIL_CLIENT_SECRET`
+  - `GMAIL_REFRESH_TOKEN`
+
+The Gmail credential needs read-only access to the mailbox. Do not grant send, modify, or delete scopes.
+
+Then run the workflow with:
+
+- `source=gmail`
+- a narrow query such as `newer_than:1d from:notifications@github.com`
+- `apply=false` for the first real run
+
+## Review the report
+
+The report groups events into:
+
+- `needs-reply`
+- `needs-code-fix`
+- `new-important`
+- `duplicate`
+- `closed-no-action`
+
+A direct mention becomes `needs-reply` only after the corresponding GitHub comment is successfully retrieved.
+
+## Apply journal changes
+
+After reviewing a dry run, rerun with `apply=true`.
+
+Only non-duplicate comments with `verification_status=verified` are appended to:
+
+```text
+data/github-gmail-event-journal.jsonl
+```
+
+The workflow commits journal changes to the branch from which it was manually started.
+
+## Local test
+
+```bash
+python -m unittest discover -s tests -p 'test_sync_github_gmail_events.py' -v
+```
+
+## Local dry run
+
+```bash
+python scripts/sync_github_gmail_events.py \
+  --source file \
+  --candidate-file data/github-gmail-event-candidates.example.jsonl \
+  --journal data/github-gmail-event-journal.jsonl
+```
+
+## Governing boundary
+
+> Gmail detects. GitHub verifies. Only verified events may mutate the journal.

--- a/scripts/sync_github_gmail_events.py
+++ b/scripts/sync_github_gmail_events.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-"""Synchronize GitHub notification candidates with a durable event journal.
+"""Build a deduplicated Gmail→GitHub event report.
 
-Gmail is used as a notification source. GitHub is used to verify comment identity
-and current content. The script is deliberately non-destructive by default:
-it writes a report and only appends to the journal when --apply is supplied.
-
-The script uses only the Python standard library.
+Default mode is read-only. ``--apply`` appends only GitHub-verified comments to
+``data/github-gmail-event-journal.jsonl``. No replies or reactions are sent.
 """
 
 from __future__ import annotations
@@ -25,23 +22,22 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
-GITHUB_COMMENT_URL_RE = re.compile(
-    r"https://github\.com/(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
-    r"/(?P<thread_type>issues|pull)/(?P<thread_number>\d+)"
-    r"#(?P<anchor>issuecomment|discussion_r)-?(?P<comment_id>\d+)"
+COMMENT_URL = re.compile(
+    r"https://github\.com/(?P<repo>[\w.-]+/[\w.-]+)/(?P<kind>issues|pull)/"
+    r"(?P<number>\d+)#(?P<anchor>issuecomment|discussion_r)-?(?P<comment>\d+)"
 )
-SUBJECT_THREAD_RE = re.compile(
-    r"\[(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\].*?"
-    r"\((?P<thread_type>Issue|PR|Pull Request)\s*#(?P<thread_number>\d+)\)",
+SUBJECT_THREAD = re.compile(
+    r"\[(?P<repo>[\w.-]+/[\w.-]+)\].*?"
+    r"\((?P<kind>Issue|PR|Pull Request)\s*#(?P<number>\d+)\)",
     re.IGNORECASE,
 )
-AUTHOR_RE = re.compile(r"(?P<author>[A-Za-z0-9_.-]+) left a comment", re.IGNORECASE)
-TEST_COMMENT_RE = re.compile(r"^\s*test(?: comment)?(?: from [^\n]+)?\s*$", re.IGNORECASE)
-DIRECT_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_-])@safal207(?![A-Za-z0-9_-])", re.IGNORECASE)
+AUTHOR = re.compile(r"(?P<author>[\w.-]+) left a comment", re.IGNORECASE)
+MENTION = re.compile(r"(?<![\w-])@safal207(?![\w-])", re.IGNORECASE)
+TEST_ONLY = re.compile(r"^\s*test(?: comment)?(?: from [^\n]+)?\s*$", re.IGNORECASE)
 
 
 class SyncError(RuntimeError):
-    """Raised for configuration or remote API failures that should stop a run."""
+    pass
 
 
 @dataclasses.dataclass(frozen=True)
@@ -61,9 +57,8 @@ class Candidate:
 
     @property
     def event_key(self) -> str:
-        if self.comment_id is not None:
-            return f"{self.repository}#{self.thread_number}:{self.comment_id}"
-        return f"{self.repository}#{self.thread_number}:gmail:{self.gmail_message_id}"
+        suffix = str(self.comment_id) if self.comment_id is not None else f"gmail:{self.gmail_message_id}"
+        return f"{self.repository}#{self.thread_number}:{suffix}"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -85,7 +80,7 @@ class Decision:
     verification: Verification
 
 
-def utc_now_iso() -> str:
+def now_iso() -> str:
     return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
 
 
@@ -93,105 +88,59 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     rows: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as handle:
-        for line_number, raw_line in enumerate(handle, start=1):
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                value = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise SyncError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
-            if not isinstance(value, dict):
-                raise SyncError(f"Expected an object at {path}:{line_number}")
-            rows.append(value)
+    for line_no, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SyncError(f"invalid JSONL at {path}:{line_no}: {exc}") from exc
+        if not isinstance(value, dict):
+            raise SyncError(f"expected object at {path}:{line_no}")
+        rows.append(value)
     return rows
 
 
 def write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]], *, append: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    mode = "a" if append else "w"
-    with path.open(mode, encoding="utf-8") as handle:
+    with path.open("a" if append else "w", encoding="utf-8") as handle:
         for row in rows:
             handle.write(json.dumps(dict(row), ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def _b64url_decode(value: str) -> bytes:
-    padding = "=" * (-len(value) % 4)
-    return base64.urlsafe_b64decode(value + padding)
-
-
-def _extract_text_from_gmail_payload(payload: Mapping[str, Any]) -> str:
-    chunks: list[str] = []
-
-    def walk(part: Mapping[str, Any]) -> None:
-        mime_type = str(part.get("mimeType") or "")
-        body = part.get("body") or {}
-        data = body.get("data") if isinstance(body, Mapping) else None
-        if isinstance(data, str) and mime_type in {"text/plain", "text/html"}:
-            try:
-                text = _b64url_decode(data).decode("utf-8", errors="replace")
-            except (ValueError, UnicodeDecodeError):
-                text = ""
-            if mime_type == "text/html":
-                text = re.sub(r"<[^>]+>", " ", text)
-            chunks.append(html.unescape(text))
-        for child in part.get("parts") or []:
-            if isinstance(child, Mapping):
-                walk(child)
-
-    walk(payload)
-    return "\n".join(chunk.strip() for chunk in chunks if chunk.strip())
-
-
-def _header_map(payload: Mapping[str, Any]) -> dict[str, str]:
-    headers: dict[str, str] = {}
-    for item in payload.get("headers") or []:
-        if not isinstance(item, Mapping):
-            continue
-        name = str(item.get("name") or "").lower()
-        value = str(item.get("value") or "")
-        if name:
-            headers[name] = value
-    return headers
-
-
-def parse_candidate(record: Mapping[str, Any]) -> Candidate | None:
-    message_id = str(record.get("gmail_message_id") or record.get("id") or "").strip()
-    subject = html.unescape(str(record.get("subject") or ""))
-    snippet = html.unescape(str(record.get("snippet") or ""))
-    body = html.unescape(str(record.get("body") or ""))
-    detected_at = str(record.get("detected_at") or record.get("email_ts") or "") or None
-
+def parse_candidate(row: Mapping[str, Any]) -> Candidate | None:
+    message_id = str(row.get("gmail_message_id") or row.get("id") or "").strip()
     if not message_id:
-        raise SyncError("Candidate is missing gmail_message_id/id")
+        raise SyncError("candidate is missing gmail_message_id/id")
+    subject = html.unescape(str(row.get("subject") or ""))
+    snippet = html.unescape(str(row.get("snippet") or ""))
+    body = html.unescape(str(row.get("body") or ""))
+    combined = "\n".join((subject, snippet, body))
 
-    combined = "\n".join([subject, snippet, body])
-    url_match = GITHUB_COMMENT_URL_RE.search(combined)
-    if url_match:
-        repository = url_match.group("repository")
-        thread_type = "issue" if url_match.group("thread_type") == "issues" else "pr"
-        thread_number = int(url_match.group("thread_number"))
-        comment_id = int(url_match.group("comment_id"))
-        comment_kind = "issue_comment" if url_match.group("anchor") == "issuecomment" else "review_comment"
-        github_url = url_match.group(0)
+    match = COMMENT_URL.search(combined)
+    if match:
+        repository = match.group("repo")
+        thread_type = "issue" if match.group("kind") == "issues" else "pr"
+        thread_number = int(match.group("number"))
+        comment_id = int(match.group("comment"))
+        comment_kind = "issue_comment" if match.group("anchor") == "issuecomment" else "review_comment"
+        github_url = match.group(0)
     else:
-        subject_match = SUBJECT_THREAD_RE.search(subject)
-        if not subject_match:
+        match = SUBJECT_THREAD.search(subject)
+        if not match:
             return None
-        repository = subject_match.group("repository")
-        raw_type = subject_match.group("thread_type").lower()
-        thread_type = "issue" if raw_type == "issue" else "pr"
-        thread_number = int(subject_match.group("thread_number"))
-        comment_id = _optional_int(record.get("comment_id"))
-        comment_kind = str(record.get("comment_kind") or "") or None
-        github_url = str(record.get("github_url") or "") or None
+        repository = match.group("repo")
+        thread_type = "issue" if match.group("kind").lower() == "issue" else "pr"
+        thread_number = int(match.group("number"))
+        raw_comment_id = row.get("comment_id")
+        comment_id = int(raw_comment_id) if raw_comment_id not in (None, "") else None
+        comment_kind = str(row.get("comment_kind") or "") or None
+        github_url = str(row.get("github_url") or "") or None
 
-    author_match = AUTHOR_RE.search(combined)
-    author = str(record.get("author") or "").strip() or (
+    author_match = AUTHOR.search(combined)
+    author = str(row.get("author") or "").strip() or (
         author_match.group("author") if author_match else None
     )
-
     return Candidate(
         gmail_message_id=message_id,
         repository=repository,
@@ -203,254 +152,172 @@ def parse_candidate(record: Mapping[str, Any]) -> Candidate | None:
         subject=subject,
         snippet=snippet,
         body=body,
-        detected_at=detected_at,
+        detected_at=str(row.get("detected_at") or row.get("email_ts") or "") or None,
         github_url=github_url,
     )
 
 
-def _optional_int(value: Any) -> int | None:
-    if value in (None, ""):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError) as exc:
-        raise SyncError(f"Expected integer comment_id, got {value!r}") from exc
-
-
-def _http_json(
+def http_json(
     url: str,
     *,
-    method: str = "GET",
     headers: Mapping[str, str] | None = None,
-    data: Mapping[str, str] | None = None,
-    timeout: int = 30,
+    form: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
-    request_headers = {"User-Agent": "pythiaLabs-github-gmail-sync/0.1"}
-    if headers:
-        request_headers.update(headers)
-    encoded_data = None
-    if data is not None:
-        encoded_data = urllib.parse.urlencode(data).encode("utf-8")
-        request_headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
-    request = urllib.request.Request(url, data=encoded_data, headers=request_headers, method=method)
+    request_headers = {"User-Agent": "pythiaLabs-github-gmail-sync/0.1", **(headers or {})}
+    data = urllib.parse.urlencode(form).encode() if form else None
+    if form:
+        request_headers["Content-Type"] = "application/x-www-form-urlencoded"
+    request = urllib.request.Request(url, data=data, headers=request_headers, method="POST" if form else "GET")
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            payload = response.read().decode("utf-8")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            result = json.loads(response.read().decode())
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise SyncError(f"HTTP {exc.code} for {url}: {detail[:500]}") from exc
-    except urllib.error.URLError as exc:
-        raise SyncError(f"Network error for {url}: {exc.reason}") from exc
-    try:
-        result = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise SyncError(f"Non-JSON response from {url}") from exc
+        detail = exc.read().decode(errors="replace")
+        raise SyncError(f"HTTP {exc.code} for {url}: {detail[:300]}") from exc
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise SyncError(f"request failed for {url}: {exc}") from exc
     if not isinstance(result, dict):
-        raise SyncError(f"Expected JSON object from {url}")
+        raise SyncError(f"expected JSON object from {url}")
     return result
 
 
-def gmail_access_token_from_env(env: Mapping[str, str]) -> str:
-    direct = env.get("GMAIL_ACCESS_TOKEN", "").strip()
-    if direct:
-        return direct
-
-    required = ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"]
-    missing = [name for name in required if not env.get(name, "").strip()]
+def gmail_token(env: Mapping[str, str]) -> str:
+    if env.get("GMAIL_ACCESS_TOKEN", "").strip():
+        return env["GMAIL_ACCESS_TOKEN"].strip()
+    names = ("GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN")
+    missing = [name for name in names if not env.get(name, "").strip()]
     if missing:
-        raise SyncError(
-            "Gmail mode requires GMAIL_ACCESS_TOKEN or refresh-token credentials: "
-            + ", ".join(missing)
-        )
-    response = _http_json(
+        raise SyncError("gmail mode missing: " + ", ".join(missing))
+    response = http_json(
         "https://oauth2.googleapis.com/token",
-        method="POST",
-        data={
+        form={
             "client_id": env["GMAIL_CLIENT_ID"],
             "client_secret": env["GMAIL_CLIENT_SECRET"],
             "refresh_token": env["GMAIL_REFRESH_TOKEN"],
             "grant_type": "refresh_token",
         },
     )
-    token = str(response.get("access_token") or "").strip()
+    token = str(response.get("access_token") or "")
     if not token:
-        raise SyncError("OAuth token response did not contain access_token")
+        raise SyncError("OAuth response had no access_token")
     return token
 
 
-def fetch_gmail_records(query: str, env: Mapping[str, str], max_results: int) -> list[dict[str, Any]]:
-    token = gmail_access_token_from_env(env)
-    headers = {"Authorization": f"Bearer {token}"}
+def decode_part(value: str) -> str:
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4)).decode(errors="replace")
+    except ValueError:
+        return ""
+
+
+def gmail_text(payload: Mapping[str, Any]) -> str:
+    chunks: list[str] = []
+
+    def visit(part: Mapping[str, Any]) -> None:
+        mime = str(part.get("mimeType") or "")
+        data = (part.get("body") or {}).get("data")
+        if isinstance(data, str) and mime in {"text/plain", "text/html"}:
+            text = decode_part(data)
+            chunks.append(html.unescape(re.sub(r"<[^>]+>", " ", text)) if mime == "text/html" else text)
+        for child in part.get("parts") or []:
+            if isinstance(child, Mapping):
+                visit(child)
+
+    visit(payload)
+    return "\n".join(chunk.strip() for chunk in chunks if chunk.strip())
+
+
+def fetch_gmail(query: str, max_results: int) -> list[dict[str, Any]]:
+    headers = {"Authorization": f"Bearer {gmail_token(os.environ)}"}
     params = urllib.parse.urlencode({"q": query, "maxResults": max_results})
-    listing = _http_json(
-        f"https://gmail.googleapis.com/gmail/v1/users/me/messages?{params}", headers=headers
-    )
-    messages = listing.get("messages") or []
-    records: list[dict[str, Any]] = []
-    for summary in messages:
-        if not isinstance(summary, Mapping) or not summary.get("id"):
+    listing = http_json(f"https://gmail.googleapis.com/gmail/v1/users/me/messages?{params}", headers=headers)
+    rows: list[dict[str, Any]] = []
+    for item in listing.get("messages") or []:
+        message_id = str(item.get("id") or "")
+        if not message_id:
             continue
-        message_id = str(summary["id"])
-        message = _http_json(
+        message = http_json(
             f"https://gmail.googleapis.com/gmail/v1/users/me/messages/{message_id}?format=full",
             headers=headers,
         )
         payload = message.get("payload") or {}
-        if not isinstance(payload, Mapping):
-            continue
-        headers_map = _header_map(payload)
-        records.append(
+        header_map = {
+            str(header.get("name") or "").lower(): str(header.get("value") or "")
+            for header in payload.get("headers") or []
+            if isinstance(header, Mapping)
+        }
+        rows.append(
             {
                 "gmail_message_id": message_id,
-                "subject": headers_map.get("subject", ""),
+                "subject": header_map.get("subject", ""),
                 "snippet": message.get("snippet", ""),
-                "body": _extract_text_from_gmail_payload(payload),
+                "body": gmail_text(payload),
                 "detected_at": message.get("internalDate"),
             }
         )
-    return records
+    return rows
 
 
-def verify_candidate(candidate: Candidate, github_token: str | None) -> Verification:
+def verify_candidate(candidate: Candidate, token: str | None) -> Verification:
     if candidate.comment_id is None:
-        return Verification(
-            status="thread-only",
-            github_url=candidate.github_url,
-            author=candidate.author,
-            body=None,
-            error=None,
-        )
-    if not github_token:
-        return Verification(
-            status="unverified",
-            github_url=candidate.github_url,
-            author=candidate.author,
-            body=None,
-            error="GITHUB_TOKEN not provided",
-        )
-
-    if candidate.comment_kind == "review_comment":
-        endpoint = (
-            f"https://api.github.com/repos/{candidate.repository}/pulls/comments/"
-            f"{candidate.comment_id}"
-        )
-    else:
-        endpoint = (
-            f"https://api.github.com/repos/{candidate.repository}/issues/comments/"
-            f"{candidate.comment_id}"
-        )
+        return Verification("thread-only", candidate.github_url, candidate.author, None)
+    if not token:
+        return Verification("unverified", candidate.github_url, candidate.author, None, "GITHUB_TOKEN not provided")
+    path = "pulls/comments" if candidate.comment_kind == "review_comment" else "issues/comments"
+    endpoint = f"https://api.github.com/repos/{candidate.repository}/{path}/{candidate.comment_id}"
     try:
-        response = _http_json(
+        response = http_json(
             endpoint,
             headers={
-                "Authorization": f"Bearer {github_token}",
+                "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
     except SyncError as exc:
-        return Verification(
-            status="verification-failed",
-            github_url=candidate.github_url,
-            author=candidate.author,
-            body=None,
-            error=str(exc),
-        )
-
+        return Verification("verification-failed", candidate.github_url, candidate.author, None, str(exc))
     user = response.get("user") or {}
-    author = str(user.get("login") or candidate.author or "") or None
     return Verification(
-        status="verified",
-        github_url=str(response.get("html_url") or candidate.github_url or "") or None,
-        author=author,
-        body=str(response.get("body") or ""),
-        error=None,
+        "verified",
+        str(response.get("html_url") or candidate.github_url or "") or None,
+        str(user.get("login") or candidate.author or "") or None,
+        str(response.get("body") or ""),
     )
 
 
-def classify(
-    candidate: Candidate,
-    verification: Verification,
-    existing_event_keys: set[str],
-) -> Decision:
-    if candidate.event_key in existing_event_keys:
-        return Decision(
-            candidate.event_key,
-            "duplicate",
-            "none",
-            "event_key already exists in the journal",
-            candidate,
-            verification,
-        )
-
-    authoritative_body = verification.body if verification.body is not None else candidate.body
-    normalized_body = authoritative_body.strip()
-    combined = "\n".join([candidate.subject, candidate.snippet, authoritative_body])
-    lowered = combined.lower()
-
-    if TEST_COMMENT_RE.fullmatch(normalized_body):
-        return Decision(
-            candidate.event_key,
-            "duplicate",
-            "none",
-            "test-only comment",
-            candidate,
-            verification,
-        )
-
-    if any(marker in lowered for marker in ("actionable comments posted", "codex review", "p1 badge", "p2 badge")):
-        return Decision(
-            candidate.event_key,
-            "needs-code-fix",
-            "review-code",
-            "automated review contains actionable code findings",
-            candidate,
-            verification,
-        )
-
-    if any(marker in lowered for marker in ("closed #", "closed as completed", "merged pull request")):
-        return Decision(
-            candidate.event_key,
-            "closed-no-action",
-            "none",
-            "thread state notification does not require a prose reply",
-            candidate,
-            verification,
-        )
-
-    if DIRECT_MENTION_RE.search(authoritative_body):
-        return Decision(
-            candidate.event_key,
-            "needs-reply",
-            "draft-reply",
-            "verified comment directly mentions @safal207",
-            candidate,
-            verification,
-        )
-
-    return Decision(
-        candidate.event_key,
-        "new-important",
-        "review",
-        "new verified thread event; human classification required",
-        candidate,
-        verification,
+def classify(candidate: Candidate, verification: Verification, existing: set[str]) -> Decision:
+    if candidate.event_key in existing:
+        return Decision(candidate.event_key, "duplicate", "none", "event_key already exists in the journal", candidate, verification)
+    body = verification.body if verification.body is not None else candidate.body
+    lowered = "\n".join((candidate.subject, candidate.snippet, body)).lower()
+    if TEST_ONLY.fullmatch(body.strip()):
+        return Decision(candidate.event_key, "duplicate", "none", "test-only comment", candidate, verification)
+    if any(mark in lowered for mark in ("actionable comments posted", "codex review", "p1 badge", "p2 badge")):
+        return Decision(candidate.event_key, "needs-code-fix", "review-code", "automated review contains actionable code findings", candidate, verification)
+    if any(mark in lowered for mark in ("closed #", "closed as completed", "merged pull request")):
+        return Decision(candidate.event_key, "closed-no-action", "none", "thread state notification does not require a prose reply", candidate, verification)
+    if verification.status == "verified" and MENTION.search(body):
+        return Decision(candidate.event_key, "needs-reply", "draft-reply", "verified comment directly mentions @safal207", candidate, verification)
+    reason = (
+        "new verified thread event; human classification required"
+        if verification.status == "verified"
+        else f"event requires human review because verification status is {verification.status}"
     )
+    return Decision(candidate.event_key, "new-important", "review", reason, candidate, verification)
 
 
-def decision_to_report_row(decision: Decision) -> dict[str, Any]:
-    candidate = decision.candidate
-    verification = decision.verification
+def report_row(item: Decision) -> dict[str, Any]:
+    candidate, verification = item.candidate, item.verification
     return {
-        "event_key": decision.event_key,
+        "event_key": item.event_key,
         "repository": candidate.repository,
         "thread_type": candidate.thread_type,
         "thread_number": candidate.thread_number,
         "comment_id": candidate.comment_id,
         "author": verification.author or candidate.author,
-        "status": decision.status,
-        "recommended_action": decision.action,
-        "reason": decision.reason,
+        "status": item.status,
+        "recommended_action": item.action,
+        "reason": item.reason,
         "verification_status": verification.status,
         "verification_error": verification.error,
         "github_url": verification.github_url or candidate.github_url,
@@ -459,112 +326,74 @@ def decision_to_report_row(decision: Decision) -> dict[str, Any]:
     }
 
 
-def decision_to_journal_row(decision: Decision) -> dict[str, Any]:
-    candidate = decision.candidate
-    verification = decision.verification
+def journal_row(item: Decision) -> dict[str, Any]:
+    row = report_row(item)
     return {
-        "event_key": decision.event_key,
-        "repository": candidate.repository,
-        "thread_type": candidate.thread_type,
-        "thread_number": candidate.thread_number,
-        "comment_id": candidate.comment_id,
-        "author": verification.author or candidate.author,
+        "event_key": row["event_key"],
+        "repository": row["repository"],
+        "thread_type": row["thread_type"],
+        "thread_number": row["thread_number"],
+        "comment_id": row["comment_id"],
+        "author": row["author"],
         "detected_via": "gmail",
-        "verified_via": "github" if verification.status == "verified" else verification.status,
-        "status": decision.status,
-        "action": "pending" if decision.action != "none" else "none",
+        "verified_via": "github",
+        "status": row["status"],
+        "action": "pending" if row["recommended_action"] != "none" else "none",
         "response_comment_id": None,
-        "processed_at": utc_now_iso(),
-        "notes": decision.reason,
+        "processed_at": now_iso(),
+        "notes": row["reason"],
     }
 
 
-def render_markdown(decisions: Sequence[Decision]) -> str:
-    groups = [
+def markdown(decisions: Sequence[Decision]) -> str:
+    groups = (
         ("Needs reply", {"needs-reply"}),
         ("Needs action in code", {"needs-code-fix"}),
         ("New and important", {"new-important"}),
         ("Already handled or ignored", {"duplicate", "closed-no-action"}),
-    ]
-    lines = ["# GitHub ↔ Gmail sync report", "", f"Generated: `{utc_now_iso()}`", ""]
+    )
+    lines = ["# GitHub ↔ Gmail sync report", "", f"Generated: `{now_iso()}`", ""]
     for title, statuses in groups:
-        lines.extend([f"## {title}", ""])
+        lines += [f"## {title}", ""]
         selected = [item for item in decisions if item.status in statuses]
         if not selected:
-            lines.extend(["_None._", ""])
+            lines += ["_None._", ""]
             continue
         for item in selected:
-            candidate = item.candidate
-            verification = item.verification
-            url = verification.github_url or candidate.github_url
-            label = item.event_key
-            if url:
-                label = f"[{label}]({url})"
+            url = item.verification.github_url or item.candidate.github_url
+            label = f"[{item.event_key}]({url})" if url else item.event_key
             lines.append(f"- {label} — **{item.status}**: {item.reason}")
         lines.append("")
     return "\n".join(lines)
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--source", choices=("file", "gmail"), default="file")
-    parser.add_argument(
-        "--candidate-file",
-        type=Path,
-        default=Path("data/github-gmail-event-candidates.jsonl"),
-    )
-    parser.add_argument(
-        "--journal",
-        type=Path,
-        default=Path("data/github-gmail-event-journal.jsonl"),
-    )
-    parser.add_argument("--report-jsonl", type=Path, default=Path("artifacts/sync-report.jsonl"))
-    parser.add_argument("--report-md", type=Path, default=Path("artifacts/sync-report.md"))
-    parser.add_argument(
-        "--gmail-query",
-        default="newer_than:1d from:notifications@github.com",
-    )
-    parser.add_argument("--max-results", type=int, default=50)
-    parser.add_argument("--apply", action="store_true")
-    return parser
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--source", choices=("file", "gmail"), default="file")
+    result.add_argument("--candidate-file", type=Path, default=Path("data/github-gmail-event-candidates.jsonl"))
+    result.add_argument("--journal", type=Path, default=Path("data/github-gmail-event-journal.jsonl"))
+    result.add_argument("--report-jsonl", type=Path, default=Path("artifacts/sync-report.jsonl"))
+    result.add_argument("--report-md", type=Path, default=Path("artifacts/sync-report.md"))
+    result.add_argument("--gmail-query", default="newer_than:1d from:notifications@github.com")
+    result.add_argument("--max-results", type=int, default=50)
+    result.add_argument("--apply", action="store_true")
+    return result
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    args = parser().parse_args(argv)
     try:
-        if args.source == "gmail":
-            raw_records = fetch_gmail_records(args.gmail_query, os.environ, args.max_results)
-        else:
-            raw_records = read_jsonl(args.candidate_file)
-
-        candidates = [candidate for row in raw_records if (candidate := parse_candidate(row))]
-        journal_rows = read_jsonl(args.journal)
-        existing_event_keys = {
-            str(row.get("event_key")) for row in journal_rows if row.get("event_key")
-        }
-        github_token = os.environ.get("GITHUB_TOKEN", "").strip() or None
-        decisions = [
-            classify(candidate, verify_candidate(candidate, github_token), existing_event_keys)
-            for candidate in candidates
-        ]
-
-        write_jsonl(args.report_jsonl, (decision_to_report_row(item) for item in decisions))
+        raw = fetch_gmail(args.gmail_query, args.max_results) if args.source == "gmail" else read_jsonl(args.candidate_file)
+        candidates = [candidate for row in raw if (candidate := parse_candidate(row))]
+        existing = {str(row["event_key"]) for row in read_jsonl(args.journal) if row.get("event_key")}
+        token = os.environ.get("GITHUB_TOKEN", "").strip() or None
+        decisions = [classify(candidate, verify_candidate(candidate, token), existing) for candidate in candidates]
+        write_jsonl(args.report_jsonl, (report_row(item) for item in decisions))
         args.report_md.parent.mkdir(parents=True, exist_ok=True)
-        args.report_md.write_text(render_markdown(decisions), encoding="utf-8")
-
+        args.report_md.write_text(markdown(decisions), encoding="utf-8")
         if args.apply:
-            appendable = [
-                item
-                for item in decisions
-                if item.status != "duplicate"
-                and item.verification.status in {"verified", "thread-only"}
-            ]
-            write_jsonl(
-                args.journal,
-                (decision_to_journal_row(item) for item in appendable),
-                append=True,
-            )
-
+            verified = [item for item in decisions if item.status != "duplicate" and item.verification.status == "verified"]
+            write_jsonl(args.journal, (journal_row(item) for item in verified), append=True)
         counts: dict[str, int] = {}
         for item in decisions:
             counts[item.status] = counts.get(item.status, 0) + 1

--- a/scripts/sync_github_gmail_events.py
+++ b/scripts/sync_github_gmail_events.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Synchronize GitHub notification candidates with a durable event journal.
+
+Gmail is used as a notification source. GitHub is used to verify comment identity
+and current content. The script is deliberately non-destructive by default:
+it writes a report and only appends to the journal when --apply is supplied.
+
+The script uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import datetime as dt
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+GITHUB_COMMENT_URL_RE = re.compile(
+    r"https://github\.com/(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
+    r"/(?P<thread_type>issues|pull)/(?P<thread_number>\d+)"
+    r"#(?P<anchor>issuecomment|discussion_r)-?(?P<comment_id>\d+)"
+)
+SUBJECT_THREAD_RE = re.compile(
+    r"\[(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)\].*?"
+    r"\((?P<thread_type>Issue|PR|Pull Request)\s*#(?P<thread_number>\d+)\)",
+    re.IGNORECASE,
+)
+AUTHOR_RE = re.compile(r"(?P<author>[A-Za-z0-9_.-]+) left a comment", re.IGNORECASE)
+TEST_COMMENT_RE = re.compile(r"^\s*test(?: comment)?(?: from [^\n]+)?\s*$", re.IGNORECASE)
+DIRECT_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_-])@safal207(?![A-Za-z0-9_-])", re.IGNORECASE)
+
+
+class SyncError(RuntimeError):
+    """Raised for configuration or remote API failures that should stop a run."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Candidate:
+    gmail_message_id: str
+    repository: str
+    thread_type: str
+    thread_number: int
+    comment_id: int | None
+    comment_kind: str | None
+    author: str | None
+    subject: str
+    snippet: str
+    body: str
+    detected_at: str | None
+    github_url: str | None
+
+    @property
+    def event_key(self) -> str:
+        if self.comment_id is not None:
+            return f"{self.repository}#{self.thread_number}:{self.comment_id}"
+        return f"{self.repository}#{self.thread_number}:gmail:{self.gmail_message_id}"
+
+
+@dataclasses.dataclass(frozen=True)
+class Verification:
+    status: str
+    github_url: str | None
+    author: str | None
+    body: str | None
+    error: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Decision:
+    event_key: str
+    status: str
+    action: str
+    reason: str
+    candidate: Candidate
+    verification: Verification
+
+
+def utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SyncError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+            if not isinstance(value, dict):
+                raise SyncError(f"Expected an object at {path}:{line_number}")
+            rows.append(value)
+    return rows
+
+
+def write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]], *, append: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = "a" if append else "w"
+    with path.open(mode, encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(dict(row), ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _extract_text_from_gmail_payload(payload: Mapping[str, Any]) -> str:
+    chunks: list[str] = []
+
+    def walk(part: Mapping[str, Any]) -> None:
+        mime_type = str(part.get("mimeType") or "")
+        body = part.get("body") or {}
+        data = body.get("data") if isinstance(body, Mapping) else None
+        if isinstance(data, str) and mime_type in {"text/plain", "text/html"}:
+            try:
+                text = _b64url_decode(data).decode("utf-8", errors="replace")
+            except (ValueError, UnicodeDecodeError):
+                text = ""
+            if mime_type == "text/html":
+                text = re.sub(r"<[^>]+>", " ", text)
+            chunks.append(html.unescape(text))
+        for child in part.get("parts") or []:
+            if isinstance(child, Mapping):
+                walk(child)
+
+    walk(payload)
+    return "\n".join(chunk.strip() for chunk in chunks if chunk.strip())
+
+
+def _header_map(payload: Mapping[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for item in payload.get("headers") or []:
+        if not isinstance(item, Mapping):
+            continue
+        name = str(item.get("name") or "").lower()
+        value = str(item.get("value") or "")
+        if name:
+            headers[name] = value
+    return headers
+
+
+def parse_candidate(record: Mapping[str, Any]) -> Candidate | None:
+    message_id = str(record.get("gmail_message_id") or record.get("id") or "").strip()
+    subject = html.unescape(str(record.get("subject") or ""))
+    snippet = html.unescape(str(record.get("snippet") or ""))
+    body = html.unescape(str(record.get("body") or ""))
+    detected_at = str(record.get("detected_at") or record.get("email_ts") or "") or None
+
+    if not message_id:
+        raise SyncError("Candidate is missing gmail_message_id/id")
+
+    combined = "\n".join([subject, snippet, body])
+    url_match = GITHUB_COMMENT_URL_RE.search(combined)
+    if url_match:
+        repository = url_match.group("repository")
+        thread_type = "issue" if url_match.group("thread_type") == "issues" else "pr"
+        thread_number = int(url_match.group("thread_number"))
+        comment_id = int(url_match.group("comment_id"))
+        comment_kind = "issue_comment" if url_match.group("anchor") == "issuecomment" else "review_comment"
+        github_url = url_match.group(0)
+    else:
+        subject_match = SUBJECT_THREAD_RE.search(subject)
+        if not subject_match:
+            return None
+        repository = subject_match.group("repository")
+        raw_type = subject_match.group("thread_type").lower()
+        thread_type = "issue" if raw_type == "issue" else "pr"
+        thread_number = int(subject_match.group("thread_number"))
+        comment_id = _optional_int(record.get("comment_id"))
+        comment_kind = str(record.get("comment_kind") or "") or None
+        github_url = str(record.get("github_url") or "") or None
+
+    author_match = AUTHOR_RE.search(combined)
+    author = str(record.get("author") or "").strip() or (
+        author_match.group("author") if author_match else None
+    )
+
+    return Candidate(
+        gmail_message_id=message_id,
+        repository=repository,
+        thread_type=thread_type,
+        thread_number=thread_number,
+        comment_id=comment_id,
+        comment_kind=comment_kind,
+        author=author,
+        subject=subject,
+        snippet=snippet,
+        body=body,
+        detected_at=detected_at,
+        github_url=github_url,
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise SyncError(f"Expected integer comment_id, got {value!r}") from exc
+
+
+def _http_json(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: Mapping[str, str] | None = None,
+    data: Mapping[str, str] | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    request_headers = {"User-Agent": "pythiaLabs-github-gmail-sync/0.1"}
+    if headers:
+        request_headers.update(headers)
+    encoded_data = None
+    if data is not None:
+        encoded_data = urllib.parse.urlencode(data).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
+    request = urllib.request.Request(url, data=encoded_data, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SyncError(f"HTTP {exc.code} for {url}: {detail[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise SyncError(f"Network error for {url}: {exc.reason}") from exc
+    try:
+        result = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SyncError(f"Non-JSON response from {url}") from exc
+    if not isinstance(result, dict):
+        raise SyncError(f"Expected JSON object from {url}")
+    return result
+
+
+def gmail_access_token_from_env(env: Mapping[str, str]) -> str:
+    direct = env.get("GMAIL_ACCESS_TOKEN", "").strip()
+    if direct:
+        return direct
+
+    required = ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"]
+    missing = [name for name in required if not env.get(name, "").strip()]
+    if missing:
+        raise SyncError(
+            "Gmail mode requires GMAIL_ACCESS_TOKEN or refresh-token credentials: "
+            + ", ".join(missing)
+        )
+    response = _http_json(
+        "https://oauth2.googleapis.com/token",
+        method="POST",
+        data={
+            "client_id": env["GMAIL_CLIENT_ID"],
+            "client_secret": env["GMAIL_CLIENT_SECRET"],
+            "refresh_token": env["GMAIL_REFRESH_TOKEN"],
+            "grant_type": "refresh_token",
+        },
+    )
+    token = str(response.get("access_token") or "").strip()
+    if not token:
+        raise SyncError("OAuth token response did not contain access_token")
+    return token
+
+
+def fetch_gmail_records(query: str, env: Mapping[str, str], max_results: int) -> list[dict[str, Any]]:
+    token = gmail_access_token_from_env(env)
+    headers = {"Authorization": f"Bearer {token}"}
+    params = urllib.parse.urlencode({"q": query, "maxResults": max_results})
+    listing = _http_json(
+        f"https://gmail.googleapis.com/gmail/v1/users/me/messages?{params}", headers=headers
+    )
+    messages = listing.get("messages") or []
+    records: list[dict[str, Any]] = []
+    for summary in messages:
+        if not isinstance(summary, Mapping) or not summary.get("id"):
+            continue
+        message_id = str(summary["id"])
+        message = _http_json(
+            f"https://gmail.googleapis.com/gmail/v1/users/me/messages/{message_id}?format=full",
+            headers=headers,
+        )
+        payload = message.get("payload") or {}
+        if not isinstance(payload, Mapping):
+            continue
+        headers_map = _header_map(payload)
+        records.append(
+            {
+                "gmail_message_id": message_id,
+                "subject": headers_map.get("subject", ""),
+                "snippet": message.get("snippet", ""),
+                "body": _extract_text_from_gmail_payload(payload),
+                "detected_at": message.get("internalDate"),
+            }
+        )
+    return records
+
+
+def verify_candidate(candidate: Candidate, github_token: str | None) -> Verification:
+    if candidate.comment_id is None:
+        return Verification(
+            status="thread-only",
+            github_url=candidate.github_url,
+            author=candidate.author,
+            body=None,
+            error=None,
+        )
+    if not github_token:
+        return Verification(
+            status="unverified",
+            github_url=candidate.github_url,
+            author=candidate.author,
+            body=None,
+            error="GITHUB_TOKEN not provided",
+        )
+
+    if candidate.comment_kind == "review_comment":
+        endpoint = (
+            f"https://api.github.com/repos/{candidate.repository}/pulls/comments/"
+            f"{candidate.comment_id}"
+        )
+    else:
+        endpoint = (
+            f"https://api.github.com/repos/{candidate.repository}/issues/comments/"
+            f"{candidate.comment_id}"
+        )
+    try:
+        response = _http_json(
+            endpoint,
+            headers={
+                "Authorization": f"Bearer {github_token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+    except SyncError as exc:
+        return Verification(
+            status="verification-failed",
+            github_url=candidate.github_url,
+            author=candidate.author,
+            body=None,
+            error=str(exc),
+        )
+
+    user = response.get("user") or {}
+    author = str(user.get("login") or candidate.author or "") or None
+    return Verification(
+        status="verified",
+        github_url=str(response.get("html_url") or candidate.github_url or "") or None,
+        author=author,
+        body=str(response.get("body") or ""),
+        error=None,
+    )
+
+
+def classify(
+    candidate: Candidate,
+    verification: Verification,
+    existing_event_keys: set[str],
+) -> Decision:
+    if candidate.event_key in existing_event_keys:
+        return Decision(
+            candidate.event_key,
+            "duplicate",
+            "none",
+            "event_key already exists in the journal",
+            candidate,
+            verification,
+        )
+
+    authoritative_body = verification.body if verification.body is not None else candidate.body
+    normalized_body = authoritative_body.strip()
+    combined = "\n".join([candidate.subject, candidate.snippet, authoritative_body])
+    lowered = combined.lower()
+
+    if TEST_COMMENT_RE.fullmatch(normalized_body):
+        return Decision(
+            candidate.event_key,
+            "duplicate",
+            "none",
+            "test-only comment",
+            candidate,
+            verification,
+        )
+
+    if any(marker in lowered for marker in ("actionable comments posted", "codex review", "p1 badge", "p2 badge")):
+        return Decision(
+            candidate.event_key,
+            "needs-code-fix",
+            "review-code",
+            "automated review contains actionable code findings",
+            candidate,
+            verification,
+        )
+
+    if any(marker in lowered for marker in ("closed #", "closed as completed", "merged pull request")):
+        return Decision(
+            candidate.event_key,
+            "closed-no-action",
+            "none",
+            "thread state notification does not require a prose reply",
+            candidate,
+            verification,
+        )
+
+    if DIRECT_MENTION_RE.search(authoritative_body):
+        return Decision(
+            candidate.event_key,
+            "needs-reply",
+            "draft-reply",
+            "verified comment directly mentions @safal207",
+            candidate,
+            verification,
+        )
+
+    return Decision(
+        candidate.event_key,
+        "new-important",
+        "review",
+        "new verified thread event; human classification required",
+        candidate,
+        verification,
+    )
+
+
+def decision_to_report_row(decision: Decision) -> dict[str, Any]:
+    candidate = decision.candidate
+    verification = decision.verification
+    return {
+        "event_key": decision.event_key,
+        "repository": candidate.repository,
+        "thread_type": candidate.thread_type,
+        "thread_number": candidate.thread_number,
+        "comment_id": candidate.comment_id,
+        "author": verification.author or candidate.author,
+        "status": decision.status,
+        "recommended_action": decision.action,
+        "reason": decision.reason,
+        "verification_status": verification.status,
+        "verification_error": verification.error,
+        "github_url": verification.github_url or candidate.github_url,
+        "gmail_message_id": candidate.gmail_message_id,
+        "detected_at": candidate.detected_at,
+    }
+
+
+def decision_to_journal_row(decision: Decision) -> dict[str, Any]:
+    candidate = decision.candidate
+    verification = decision.verification
+    return {
+        "event_key": decision.event_key,
+        "repository": candidate.repository,
+        "thread_type": candidate.thread_type,
+        "thread_number": candidate.thread_number,
+        "comment_id": candidate.comment_id,
+        "author": verification.author or candidate.author,
+        "detected_via": "gmail",
+        "verified_via": "github" if verification.status == "verified" else verification.status,
+        "status": decision.status,
+        "action": "pending" if decision.action != "none" else "none",
+        "response_comment_id": None,
+        "processed_at": utc_now_iso(),
+        "notes": decision.reason,
+    }
+
+
+def render_markdown(decisions: Sequence[Decision]) -> str:
+    groups = [
+        ("Needs reply", {"needs-reply"}),
+        ("Needs action in code", {"needs-code-fix"}),
+        ("New and important", {"new-important"}),
+        ("Already handled or ignored", {"duplicate", "closed-no-action"}),
+    ]
+    lines = ["# GitHub ↔ Gmail sync report", "", f"Generated: `{utc_now_iso()}`", ""]
+    for title, statuses in groups:
+        lines.extend([f"## {title}", ""])
+        selected = [item for item in decisions if item.status in statuses]
+        if not selected:
+            lines.extend(["_None._", ""])
+            continue
+        for item in selected:
+            candidate = item.candidate
+            verification = item.verification
+            url = verification.github_url or candidate.github_url
+            label = item.event_key
+            if url:
+                label = f"[{label}]({url})"
+            lines.append(f"- {label} — **{item.status}**: {item.reason}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", choices=("file", "gmail"), default="file")
+    parser.add_argument(
+        "--candidate-file",
+        type=Path,
+        default=Path("data/github-gmail-event-candidates.jsonl"),
+    )
+    parser.add_argument(
+        "--journal",
+        type=Path,
+        default=Path("data/github-gmail-event-journal.jsonl"),
+    )
+    parser.add_argument("--report-jsonl", type=Path, default=Path("artifacts/sync-report.jsonl"))
+    parser.add_argument("--report-md", type=Path, default=Path("artifacts/sync-report.md"))
+    parser.add_argument(
+        "--gmail-query",
+        default="newer_than:1d from:notifications@github.com",
+    )
+    parser.add_argument("--max-results", type=int, default=50)
+    parser.add_argument("--apply", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.source == "gmail":
+            raw_records = fetch_gmail_records(args.gmail_query, os.environ, args.max_results)
+        else:
+            raw_records = read_jsonl(args.candidate_file)
+
+        candidates = [candidate for row in raw_records if (candidate := parse_candidate(row))]
+        journal_rows = read_jsonl(args.journal)
+        existing_event_keys = {
+            str(row.get("event_key")) for row in journal_rows if row.get("event_key")
+        }
+        github_token = os.environ.get("GITHUB_TOKEN", "").strip() or None
+        decisions = [
+            classify(candidate, verify_candidate(candidate, github_token), existing_event_keys)
+            for candidate in candidates
+        ]
+
+        write_jsonl(args.report_jsonl, (decision_to_report_row(item) for item in decisions))
+        args.report_md.parent.mkdir(parents=True, exist_ok=True)
+        args.report_md.write_text(render_markdown(decisions), encoding="utf-8")
+
+        if args.apply:
+            appendable = [
+                item
+                for item in decisions
+                if item.status != "duplicate"
+                and item.verification.status in {"verified", "thread-only"}
+            ]
+            write_jsonl(
+                args.journal,
+                (decision_to_journal_row(item) for item in appendable),
+                append=True,
+            )
+
+        counts: dict[str, int] = {}
+        for item in decisions:
+            counts[item.status] = counts.get(item.status, 0) + 1
+        print(json.dumps({"candidates": len(candidates), "counts": counts, "applied": args.apply}))
+        return 0
+    except SyncError as exc:
+        print(f"sync error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sync_github_gmail_events.py
+++ b/tests/test_sync_github_gmail_events.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
+import sync_github_gmail_events as sync
+
+
+class CandidateParsingTests(unittest.TestCase):
+    def test_parses_issue_comment_url(self) -> None:
+        candidate = sync.parse_candidate(
+            {
+                "gmail_message_id": "m1",
+                "subject": "Re: [langchain-ai/langgraph] Example (Issue #5672)",
+                "body": (
+                    "Tuttotorna left a comment "
+                    "(https://github.com/langchain-ai/langgraph/issues/5672"
+                    "#issuecomment-4835616520)"
+                ),
+            }
+        )
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate.event_key, "langchain-ai/langgraph#5672:4835616520")
+        self.assertEqual(candidate.author, "Tuttotorna")
+        self.assertEqual(candidate.comment_kind, "issue_comment")
+
+    def test_subject_fallback_without_comment_url(self) -> None:
+        candidate = sync.parse_candidate(
+            {
+                "gmail_message_id": "m2",
+                "subject": "Re: [openai/codex] Something happened (Issue #28495)",
+                "body": "Closed #28495 as completed.",
+            }
+        )
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate.repository, "openai/codex")
+        self.assertEqual(candidate.event_key, "openai/codex#28495:gmail:m2")
+
+
+class ClassificationTests(unittest.TestCase):
+    def make_candidate(self, body: str = "@safal207 useful point"):
+        return sync.Candidate(
+            gmail_message_id="m1",
+            repository="owner/repo",
+            thread_type="issue",
+            thread_number=1,
+            comment_id=10,
+            comment_kind="issue_comment",
+            author="author",
+            subject="subject",
+            snippet="",
+            body=body,
+            detected_at=None,
+            github_url="https://github.com/owner/repo/issues/1#issuecomment-10",
+        )
+
+    def test_existing_event_is_duplicate(self) -> None:
+        candidate = self.make_candidate()
+        verification = sync.Verification("verified", candidate.github_url, "author", candidate.body)
+        decision = sync.classify(candidate, verification, {candidate.event_key})
+        self.assertEqual(decision.status, "duplicate")
+
+    def test_direct_mention_needs_reply(self) -> None:
+        candidate = self.make_candidate()
+        verification = sync.Verification("verified", candidate.github_url, "author", candidate.body)
+        decision = sync.classify(candidate, verification, set())
+        self.assertEqual(decision.status, "needs-reply")
+
+    def test_review_feedback_needs_code_fix(self) -> None:
+        candidate = self.make_candidate("Actionable comments posted: 2")
+        verification = sync.Verification("verified", candidate.github_url, "bot", candidate.body)
+        decision = sync.classify(candidate, verification, set())
+        self.assertEqual(decision.status, "needs-code-fix")
+
+    def test_test_comment_is_ignored(self) -> None:
+        candidate = self.make_candidate("Test comment from HeartFlow")
+        verification = sync.Verification("verified", candidate.github_url, "author", candidate.body)
+        decision = sync.classify(candidate, verification, set())
+        self.assertEqual(decision.status, "duplicate")
+
+
+class JsonlTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "events.jsonl"
+            sync.write_jsonl(path, [{"event_key": "a"}, {"event_key": "b"}])
+            self.assertEqual(sync.read_jsonl(path), [{"event_key": "a"}, {"event_key": "b"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_github_gmail_events.py
+++ b/tests/test_sync_github_gmail_events.py
@@ -71,6 +71,14 @@ class ClassificationTests(unittest.TestCase):
         decision = sync.classify(candidate, verification, set())
         self.assertEqual(decision.status, "needs-reply")
 
+    def test_unverified_direct_mention_stays_for_review(self) -> None:
+        candidate = self.make_candidate()
+        verification = sync.Verification(
+            "unverified", candidate.github_url, "author", None, "token missing"
+        )
+        decision = sync.classify(candidate, verification, set())
+        self.assertEqual(decision.status, "new-important")
+
     def test_review_feedback_needs_code_fix(self) -> None:
         candidate = self.make_candidate("Actionable comments posted: 2")
         verification = sync.Verification("verified", candidate.github_url, "bot", candidate.body)


### PR DESCRIPTION
Adds a manual, dry-run-first synchronizer for Gmail GitHub notifications.

Included:
- JSONL or Gmail input
- GitHub comment verification
- stable event-key deduplication
- Markdown and JSONL reports
- explicit apply mode for verified journal entries only
- manual GitHub Actions workflow
- example fixture, runbook, and 8 passing unit tests

Safety boundary: Gmail detects, GitHub verifies, and only verified events may change the journal. The tool never sends comments or reactions.