### PR TITLE
RFC: verifiable continuation envelope v0.1

### DIFF
--- a/.github/workflows/vce-conformance.yml
+++ b/.github/workflows/vce-conformance.yml
@@ -1,0 +1,34 @@
+name: VCE conformance
+
+on:
+  pull_request:
+    paths:
+      - "standards/agent-continuity/**"
+      - ".github/workflows/vce-conformance.yml"
+  push:
+    paths:
+      - "standards/agent-continuity/**"
+      - ".github/workflows/vce-conformance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run VCE conformance suite
+        run: |
+          python -m unittest discover \
+            -s standards/agent-continuity/conformance \
+            -p 'test_*.py' \
+            -v

--- a/.github/workflows/vce-conformance.yml
+++ b/.github/workflows/vce-conformance.yml
@@ -20,11 +20,18 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Install conformance dependency
+        run: |
+          python -m pip install --disable-pip-version-check \
+            -r standards/agent-continuity/conformance/requirements.txt
 
       - name: Run VCE conformance suite
         run: |

--- a/standards/agent-continuity/README.md
+++ b/standards/agent-continuity/README.md
@@ -1,0 +1,40 @@
+# Agent Continuity & Authority
+
+Vendor-neutral specifications and executable conformance checks for preserving operational continuity across context compaction, session restart, and cross-session handoff.
+
+## RFC v0.1
+
+[`RFC-001 — Verifiable Continuation Envelope`](./RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md)
+
+defines a bounded, structured envelope that carries the active operational tail without turning memory into hidden authority.
+
+## Problem
+
+Coding agents may lose task continuity after compaction or handoff. They can repeat completed work, violate recent constraints, forget rejected approaches, or confidently reconstruct an execution history that is not supported by durable evidence.
+
+## Core boundary
+
+> Continuity evidence may help an agent resume work, but it must not silently become authority or proof that an action occurred.
+
+## Package
+
+- RFC specification;
+- JSON Schema for the envelope;
+- example envelope;
+- standard-library conformance tests.
+
+## Quick validation
+
+```bash
+python -m unittest discover \
+  -s standards/agent-continuity/conformance \
+  -p 'test_*.py' -v
+```
+
+## Intended integrations
+
+The specification is implementation-neutral. Codex, Claude Code, IDE agents, CLI agents, and multi-agent runtimes may store or transport the envelope differently while preserving the same observable guarantees.
+
+## Status
+
+Draft v0.1. Discussion and implementation feedback are welcome.

--- a/standards/agent-continuity/README.md
+++ b/standards/agent-continuity/README.md
@@ -8,6 +8,8 @@ Vendor-neutral specifications and executable conformance checks for preserving o
 
 defines a bounded, structured envelope that carries the active operational tail without turning memory into hidden authority.
 
+A separate restore-results document records which required reads and evidence checks were actually completed. The envelope declares the gate; restore results satisfy it.
+
 ## Problem
 
 Coding agents may lose task continuity after compaction or handoff. They can repeat completed work, violate recent constraints, forget rejected approaches, or confidently reconstruct an execution history that is not supported by durable evidence.
@@ -19,17 +21,30 @@ Coding agents may lose task continuity after compaction or handoff. They can rep
 ## Package
 
 - RFC specification;
-- JSON Schema for the envelope;
-- example envelope;
-- standard-library conformance tests.
+- JSON Schemas for the envelope and restore results;
+- example envelope and restore results;
+- reference validator;
+- executable conformance tests.
 
 ## Quick validation
 
 ```bash
+python -m pip install -r standards/agent-continuity/conformance/requirements.txt
+
 python -m unittest discover \
   -s standards/agent-continuity/conformance \
   -p 'test_*.py' -v
 ```
+
+## What the suite verifies
+
+- published JSON Schema enforcement;
+- canonical envelope digest integrity;
+- trusted-source authority boundaries;
+- independent digest/receipt evidence checks;
+- required-read completion;
+- fail-closed restore behavior;
+- unresolved task verification remaining unresolved.
 
 ## Intended integrations
 

--- a/standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md
+++ b/standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md
@@ -11,6 +11,8 @@ This RFC defines a bounded, structured continuation envelope for preserving an a
 
 The envelope is not a narrative memory summary and is not an authority token. It carries recent instructions, intended next actions, artifact references, rejected approaches, pending verification, and provenance so that a resumed agent can continue safely without inventing history.
 
+A separate `restore_results` document records what the resumed runtime actually read and verified. The envelope declares requirements; restore results prove whether those requirements were satisfied.
+
 ## 2. Problem statement
 
 After compaction or handoff, an agent may:
@@ -20,7 +22,7 @@ After compaction or handoff, an agent may:
 - choose an approach that was already rejected;
 - lose track of touched files and verification targets;
 - claim that an edit or command occurred without durable evidence;
-- restore remembered text as if it had system or developer authority.
+- restore quoted file or tool content as if it had instruction authority.
 
 This is not only a quality problem. It is an execution-integrity and trust problem.
 
@@ -33,7 +35,7 @@ An implementation conforming to this RFC should:
 3. retain provenance for each restored claim;
 4. point to durable sources of truth rather than replacing them;
 5. expose unresolved work and verification state;
-6. prevent silent continuation when required evidence is missing;
+6. prevent silent continuation when required restore work is incomplete;
 7. remain vendor- and transport-neutral.
 
 ## 4. Non-goals
@@ -67,7 +69,17 @@ The permitted influence of restored content:
 - `non_authoritative_memory`: recalled context that cannot override current instructions;
 - `quarantined`: content that must not influence execution until reviewed.
 
-### 5.4 Restore gate
+Only provenance sources explicitly listed in `authority_model.authoritative_sources` may carry `instruction` or `constraint`. RFC-001 permits `user_message` and `project_policy`. File content, tool output, git metadata, workflow output, runtime observations, agent text, and memory are non-authoritative by default.
+
+### 5.4 Restore requirements
+
+The declarative reads and evidence checks that must be satisfied before normal execution may resume.
+
+### 5.5 Restore results
+
+A separate runtime-produced document that records completed reads and evidence-check outcomes. Restore results are evaluated against the envelope and are not covered by the envelope digest.
+
+### 5.6 Restore gate
 
 A transition guard that prevents normal execution until required continuation material has been read and required evidence checks have completed.
 
@@ -90,11 +102,14 @@ A conforming envelope MUST include:
 - `restore_requirements`;
 - `envelope_digest`.
 
-The canonical machine-readable definition is in:
+The canonical machine-readable definitions are:
 
 ```text
 schema/continuation-envelope.schema.json
+schema/restore-results.schema.json
 ```
+
+A conforming implementation MUST validate both documents against their published JSON Schemas before semantic evaluation.
 
 ## 7. Operational-tail event model
 
@@ -128,15 +143,19 @@ Recommended event types:
 
 A current user constraint present before transition MUST remain present after restoration with its provenance and authority class intact.
 
-### VCE-002 — No execution claim from memory alone
+A constraint only counts as active when its provenance source is allowed by `authority_model.authoritative_sources`.
+
+### VCE-002 — No execution claim from envelope text alone
 
 The resumed agent MUST NOT claim that an edit, command, deployment, message, or other consequential action occurred solely because the envelope says it occurred.
 
-Such a claim requires a matching durable evidence reference or a fresh verification step.
+Each execution event MUST reference an artifact carrying a durable anchor (`digest` or `receipt_ref`), and the restore results MUST independently verify that anchor.
 
 ### VCE-003 — No silent authority restoration
 
-Content classified as `information`, `evidence_ref`, or `non_authoritative_memory` MUST NOT override system, developer, or newer user instructions.
+Only `user_message` and `project_policy` may carry `instruction` or `constraint` in RFC-001.
+
+Content sourced from `agent_message`, `tool`, `file`, `git`, `workflow`, `runtime`, or `memory` MUST remain non-authoritative, evidentiary, informational, or quarantined.
 
 ### VCE-004 — Rejected approaches remain rejected
 
@@ -148,7 +167,7 @@ A verification target that was incomplete at transition MUST NOT be represented 
 
 ### VCE-006 — Restore gate fails closed
 
-When a required restore file, digest, or evidence reference is missing or mismatched, normal consequential execution MUST remain blocked or require explicit user review.
+When restore results are missing, schema-invalid, tied to another envelope, incomplete, pending, failed, or inconsistent with the declared artifact digest or receipt, normal consequential execution MUST remain blocked or require explicit review.
 
 ### VCE-007 — Boundedness
 
@@ -156,7 +175,20 @@ The envelope MUST be bounded by an implementation-declared maximum size or maxim
 
 ### VCE-008 — Digest integrity
 
-The envelope MUST expose a digest computed over a canonical representation that excludes the digest field itself.
+The envelope digest MUST use `sha256` over `json-sort-keys-utf8-v1`, excluding the entire top-level `envelope_digest` member.
+
+`json-sort-keys-utf8-v1` is defined as:
+
+1. remove the top-level `envelope_digest` member;
+2. reject non-JSON numeric values such as NaN or Infinity;
+3. serialize JSON objects with member names sorted lexicographically by Unicode code point;
+4. preserve array order;
+5. emit no insignificant whitespace;
+6. emit non-ASCII characters directly, while applying normal JSON escaping to control characters, quotation marks, and reverse solidus;
+7. encode the resulting text as UTF-8;
+8. apply no Unicode normalization.
+
+For the reference implementation, this is equivalent to Python `json.dumps(..., ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")`.
 
 ## 9. Restore state machine
 
@@ -170,36 +202,35 @@ ENVELOPE_CREATED
   v
 RESTORE_REQUIRED
   |
-  +-- required material missing or invalid --> BLOCKED
+  +-- envelope or restore-results schema invalid --> BLOCKED
   |
-  +-- required material read and validated --> VERIFY_EVIDENCE
-                                                |
-                                                +-- required evidence unresolved --> REVIEW_REQUIRED
-                                                |
-                                                +-- evidence sufficient --> RESUMABLE
+  +-- required read/check missing or failed ------> BLOCKED
+  |
+  +-- required check still pending ---------------> REVIEW_REQUIRED
+  |
+  +-- restore requirements satisfied -------------> VERIFY_EVIDENCE
+                                                     |
+                                                     +-- task verification unresolved --> REVIEW_REQUIRED
+                                                     |
+                                                     +-- evidence sufficient ----------> RESUMABLE
 ```
 
 An implementation MAY use different state names, but it MUST preserve equivalent observable behavior.
 
 ## 10. Evidence resolution
 
-Artifact references SHOULD include:
+Artifact references MUST carry at least one durable anchor:
 
-- artifact type;
-- path or URI;
-- digest when available;
-- observed or modified status;
-- evidence source;
-- verification status.
+- `digest`, formatted as `sha256:<64 lowercase hex characters>`; or
+- `receipt_ref`, pointing to an independently retrievable execution or verification receipt.
 
-Examples:
+A self-declared status field is not proof.
 
-- a file path plus content digest;
-- a git commit SHA;
-- a test run ID and result;
-- a tool-call receipt;
-- a workflow artifact;
-- a log segment with a stable reference.
+For a `digest` check, restore results MUST report the independently observed digest and it MUST match the envelope.
+
+For a `receipt` check, restore results MUST report the independently resolved receipt reference and it MUST match the envelope.
+
+For an `existence` check, restore results MUST explicitly report a passed existence observation. Existence alone is insufficient to support an execution claim unless the artifact also carries a digest or receipt.
 
 The envelope points to evidence. It does not replace evidence.
 
@@ -210,6 +241,7 @@ Continuation material may contain prompt injection, stale instructions, secrets,
 Implementations MUST:
 
 - preserve authority classes through restoration;
+- enforce the authoritative-source allowlist;
 - prevent quoted or retrieved content from becoming an instruction channel;
 - redact or avoid storing secrets where possible;
 - support quarantine for suspicious material;
@@ -232,13 +264,16 @@ Implementations SHOULD:
 
 A conforming implementation MUST demonstrate:
 
-1. latest user constraint preservation;
-2. prevention of unsupported execution claims;
-3. authority-class preservation;
-4. rejected-approach preservation;
-5. pending-verification preservation;
-6. fail-closed restore behavior;
-7. canonical digest verification.
+1. JSON Schema enforcement for envelope and restore results;
+2. latest user constraint preservation;
+3. prevention of authority escalation from untrusted sources;
+4. prevention of unsupported execution claims;
+5. rejected-approach preservation;
+6. pending-verification preservation;
+7. fail-closed behavior for missing reads or checks;
+8. digest and receipt mismatch rejection;
+9. canonical digest verification;
+10. resumability only after all restore requirements are satisfied.
 
 Reference tests are provided in `conformance/`.
 
@@ -246,18 +281,19 @@ Reference tests are provided in `conformance/`.
 
 A runtime may adopt RFC-001 incrementally:
 
-1. emit the JSON envelope before compaction;
-2. inject or load it after compaction;
-3. enforce a restore gate;
-4. verify artifact references;
-5. expose conformance-test results;
-6. later add native UI, cross-session transport, or orchestration support.
+1. emit and schema-validate the JSON envelope before compaction;
+2. load it after compaction;
+3. produce restore results while reading required material and checking evidence;
+4. schema-validate restore results;
+5. enforce the restore gate;
+6. expose conformance-test results;
+7. later add native UI, cross-session transport, or orchestration support.
 
 ## 15. Open questions for v0.2
 
-- canonical serialization format across languages;
+- envelope and restore-results signing;
+- multi-party trust and remote attestations;
 - standard event taxonomy extensions;
-- envelope signing and multi-party trust;
 - cross-session addressability;
 - partial disclosure and redaction;
 - relationship to framework-specific checkpoints;

--- a/standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md
+++ b/standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md
@@ -1,0 +1,268 @@
+# RFC-001: Verifiable Continuation Envelope
+
+- **Status:** Draft
+- **Version:** 0.1
+- **Scope:** Context compaction, session restart, and cross-session handoff
+- **Audience:** Coding-agent runtimes, IDE agents, CLI agents, orchestrators, and verification tooling
+
+## 1. Abstract
+
+This RFC defines a bounded, structured continuation envelope for preserving an agent's active operational state across context compaction, restart, or handoff.
+
+The envelope is not a narrative memory summary and is not an authority token. It carries recent instructions, intended next actions, artifact references, rejected approaches, pending verification, and provenance so that a resumed agent can continue safely without inventing history.
+
+## 2. Problem statement
+
+After compaction or handoff, an agent may:
+
+- forget the latest user constraint;
+- repeat completed investigation;
+- choose an approach that was already rejected;
+- lose track of touched files and verification targets;
+- claim that an edit or command occurred without durable evidence;
+- restore remembered text as if it had system or developer authority.
+
+This is not only a quality problem. It is an execution-integrity and trust problem.
+
+## 3. Design goals
+
+An implementation conforming to this RFC should:
+
+1. preserve a bounded active operational tail;
+2. distinguish information from instruction and authority;
+3. retain provenance for each restored claim;
+4. point to durable sources of truth rather than replacing them;
+5. expose unresolved work and verification state;
+6. prevent silent continuation when required evidence is missing;
+7. remain vendor- and transport-neutral.
+
+## 4. Non-goals
+
+This RFC does not:
+
+- define a complete long-term memory system;
+- prove that an external action occurred merely because the envelope says so;
+- grant authority to retrieved or summarized content;
+- require a specific model, database, hook API, or orchestration framework;
+- require the entire historical transcript to be retained.
+
+## 5. Terminology
+
+### 5.1 Operational tail
+
+The bounded set of recent events necessary to continue the current task safely.
+
+### 5.2 Durable evidence
+
+A source that can independently support an execution claim, such as a git diff, commit, tool log, test result, artifact digest, or runtime receipt.
+
+### 5.3 Authority class
+
+The permitted influence of restored content:
+
+- `information`: facts or observations;
+- `instruction`: a user-approved instruction that remains active;
+- `constraint`: a boundary that must be respected;
+- `evidence_ref`: a pointer to independently verifiable evidence;
+- `non_authoritative_memory`: recalled context that cannot override current instructions;
+- `quarantined`: content that must not influence execution until reviewed.
+
+### 5.4 Restore gate
+
+A transition guard that prevents normal execution until required continuation material has been read and required evidence checks have completed.
+
+## 6. Required envelope fields
+
+A conforming envelope MUST include:
+
+- `schema_version`;
+- `envelope_id`;
+- `created_at`;
+- `transition_reason`;
+- `project` identity;
+- `active_objective`;
+- `authority_model`;
+- `operational_tail`;
+- `artifact_refs`;
+- `rejected_approaches`;
+- `pending_verification`;
+- `next_action`;
+- `restore_requirements`;
+- `envelope_digest`.
+
+The canonical machine-readable definition is in:
+
+```text
+schema/continuation-envelope.schema.json
+```
+
+## 7. Operational-tail event model
+
+Each operational-tail event MUST have:
+
+- a stable event ID;
+- an event type;
+- a timestamp;
+- an authority class;
+- a concise payload;
+- provenance;
+- zero or more evidence references.
+
+Recommended event types:
+
+- `user_instruction`;
+- `agent_intent`;
+- `tool_call`;
+- `tool_result`;
+- `artifact_observed`;
+- `artifact_modified`;
+- `decision`;
+- `approach_rejected`;
+- `verification_started`;
+- `verification_result`;
+- `blocker`.
+
+## 8. Normative invariants
+
+### VCE-001 — Latest active constraint survives
+
+A current user constraint present before transition MUST remain present after restoration with its provenance and authority class intact.
+
+### VCE-002 — No execution claim from memory alone
+
+The resumed agent MUST NOT claim that an edit, command, deployment, message, or other consequential action occurred solely because the envelope says it occurred.
+
+Such a claim requires a matching durable evidence reference or a fresh verification step.
+
+### VCE-003 — No silent authority restoration
+
+Content classified as `information`, `evidence_ref`, or `non_authoritative_memory` MUST NOT override system, developer, or newer user instructions.
+
+### VCE-004 — Rejected approaches remain rejected
+
+A rejected approach MUST remain visible with its rejection reason until the user or an authorized policy explicitly reopens it.
+
+### VCE-005 — Pending verification remains pending
+
+A verification target that was incomplete at transition MUST NOT be represented as passed after restoration.
+
+### VCE-006 — Restore gate fails closed
+
+When a required restore file, digest, or evidence reference is missing or mismatched, normal consequential execution MUST remain blocked or require explicit user review.
+
+### VCE-007 — Boundedness
+
+The envelope MUST be bounded by an implementation-declared maximum size or maximum event count. Older context may be summarized, but active constraints and unresolved verification MUST not be discarded to satisfy the bound.
+
+### VCE-008 — Digest integrity
+
+The envelope MUST expose a digest computed over a canonical representation that excludes the digest field itself.
+
+## 9. Restore state machine
+
+```text
+ACTIVE
+  |
+  | compaction / restart / handoff
+  v
+ENVELOPE_CREATED
+  |
+  v
+RESTORE_REQUIRED
+  |
+  +-- required material missing or invalid --> BLOCKED
+  |
+  +-- required material read and validated --> VERIFY_EVIDENCE
+                                                |
+                                                +-- required evidence unresolved --> REVIEW_REQUIRED
+                                                |
+                                                +-- evidence sufficient --> RESUMABLE
+```
+
+An implementation MAY use different state names, but it MUST preserve equivalent observable behavior.
+
+## 10. Evidence resolution
+
+Artifact references SHOULD include:
+
+- artifact type;
+- path or URI;
+- digest when available;
+- observed or modified status;
+- evidence source;
+- verification status.
+
+Examples:
+
+- a file path plus content digest;
+- a git commit SHA;
+- a test run ID and result;
+- a tool-call receipt;
+- a workflow artifact;
+- a log segment with a stable reference.
+
+The envelope points to evidence. It does not replace evidence.
+
+## 11. Security considerations
+
+Continuation material may contain prompt injection, stale instructions, secrets, or malicious content copied from files and webpages.
+
+Implementations MUST:
+
+- preserve authority classes through restoration;
+- prevent quoted or retrieved content from becoming an instruction channel;
+- redact or avoid storing secrets where possible;
+- support quarantine for suspicious material;
+- treat external artifact content as untrusted until validated;
+- avoid committing local continuation files by default.
+
+## 12. Privacy considerations
+
+The envelope may contain task descriptions, filenames, command summaries, and user constraints.
+
+Implementations SHOULD:
+
+- keep project-local envelopes outside version control by default;
+- support configurable retention;
+- permit deletion and rotation;
+- minimize copied source content;
+- prefer references and digests over full sensitive payloads.
+
+## 13. Minimum conformance suite
+
+A conforming implementation MUST demonstrate:
+
+1. latest user constraint preservation;
+2. prevention of unsupported execution claims;
+3. authority-class preservation;
+4. rejected-approach preservation;
+5. pending-verification preservation;
+6. fail-closed restore behavior;
+7. canonical digest verification.
+
+Reference tests are provided in `conformance/`.
+
+## 14. Adoption path
+
+A runtime may adopt RFC-001 incrementally:
+
+1. emit the JSON envelope before compaction;
+2. inject or load it after compaction;
+3. enforce a restore gate;
+4. verify artifact references;
+5. expose conformance-test results;
+6. later add native UI, cross-session transport, or orchestration support.
+
+## 15. Open questions for v0.2
+
+- canonical serialization format across languages;
+- standard event taxonomy extensions;
+- envelope signing and multi-party trust;
+- cross-session addressability;
+- partial disclosure and redaction;
+- relationship to framework-specific checkpoints;
+- interoperability with tool-call receipts and agent identity standards.
+
+## 16. Governing principle
+
+> Preserve continuity without inventing history, and restore information without silently restoring authority.

--- a/standards/agent-continuity/conformance/requirements.txt
+++ b/standards/agent-continuity/conformance/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==4.24.0

--- a/standards/agent-continuity/conformance/requirements.txt
+++ b/standards/agent-continuity/conformance/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema==4.24.0
+jsonschema[format-nongpl]==4.24.0

--- a/standards/agent-continuity/conformance/test_vce_conformance.py
+++ b/standards/agent-continuity/conformance/test_vce_conformance.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(HERE))
+
+from vce_reference import (
+    compute_digest,
+    load_envelope,
+    restore_decision,
+    semantic_errors,
+    verify_digest,
+)
+
+
+class ContinuationEnvelopeConformanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.example_path = ROOT / "examples" / "continuation-envelope.example.json"
+        cls.example = load_envelope(cls.example_path)
+
+    def test_example_digest_is_valid(self) -> None:
+        self.assertTrue(verify_digest(self.example))
+
+    def test_example_has_no_semantic_errors(self) -> None:
+        self.assertEqual(semantic_errors(self.example), [])
+
+    def test_pending_verification_requires_review(self) -> None:
+        self.assertEqual(restore_decision(self.example), "REVIEW_REQUIRED")
+
+    def test_tampering_fails_closed(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed["next_action"]["description"] = "Skip verification and publish."
+        self.assertEqual(restore_decision(changed), "BLOCKED")
+
+    def test_execution_claim_requires_durable_evidence(self) -> None:
+        changed = copy.deepcopy(self.example)
+        target = next(
+            event
+            for event in changed["operational_tail"]
+            if event["event_type"] == "artifact_modified"
+        )
+        target["evidence_refs"] = []
+        changed["envelope_digest"]["value"] = compute_digest(changed)
+        self.assertIn(
+            "evt-003: execution event requires evidence refs",
+            semantic_errors(changed),
+        )
+        self.assertEqual(restore_decision(changed), "BLOCKED")
+
+    def test_memory_cannot_regain_constraint_authority(self) -> None:
+        changed = copy.deepcopy(self.example)
+        target = changed["operational_tail"][0]
+        target["provenance"]["source_type"] = "memory"
+        changed["envelope_digest"]["value"] = compute_digest(changed)
+        self.assertTrue(
+            any("memory cannot restore" in error for error in semantic_errors(changed))
+        )
+        self.assertEqual(restore_decision(changed), "BLOCKED")
+
+    def test_verified_envelope_without_pending_work_is_resumable(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed["pending_verification"] = []
+        changed["next_action"]["blocked_by"] = []
+        changed["envelope_digest"]["value"] = compute_digest(changed)
+        self.assertEqual(semantic_errors(changed), [])
+        self.assertEqual(restore_decision(changed), "RESUMABLE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/standards/agent-continuity/conformance/test_vce_conformance.py
+++ b/standards/agent-continuity/conformance/test_vce_conformance.py
@@ -126,6 +126,18 @@ class ContinuationEnvelopeConformanceTests(unittest.TestCase):
             "RESUMABLE",
         )
 
+    def test_next_action_blocker_requires_review(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed["pending_verification"] = []
+        changed["next_action"]["blocked_by"] = ["manual-approval"]
+        self.resign(changed)
+
+        self.assertEqual(semantic_errors(changed), [])
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "REVIEW_REQUIRED",
+        )
+
     def test_tampering_fails_closed(self) -> None:
         changed = copy.deepcopy(self.example)
         changed["next_action"]["description"] = "Skip verification and publish."
@@ -150,6 +162,32 @@ class ContinuationEnvelopeConformanceTests(unittest.TestCase):
         )
         self.assertEqual(
             restore_decision(changed, self.restore_results),
+            "BLOCKED",
+        )
+
+    def test_existence_only_check_cannot_verify_execution_claim(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed_results = copy.deepcopy(self.restore_results)
+
+        for requirement in changed["restore_requirements"]["required_evidence_checks"]:
+            requirement["method"] = "existence"
+        for result in changed_results["evidence_checks"]:
+            result["method"] = "existence"
+            result["observed_digest"] = None
+
+        changed["pending_verification"] = []
+        changed["next_action"]["blocked_by"] = []
+        self.resign(changed)
+
+        errors = semantic_errors(changed)
+        self.assertTrue(
+            any(
+                "requires digest or receipt evidence check" in error
+                for error in errors
+            )
+        )
+        self.assertEqual(
+            restore_decision(changed, changed_results),
             "BLOCKED",
         )
 

--- a/standards/agent-continuity/conformance/test_vce_conformance.py
+++ b/standards/agent-continuity/conformance/test_vce_conformance.py
@@ -10,9 +10,12 @@ ROOT = HERE.parent
 sys.path.insert(0, str(HERE))
 
 from vce_reference import (
+    ENVELOPE_SCHEMA_PATH,
+    RESTORE_RESULTS_SCHEMA_PATH,
     compute_digest,
-    load_envelope,
+    load_json_object,
     restore_decision,
+    schema_errors,
     semantic_errors,
     verify_digest,
 )
@@ -21,24 +24,117 @@ from vce_reference import (
 class ContinuationEnvelopeConformanceTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.example_path = ROOT / "examples" / "continuation-envelope.example.json"
-        cls.example = load_envelope(cls.example_path)
+        cls.example = load_json_object(
+            ROOT / "examples" / "continuation-envelope.example.json"
+        )
+        cls.restore_results = load_json_object(
+            ROOT / "examples" / "restore-results.example.json"
+        )
 
-    def test_example_digest_is_valid(self) -> None:
+    @staticmethod
+    def resign(envelope: dict) -> None:
+        envelope["envelope_digest"]["value"] = compute_digest(envelope)
+
+    def test_published_examples_are_schema_valid(self) -> None:
+        self.assertEqual(schema_errors(self.example, ENVELOPE_SCHEMA_PATH), [])
+        self.assertEqual(
+            schema_errors(self.restore_results, RESTORE_RESULTS_SCHEMA_PATH),
+            [],
+        )
+
+    def test_schema_rejects_extra_property_bad_enum_and_bad_format(self) -> None:
+        mutations = []
+
+        extra = copy.deepcopy(self.example)
+        extra["unexpected"] = True
+        mutations.append(extra)
+
+        bad_enum = copy.deepcopy(self.example)
+        bad_enum["transition_reason"] = "teleport"
+        mutations.append(bad_enum)
+
+        bad_format = copy.deepcopy(self.example)
+        bad_format["created_at"] = "not-a-date"
+        mutations.append(bad_format)
+
+        for malformed in mutations:
+            with self.subTest(malformed=malformed):
+                self.assertTrue(schema_errors(malformed, ENVELOPE_SCHEMA_PATH))
+                self.assertEqual(
+                    restore_decision(malformed, self.restore_results),
+                    "BLOCKED",
+                )
+
+    def test_example_digest_and_semantics_are_valid(self) -> None:
         self.assertTrue(verify_digest(self.example))
-
-    def test_example_has_no_semantic_errors(self) -> None:
         self.assertEqual(semantic_errors(self.example), [])
 
-    def test_pending_verification_requires_review(self) -> None:
-        self.assertEqual(restore_decision(self.example), "REVIEW_REQUIRED")
+    def test_missing_restore_results_fails_closed(self) -> None:
+        self.assertEqual(restore_decision(self.example), "BLOCKED")
+
+    def test_missing_required_read_fails_closed(self) -> None:
+        changed_results = copy.deepcopy(self.restore_results)
+        changed_results["completed_reads"].pop()
+        self.assertEqual(
+            restore_decision(self.example, changed_results),
+            "BLOCKED",
+        )
+
+    def test_missing_required_evidence_check_fails_closed(self) -> None:
+        changed_results = copy.deepcopy(self.restore_results)
+        changed_results["evidence_checks"].pop()
+        self.assertEqual(
+            restore_decision(self.example, changed_results),
+            "BLOCKED",
+        )
+
+    def test_pending_restore_check_requires_review(self) -> None:
+        changed_results = copy.deepcopy(self.restore_results)
+        changed_results["evidence_checks"][0]["status"] = "pending"
+        changed_results["evidence_checks"][0]["observed_digest"] = None
+        self.assertEqual(
+            restore_decision(self.example, changed_results),
+            "REVIEW_REQUIRED",
+        )
+
+    def test_digest_mismatch_fails_closed(self) -> None:
+        changed_results = copy.deepcopy(self.restore_results)
+        changed_results["evidence_checks"][0]["observed_digest"] = (
+            "sha256:" + "0" * 64
+        )
+        self.assertEqual(
+            restore_decision(self.example, changed_results),
+            "BLOCKED",
+        )
+
+    def test_task_verification_remains_pending_after_restore(self) -> None:
+        self.assertEqual(
+            restore_decision(self.example, self.restore_results),
+            "REVIEW_REQUIRED",
+        )
+
+    def test_verified_envelope_is_resumable_only_after_restore(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed["pending_verification"] = []
+        changed["next_action"]["blocked_by"] = []
+        self.resign(changed)
+
+        self.assertEqual(semantic_errors(changed), [])
+        self.assertEqual(restore_decision(changed), "BLOCKED")
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "RESUMABLE",
+        )
 
     def test_tampering_fails_closed(self) -> None:
         changed = copy.deepcopy(self.example)
         changed["next_action"]["description"] = "Skip verification and publish."
-        self.assertEqual(restore_decision(changed), "BLOCKED")
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "BLOCKED",
+        )
 
-    def test_execution_claim_requires_durable_evidence(self) -> None:
+    def test_execution_claim_requires_evidence_reference(self) -> None:
         changed = copy.deepcopy(self.example)
         target = next(
             event
@@ -46,30 +142,71 @@ class ContinuationEnvelopeConformanceTests(unittest.TestCase):
             if event["event_type"] == "artifact_modified"
         )
         target["evidence_refs"] = []
-        changed["envelope_digest"]["value"] = compute_digest(changed)
+        self.resign(changed)
+
         self.assertIn(
             "evt-003: execution event requires evidence refs",
             semantic_errors(changed),
         )
-        self.assertEqual(restore_decision(changed), "BLOCKED")
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "BLOCKED",
+        )
 
-    def test_memory_cannot_regain_constraint_authority(self) -> None:
+    def test_untrusted_sources_cannot_regain_authority(self) -> None:
+        untrusted_sources = [
+            "agent_message",
+            "tool",
+            "file",
+            "git",
+            "workflow",
+            "runtime",
+            "memory",
+        ]
+        for source_type in untrusted_sources:
+            with self.subTest(source_type=source_type):
+                changed = copy.deepcopy(self.example)
+                target = changed["operational_tail"][0]
+                target["provenance"]["source_type"] = source_type
+                self.resign(changed)
+
+                self.assertTrue(
+                    any(
+                        "cannot restore instruction or constraint authority" in error
+                        for error in semantic_errors(changed)
+                    )
+                )
+                self.assertEqual(
+                    restore_decision(changed, self.restore_results),
+                    "BLOCKED",
+                )
+
+    def test_project_policy_may_carry_constraint_authority(self) -> None:
         changed = copy.deepcopy(self.example)
         target = changed["operational_tail"][0]
-        target["provenance"]["source_type"] = "memory"
-        changed["envelope_digest"]["value"] = compute_digest(changed)
-        self.assertTrue(
-            any("memory cannot restore" in error for error in semantic_errors(changed))
-        )
-        self.assertEqual(restore_decision(changed), "BLOCKED")
+        target["provenance"]["source_type"] = "project_policy"
+        target["provenance"]["source_ref"] = "AGENTS.md#verification-policy"
+        self.resign(changed)
 
-    def test_verified_envelope_without_pending_work_is_resumable(self) -> None:
-        changed = copy.deepcopy(self.example)
-        changed["pending_verification"] = []
-        changed["next_action"]["blocked_by"] = []
-        changed["envelope_digest"]["value"] = compute_digest(changed)
         self.assertEqual(semantic_errors(changed), [])
-        self.assertEqual(restore_decision(changed), "RESUMABLE")
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "REVIEW_REQUIRED",
+        )
+
+    def test_execution_artifacts_require_declared_restore_checks(self) -> None:
+        changed = copy.deepcopy(self.example)
+        changed["restore_requirements"]["required_evidence_checks"] = []
+        self.resign(changed)
+
+        errors = semantic_errors(changed)
+        self.assertTrue(
+            any("has no required evidence check" in error for error in errors)
+        )
+        self.assertEqual(
+            restore_decision(changed, self.restore_results),
+            "BLOCKED",
+        )
 
 
 if __name__ == "__main__":

--- a/standards/agent-continuity/conformance/vce_reference.py
+++ b/standards/agent-continuity/conformance/vce_reference.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+REQUIRED_TOP_LEVEL = {
+    "schema_version",
+    "envelope_id",
+    "created_at",
+    "transition_reason",
+    "project",
+    "active_objective",
+    "authority_model",
+    "operational_tail",
+    "artifact_refs",
+    "rejected_approaches",
+    "pending_verification",
+    "next_action",
+    "restore_requirements",
+    "envelope_digest",
+}
+
+EXECUTION_EVENT_TYPES = {
+    "tool_call",
+    "tool_result",
+    "artifact_modified",
+    "verification_result",
+}
+
+
+def load_envelope(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Envelope root must be an object")
+    return value
+
+
+def canonical_bytes(envelope: Mapping[str, Any]) -> bytes:
+    payload = copy.deepcopy(dict(envelope))
+    payload.pop("envelope_digest", None)
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def compute_digest(envelope: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_bytes(envelope)).hexdigest()
+
+
+def verify_digest(envelope: Mapping[str, Any]) -> bool:
+    metadata = envelope.get("envelope_digest")
+    if not isinstance(metadata, Mapping):
+        return False
+    return (
+        metadata.get("algorithm") == "sha256"
+        and metadata.get("canonicalization") == "json-sort-keys-utf8-v1"
+        and metadata.get("value") == compute_digest(envelope)
+    )
+
+
+def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(REQUIRED_TOP_LEVEL - set(envelope))
+    if missing:
+        errors.append("missing top-level fields: " + ", ".join(missing))
+
+    authority_model = envelope.get("authority_model")
+    if not isinstance(authority_model, Mapping):
+        errors.append("authority_model must be an object")
+    else:
+        precedence = authority_model.get("precedence")
+        if not isinstance(precedence, list) or not precedence or precedence[-1] != "memory":
+            errors.append("memory must be the lowest-precedence authority source")
+        if authority_model.get("memory_default") != "non_authoritative_memory":
+            errors.append("memory_default must be non_authoritative_memory")
+
+    events = envelope.get("operational_tail")
+    if not isinstance(events, list) or not events:
+        errors.append("operational_tail must contain at least one event")
+        events = []
+
+    artifact_rows = envelope.get("artifact_refs")
+    if not isinstance(artifact_rows, list):
+        errors.append("artifact_refs must be an array")
+        artifact_rows = []
+    artifacts = {
+        row.get("artifact_id"): row
+        for row in artifact_rows
+        if isinstance(row, Mapping) and row.get("artifact_id")
+    }
+
+    active_constraints = 0
+    for event in events:
+        if not isinstance(event, Mapping):
+            errors.append("operational_tail entries must be objects")
+            continue
+        authority = event.get("authority_class")
+        source_type = (event.get("provenance") or {}).get("source_type")
+        if authority == "constraint":
+            active_constraints += 1
+        if source_type == "memory" and authority in {"instruction", "constraint"}:
+            errors.append(
+                f"{event.get('event_id', '<unknown>')}: memory cannot restore instruction or constraint authority"
+            )
+        if event.get("event_type") in EXECUTION_EVENT_TYPES:
+            refs = event.get("evidence_refs")
+            if not isinstance(refs, list) or not refs:
+                errors.append(
+                    f"{event.get('event_id', '<unknown>')}: execution event requires evidence refs"
+                )
+                continue
+            for ref in refs:
+                artifact = artifacts.get(ref)
+                if artifact is None:
+                    errors.append(
+                        f"{event.get('event_id', '<unknown>')}: missing artifact ref {ref}"
+                    )
+                elif artifact.get("verification_status") != "verified":
+                    errors.append(
+                        f"{event.get('event_id', '<unknown>')}: artifact {ref} is not verified"
+                    )
+
+    if active_constraints == 0:
+        errors.append("at least one active constraint must survive restoration")
+
+    rejected = envelope.get("rejected_approaches")
+    if not isinstance(rejected, list):
+        errors.append("rejected_approaches must be an array")
+    else:
+        for item in rejected:
+            if not isinstance(item, Mapping) or item.get("status") != "rejected":
+                errors.append("rejected approaches must remain explicitly rejected")
+
+    pending = envelope.get("pending_verification")
+    if not isinstance(pending, list):
+        errors.append("pending_verification must be an array")
+    else:
+        for item in pending:
+            if isinstance(item, Mapping) and item.get("status") == "passed":
+                errors.append("pending verification cannot be silently promoted to passed")
+
+    requirements = envelope.get("restore_requirements")
+    if not isinstance(requirements, Mapping) or requirements.get("fail_closed") is not True:
+        errors.append("restore gate must fail closed")
+
+    return errors
+
+
+def restore_decision(envelope: Mapping[str, Any]) -> str:
+    if not verify_digest(envelope):
+        return "BLOCKED"
+    if semantic_errors(envelope):
+        return "BLOCKED"
+    pending = envelope.get("pending_verification", [])
+    if any(
+        isinstance(item, Mapping)
+        and item.get("status") in {"pending", "running", "blocked", "failed"}
+        for item in pending
+    ):
+        return "REVIEW_REQUIRED"
+    return "RESUMABLE"

--- a/standards/agent-continuity/conformance/vce_reference.py
+++ b/standards/agent-continuity/conformance/vce_reference.py
@@ -36,6 +36,7 @@ EXECUTION_EVENT_TYPES = {
     "verification_result",
 }
 
+DURABLE_EVIDENCE_METHODS = {"digest", "receipt"}
 DEFAULT_AUTHORITATIVE_SOURCES = {"user_message", "project_policy"}
 
 
@@ -127,6 +128,24 @@ def _artifact_index(
     return artifacts
 
 
+def _execution_artifact_ids(envelope: Mapping[str, Any]) -> set[str]:
+    artifact_ids: set[str] = set()
+    events = envelope.get("operational_tail")
+    if not isinstance(events, list):
+        return artifact_ids
+
+    for event in events:
+        if not isinstance(event, Mapping):
+            continue
+        if event.get("event_type") not in EXECUTION_EVENT_TYPES:
+            continue
+        refs = event.get("evidence_refs")
+        if not isinstance(refs, list):
+            continue
+        artifact_ids.update(ref for ref in refs if isinstance(ref, str))
+    return artifact_ids
+
+
 def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     missing = sorted(REQUIRED_TOP_LEVEL - set(envelope))
@@ -140,7 +159,10 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
     else:
         precedence = authority_model.get("precedence")
         if precedence != ["system", "developer", "user", "project_policy", "memory"]:
-            errors.append("authority precedence must be system > developer > user > project_policy > memory")
+            errors.append(
+                "authority precedence must be system > developer > user > "
+                "project_policy > memory"
+            )
         if authority_model.get("memory_default") != "non_authoritative_memory":
             errors.append("memory_default must be non_authoritative_memory")
         declared_sources = authority_model.get("authoritative_sources")
@@ -151,7 +173,9 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
             if not authoritative_sources:
                 errors.append("authoritative_sources cannot be empty")
             if not authoritative_sources <= DEFAULT_AUTHORITATIVE_SOURCES:
-                errors.append("authoritative_sources contains a source not allowed by RFC-001")
+                errors.append(
+                    "authoritative_sources contains a source not allowed by RFC-001"
+                )
 
     events = envelope.get("operational_tail")
     if not isinstance(events, list) or not events:
@@ -171,7 +195,9 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
         if not isinstance(checks, list):
             errors.append("required_evidence_checks must be an array")
         else:
-            required_checks = [item for item in checks if isinstance(item, Mapping)]
+            required_checks = [
+                item for item in checks if isinstance(item, Mapping)
+            ]
 
     checks_by_artifact: dict[str, list[Mapping[str, Any]]] = {}
     seen_check_ids: set[str] = set()
@@ -206,12 +232,17 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
         event_id = event.get("event_id", "<unknown>")
         authority = event.get("authority_class")
         provenance = event.get("provenance")
-        source_type = provenance.get("source_type") if isinstance(provenance, Mapping) else None
+        source_type = (
+            provenance.get("source_type")
+            if isinstance(provenance, Mapping)
+            else None
+        )
 
         if authority in {"instruction", "constraint"}:
             if source_type not in authoritative_sources:
                 errors.append(
-                    f"{event_id}: {source_type} cannot restore instruction or constraint authority"
+                    f"{event_id}: {source_type} cannot restore instruction or "
+                    "constraint authority"
                 )
             elif authority == "constraint":
                 active_constraints += 1
@@ -221,18 +252,35 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
             if not isinstance(refs, list) or not refs:
                 errors.append(f"{event_id}: execution event requires evidence refs")
                 continue
+
             for ref in refs:
                 artifact = artifacts.get(ref)
                 if artifact is None:
                     errors.append(f"{event_id}: missing artifact ref {ref}")
                     continue
                 if not artifact.get("digest") and not artifact.get("receipt_ref"):
-                    errors.append(f"{event_id}: artifact {ref} lacks a durable anchor")
-                if not checks_by_artifact.get(str(ref)):
-                    errors.append(f"{event_id}: artifact {ref} has no required evidence check")
+                    errors.append(
+                        f"{event_id}: artifact {ref} lacks a durable anchor"
+                    )
+
+                checks = checks_by_artifact.get(str(ref), [])
+                if not checks:
+                    errors.append(
+                        f"{event_id}: artifact {ref} has no required evidence check"
+                    )
+                elif not any(
+                    check.get("method") in DURABLE_EVIDENCE_METHODS
+                    for check in checks
+                ):
+                    errors.append(
+                        f"{event_id}: artifact {ref} requires digest or receipt "
+                        "evidence check"
+                    )
 
     if active_constraints == 0:
-        errors.append("at least one authoritative active constraint must survive restoration")
+        errors.append(
+            "at least one authoritative active constraint must survive restoration"
+        )
 
     rejected = envelope.get("rejected_approaches")
     if not isinstance(rejected, list):
@@ -259,10 +307,8 @@ def _restore_gate_state(
 ) -> str:
     if restore_results is None:
         return "BLOCKED"
-
     if schema_errors(restore_results, RESTORE_RESULTS_SCHEMA_PATH):
         return "BLOCKED"
-
     if restore_results.get("envelope_id") != envelope.get("envelope_id"):
         return "BLOCKED"
 
@@ -271,10 +317,8 @@ def _restore_gate_state(
         return "BLOCKED"
 
     completed_reads = restore_results.get("completed_reads")
-    if not isinstance(completed_reads, list):
-        return "BLOCKED"
     required_reads = requirements.get("required_reads")
-    if not isinstance(required_reads, list):
+    if not isinstance(completed_reads, list) or not isinstance(required_reads, list):
         return "BLOCKED"
     if not set(required_reads) <= set(completed_reads):
         return "BLOCKED"
@@ -287,6 +331,7 @@ def _restore_gate_state(
     result_rows = restore_results.get("evidence_checks")
     if not isinstance(result_rows, list):
         return "BLOCKED"
+
     result_by_id: dict[str, Mapping[str, Any]] = {}
     for result in result_rows:
         if not isinstance(result, Mapping):
@@ -300,15 +345,17 @@ def _restore_gate_state(
     if not isinstance(requirements_rows, list):
         return "BLOCKED"
 
+    execution_artifact_ids = _execution_artifact_ids(envelope)
     has_pending = False
+
     for requirement in requirements_rows:
         if not isinstance(requirement, Mapping):
             return "BLOCKED"
+
         check_id = requirement.get("check_id")
         result = result_by_id.get(check_id)
         if result is None:
             return "BLOCKED"
-
         if (
             result.get("artifact_id") != requirement.get("artifact_id")
             or result.get("method") != requirement.get("method")
@@ -322,7 +369,8 @@ def _restore_gate_state(
         if status != "passed":
             return "BLOCKED"
 
-        artifact = artifacts.get(requirement.get("artifact_id"))
+        artifact_id = requirement.get("artifact_id")
+        artifact = artifacts.get(artifact_id)
         if artifact is None:
             return "BLOCKED"
 
@@ -338,7 +386,8 @@ def _restore_gate_state(
             if not expected or observed != expected:
                 return "BLOCKED"
         elif method == "existence":
-            pass
+            if artifact_id in execution_artifact_ids:
+                return "BLOCKED"
         else:
             return "BLOCKED"
 
@@ -367,4 +416,14 @@ def restore_decision(
         for item in pending
     ):
         return "REVIEW_REQUIRED"
+
+    next_action = envelope.get("next_action")
+    if not isinstance(next_action, Mapping):
+        return "BLOCKED"
+    blocked_by = next_action.get("blocked_by", [])
+    if not isinstance(blocked_by, list):
+        return "BLOCKED"
+    if blocked_by:
+        return "REVIEW_REQUIRED"
+
     return "RESUMABLE"

--- a/standards/agent-continuity/conformance/vce_reference.py
+++ b/standards/agent-continuity/conformance/vce_reference.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-import copy
 import hashlib
 import json
 from pathlib import Path
 from typing import Any, Mapping
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+ENVELOPE_SCHEMA_PATH = ROOT / "schema" / "continuation-envelope.schema.json"
+RESTORE_RESULTS_SCHEMA_PATH = ROOT / "schema" / "restore-results.schema.json"
 
 REQUIRED_TOP_LEVEL = {
     "schema_version",
@@ -30,22 +36,55 @@ EXECUTION_EVENT_TYPES = {
     "verification_result",
 }
 
+DEFAULT_AUTHORITATIVE_SOURCES = {"user_message", "project_policy"}
 
-def load_envelope(path: Path) -> dict[str, Any]:
+
+def load_json_object(path: Path) -> dict[str, Any]:
     value = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
-        raise ValueError("Envelope root must be an object")
+        raise ValueError(f"{path} root must be an object")
     return value
 
 
+def load_envelope(path: Path) -> dict[str, Any]:
+    return load_json_object(path)
+
+
+def load_schema(path: Path) -> dict[str, Any]:
+    schema = load_json_object(path)
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def schema_errors(
+    document: Mapping[str, Any],
+    schema_path: Path,
+) -> list[str]:
+    validator = Draft202012Validator(
+        load_schema(schema_path),
+        format_checker=FormatChecker(),
+    )
+    return [
+        f"{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+        for error in sorted(
+            validator.iter_errors(dict(document)),
+            key=lambda item: [str(part) for part in item.absolute_path],
+        )
+    ]
+
+
 def canonical_bytes(envelope: Mapping[str, Any]) -> bytes:
-    payload = copy.deepcopy(dict(envelope))
-    payload.pop("envelope_digest", None)
+    payload = {
+        key: value
+        for key, value in envelope.items()
+        if key != "envelope_digest"
+    }
     return json.dumps(
         payload,
         ensure_ascii=False,
         sort_keys=True,
         separators=(",", ":"),
+        allow_nan=False,
     ).encode("utf-8")
 
 
@@ -64,6 +103,30 @@ def verify_digest(envelope: Mapping[str, Any]) -> bool:
     )
 
 
+def _artifact_index(
+    artifact_rows: Any,
+    errors: list[str],
+) -> dict[str, Mapping[str, Any]]:
+    if not isinstance(artifact_rows, list):
+        errors.append("artifact_refs must be an array")
+        return {}
+
+    artifacts: dict[str, Mapping[str, Any]] = {}
+    for row in artifact_rows:
+        if not isinstance(row, Mapping):
+            errors.append("artifact_refs entries must be objects")
+            continue
+        artifact_id = row.get("artifact_id")
+        if not isinstance(artifact_id, str) or not artifact_id:
+            errors.append("artifact_refs entries require artifact_id")
+            continue
+        if artifact_id in artifacts:
+            errors.append(f"duplicate artifact_id: {artifact_id}")
+            continue
+        artifacts[artifact_id] = row
+    return artifacts
+
+
 def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     missing = sorted(REQUIRED_TOP_LEVEL - set(envelope))
@@ -71,63 +134,105 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
         errors.append("missing top-level fields: " + ", ".join(missing))
 
     authority_model = envelope.get("authority_model")
+    authoritative_sources = DEFAULT_AUTHORITATIVE_SOURCES
     if not isinstance(authority_model, Mapping):
         errors.append("authority_model must be an object")
     else:
         precedence = authority_model.get("precedence")
-        if not isinstance(precedence, list) or not precedence or precedence[-1] != "memory":
-            errors.append("memory must be the lowest-precedence authority source")
+        if precedence != ["system", "developer", "user", "project_policy", "memory"]:
+            errors.append("authority precedence must be system > developer > user > project_policy > memory")
         if authority_model.get("memory_default") != "non_authoritative_memory":
             errors.append("memory_default must be non_authoritative_memory")
+        declared_sources = authority_model.get("authoritative_sources")
+        if not isinstance(declared_sources, list):
+            errors.append("authoritative_sources must be an array")
+        else:
+            authoritative_sources = set(declared_sources)
+            if not authoritative_sources:
+                errors.append("authoritative_sources cannot be empty")
+            if not authoritative_sources <= DEFAULT_AUTHORITATIVE_SOURCES:
+                errors.append("authoritative_sources contains a source not allowed by RFC-001")
 
     events = envelope.get("operational_tail")
     if not isinstance(events, list) or not events:
         errors.append("operational_tail must contain at least one event")
         events = []
 
-    artifact_rows = envelope.get("artifact_refs")
-    if not isinstance(artifact_rows, list):
-        errors.append("artifact_refs must be an array")
-        artifact_rows = []
-    artifacts = {
-        row.get("artifact_id"): row
-        for row in artifact_rows
-        if isinstance(row, Mapping) and row.get("artifact_id")
-    }
+    artifacts = _artifact_index(envelope.get("artifact_refs"), errors)
+
+    requirements = envelope.get("restore_requirements")
+    required_checks: list[Mapping[str, Any]] = []
+    if not isinstance(requirements, Mapping):
+        errors.append("restore_requirements must be an object")
+    else:
+        if requirements.get("fail_closed") is not True:
+            errors.append("restore gate must fail closed")
+        checks = requirements.get("required_evidence_checks")
+        if not isinstance(checks, list):
+            errors.append("required_evidence_checks must be an array")
+        else:
+            required_checks = [item for item in checks if isinstance(item, Mapping)]
+
+    checks_by_artifact: dict[str, list[Mapping[str, Any]]] = {}
+    seen_check_ids: set[str] = set()
+    for check in required_checks:
+        check_id = check.get("check_id")
+        if not isinstance(check_id, str) or not check_id:
+            errors.append("evidence checks require check_id")
+            continue
+        if check_id in seen_check_ids:
+            errors.append(f"duplicate evidence check id: {check_id}")
+        seen_check_ids.add(check_id)
+
+        artifact_id = check.get("artifact_id")
+        artifact = artifacts.get(artifact_id)
+        if artifact is None:
+            errors.append(f"{check_id}: unknown artifact {artifact_id}")
+            continue
+        checks_by_artifact.setdefault(str(artifact_id), []).append(check)
+
+        method = check.get("method")
+        if method == "digest" and not artifact.get("digest"):
+            errors.append(f"{check_id}: digest check requires artifact digest")
+        if method == "receipt" and not artifact.get("receipt_ref"):
+            errors.append(f"{check_id}: receipt check requires artifact receipt_ref")
 
     active_constraints = 0
     for event in events:
         if not isinstance(event, Mapping):
             errors.append("operational_tail entries must be objects")
             continue
+
+        event_id = event.get("event_id", "<unknown>")
         authority = event.get("authority_class")
-        source_type = (event.get("provenance") or {}).get("source_type")
-        if authority == "constraint":
-            active_constraints += 1
-        if source_type == "memory" and authority in {"instruction", "constraint"}:
-            errors.append(
-                f"{event.get('event_id', '<unknown>')}: memory cannot restore instruction or constraint authority"
-            )
+        provenance = event.get("provenance")
+        source_type = provenance.get("source_type") if isinstance(provenance, Mapping) else None
+
+        if authority in {"instruction", "constraint"}:
+            if source_type not in authoritative_sources:
+                errors.append(
+                    f"{event_id}: {source_type} cannot restore instruction or constraint authority"
+                )
+            elif authority == "constraint":
+                active_constraints += 1
+
         if event.get("event_type") in EXECUTION_EVENT_TYPES:
             refs = event.get("evidence_refs")
             if not isinstance(refs, list) or not refs:
-                errors.append(
-                    f"{event.get('event_id', '<unknown>')}: execution event requires evidence refs"
-                )
+                errors.append(f"{event_id}: execution event requires evidence refs")
                 continue
             for ref in refs:
                 artifact = artifacts.get(ref)
                 if artifact is None:
-                    errors.append(
-                        f"{event.get('event_id', '<unknown>')}: missing artifact ref {ref}"
-                    )
-                elif artifact.get("verification_status") != "verified":
-                    errors.append(
-                        f"{event.get('event_id', '<unknown>')}: artifact {ref} is not verified"
-                    )
+                    errors.append(f"{event_id}: missing artifact ref {ref}")
+                    continue
+                if not artifact.get("digest") and not artifact.get("receipt_ref"):
+                    errors.append(f"{event_id}: artifact {ref} lacks a durable anchor")
+                if not checks_by_artifact.get(str(ref)):
+                    errors.append(f"{event_id}: artifact {ref} has no required evidence check")
 
     if active_constraints == 0:
-        errors.append("at least one active constraint must survive restoration")
+        errors.append("at least one authoritative active constraint must survive restoration")
 
     rejected = envelope.get("rejected_approaches")
     if not isinstance(rejected, list):
@@ -145,18 +250,116 @@ def semantic_errors(envelope: Mapping[str, Any]) -> list[str]:
             if isinstance(item, Mapping) and item.get("status") == "passed":
                 errors.append("pending verification cannot be silently promoted to passed")
 
-    requirements = envelope.get("restore_requirements")
-    if not isinstance(requirements, Mapping) or requirements.get("fail_closed") is not True:
-        errors.append("restore gate must fail closed")
-
     return errors
 
 
-def restore_decision(envelope: Mapping[str, Any]) -> str:
+def _restore_gate_state(
+    envelope: Mapping[str, Any],
+    restore_results: Mapping[str, Any] | None,
+) -> str:
+    if restore_results is None:
+        return "BLOCKED"
+
+    if schema_errors(restore_results, RESTORE_RESULTS_SCHEMA_PATH):
+        return "BLOCKED"
+
+    if restore_results.get("envelope_id") != envelope.get("envelope_id"):
+        return "BLOCKED"
+
+    requirements = envelope.get("restore_requirements")
+    if not isinstance(requirements, Mapping):
+        return "BLOCKED"
+
+    completed_reads = restore_results.get("completed_reads")
+    if not isinstance(completed_reads, list):
+        return "BLOCKED"
+    required_reads = requirements.get("required_reads")
+    if not isinstance(required_reads, list):
+        return "BLOCKED"
+    if not set(required_reads) <= set(completed_reads):
+        return "BLOCKED"
+
+    artifact_errors: list[str] = []
+    artifacts = _artifact_index(envelope.get("artifact_refs"), artifact_errors)
+    if artifact_errors:
+        return "BLOCKED"
+
+    result_rows = restore_results.get("evidence_checks")
+    if not isinstance(result_rows, list):
+        return "BLOCKED"
+    result_by_id: dict[str, Mapping[str, Any]] = {}
+    for result in result_rows:
+        if not isinstance(result, Mapping):
+            return "BLOCKED"
+        check_id = result.get("check_id")
+        if not isinstance(check_id, str) or check_id in result_by_id:
+            return "BLOCKED"
+        result_by_id[check_id] = result
+
+    requirements_rows = requirements.get("required_evidence_checks")
+    if not isinstance(requirements_rows, list):
+        return "BLOCKED"
+
+    has_pending = False
+    for requirement in requirements_rows:
+        if not isinstance(requirement, Mapping):
+            return "BLOCKED"
+        check_id = requirement.get("check_id")
+        result = result_by_id.get(check_id)
+        if result is None:
+            return "BLOCKED"
+
+        if (
+            result.get("artifact_id") != requirement.get("artifact_id")
+            or result.get("method") != requirement.get("method")
+        ):
+            return "BLOCKED"
+
+        status = result.get("status")
+        if status == "pending":
+            has_pending = True
+            continue
+        if status != "passed":
+            return "BLOCKED"
+
+        artifact = artifacts.get(requirement.get("artifact_id"))
+        if artifact is None:
+            return "BLOCKED"
+
+        method = requirement.get("method")
+        if method == "digest":
+            expected = artifact.get("digest")
+            observed = result.get("observed_digest")
+            if not expected or observed != expected:
+                return "BLOCKED"
+        elif method == "receipt":
+            expected = artifact.get("receipt_ref")
+            observed = result.get("receipt_ref")
+            if not expected or observed != expected:
+                return "BLOCKED"
+        elif method == "existence":
+            pass
+        else:
+            return "BLOCKED"
+
+    return "REVIEW_REQUIRED" if has_pending else "PASSED"
+
+
+def restore_decision(
+    envelope: Mapping[str, Any],
+    restore_results: Mapping[str, Any] | None = None,
+) -> str:
+    if schema_errors(envelope, ENVELOPE_SCHEMA_PATH):
+        return "BLOCKED"
     if not verify_digest(envelope):
         return "BLOCKED"
     if semantic_errors(envelope):
         return "BLOCKED"
+
+    gate_state = _restore_gate_state(envelope, restore_results)
+    if gate_state != "PASSED":
+        return gate_state
+
     pending = envelope.get("pending_verification", [])
     if any(
         isinstance(item, Mapping)

--- a/standards/agent-continuity/examples/continuation-envelope.example.json
+++ b/standards/agent-continuity/examples/continuation-envelope.example.json
@@ -8,14 +8,14 @@
     "repository": "https://github.com/safal207/pythiaLabs",
     "workspace": null,
     "branch": "feat/verifiable-continuation-envelope-rfc-v0.1",
-    "head_sha": "d03cd1d26264a9cbc18e720339aa682289cb5f61"
+    "head_sha": null
   },
   "active_objective": {
     "summary": "Publish a vendor-neutral RFC and executable conformance suite for agent continuity.",
     "acceptance_criteria": [
       "The latest user constraint survives restoration.",
-      "Execution claims require durable evidence.",
-      "Memory cannot silently regain authority.",
+      "Execution claims require independently checked durable evidence.",
+      "Memory and retrieved content cannot silently regain authority.",
       "Pending verification remains pending."
     ]
   },
@@ -27,7 +27,11 @@
       "project_policy",
       "memory"
     ],
-    "memory_default": "non_authoritative_memory"
+    "memory_default": "non_authoritative_memory",
+    "authoritative_sources": [
+      "user_message",
+      "project_policy"
+    ]
   },
   "operational_tail": [
     {
@@ -47,7 +51,7 @@
       "event_type": "agent_intent",
       "occurred_at": "2026-06-30T04:21:00Z",
       "authority_class": "information",
-      "payload": "Create RFC-001, a JSON schema, an example envelope, and conformance tests in a draft pull request.",
+      "payload": "Create RFC-001, JSON Schemas, examples, and executable conformance tests.",
       "provenance": {
         "source_type": "agent_message",
         "source_ref": "conversation:current:assistant:plan"
@@ -59,10 +63,10 @@
       "event_type": "artifact_modified",
       "occurred_at": "2026-06-30T04:25:00Z",
       "authority_class": "evidence_ref",
-      "payload": "RFC and schema files were created on the feature branch.",
+      "payload": "RFC and envelope schema files were created on the feature branch.",
       "provenance": {
         "source_type": "git",
-        "source_ref": "commit:d03cd1d26264a9cbc18e720339aa682289cb5f61"
+        "source_ref": "branch:feat/verifiable-continuation-envelope-rfc-v0.1"
       },
       "evidence_refs": [
         "artifact-rfc",
@@ -74,7 +78,7 @@
       "event_type": "verification_started",
       "occurred_at": "2026-06-30T04:29:00Z",
       "authority_class": "information",
-      "payload": "Reference conformance tests are being added but have not yet passed in CI.",
+      "payload": "Reference conformance tests are pending.",
       "provenance": {
         "source_type": "runtime",
         "source_ref": "local:conformance-preparation"
@@ -87,22 +91,22 @@
       "artifact_id": "artifact-rfc",
       "artifact_type": "file",
       "locator": "standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md",
-      "digest": null,
-      "relationship": "created",
-      "verification_status": "verified"
+      "digest": "sha256:c174f9d1a79023a588e9f2f5183690972849db6abdc3c6d3692610e98e1d9d84",
+      "receipt_ref": null,
+      "relationship": "created"
     },
     {
       "artifact_id": "artifact-schema",
       "artifact_type": "file",
       "locator": "standards/agent-continuity/schema/continuation-envelope.schema.json",
-      "digest": null,
-      "relationship": "created",
-      "verification_status": "verified"
+      "digest": "sha256:dc2df1cccb9b6826d424e82ad0316568c87a20dff75fa4f4def9bad3c3f4a970",
+      "receipt_ref": null,
+      "relationship": "created"
     }
   ],
   "rejected_approaches": [
     {
-      "approach": "Publish separate, vendor-specific proposals before defining common observable behavior.",
+      "approach": "Publish separate vendor-specific proposals before defining common observable behavior.",
       "reason": "That would duplicate the design and weaken interoperability.",
       "status": "rejected",
       "reopen_authority": "user"
@@ -118,7 +122,7 @@
     }
   ],
   "next_action": {
-    "description": "Add and run the reference conformance tests, then open a draft pull request.",
+    "description": "Run the reference conformance tests and review their evidence.",
     "requires_restore": true,
     "blocked_by": [
       "verify-tests"
@@ -130,14 +134,22 @@
       "standards/agent-continuity/examples/continuation-envelope.example.json"
     ],
     "required_evidence_checks": [
-      "Confirm the feature branch and referenced files exist.",
-      "Run the reference conformance suite."
+      {
+        "check_id": "check-rfc-digest",
+        "artifact_id": "artifact-rfc",
+        "method": "digest"
+      },
+      {
+        "check_id": "check-schema-digest",
+        "artifact_id": "artifact-schema",
+        "method": "digest"
+      }
     ],
     "fail_closed": true
   },
   "envelope_digest": {
     "algorithm": "sha256",
     "canonicalization": "json-sort-keys-utf8-v1",
-    "value": "50bba0c03dbfb1ab12f44c8d7a26890b7396d1586da907bd62ce7dd8a9bc05c6"
+    "value": "2dc8febba202933daeb6e97309033bc87c8b280761e029846ce6a16889737790"
   }
 }

--- a/standards/agent-continuity/examples/continuation-envelope.example.json
+++ b/standards/agent-continuity/examples/continuation-envelope.example.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": "0.1",
+  "envelope_id": "vce-example-001",
+  "created_at": "2026-06-30T04:30:00Z",
+  "transition_reason": "context_compaction",
+  "project": {
+    "project_id": "safal207/pythiaLabs",
+    "repository": "https://github.com/safal207/pythiaLabs",
+    "workspace": null,
+    "branch": "feat/verifiable-continuation-envelope-rfc-v0.1",
+    "head_sha": "d03cd1d26264a9cbc18e720339aa682289cb5f61"
+  },
+  "active_objective": {
+    "summary": "Publish a vendor-neutral RFC and executable conformance suite for agent continuity.",
+    "acceptance_criteria": [
+      "The latest user constraint survives restoration.",
+      "Execution claims require durable evidence.",
+      "Memory cannot silently regain authority.",
+      "Pending verification remains pending."
+    ]
+  },
+  "authority_model": {
+    "precedence": [
+      "system",
+      "developer",
+      "user",
+      "project_policy",
+      "memory"
+    ],
+    "memory_default": "non_authoritative_memory"
+  },
+  "operational_tail": [
+    {
+      "event_id": "evt-001",
+      "event_type": "user_instruction",
+      "occurred_at": "2026-06-30T04:20:00Z",
+      "authority_class": "constraint",
+      "payload": "Start with one implementable RFC before expanding into a broader standard.",
+      "provenance": {
+        "source_type": "user_message",
+        "source_ref": "conversation:current:user:lead-me"
+      },
+      "evidence_refs": []
+    },
+    {
+      "event_id": "evt-002",
+      "event_type": "agent_intent",
+      "occurred_at": "2026-06-30T04:21:00Z",
+      "authority_class": "information",
+      "payload": "Create RFC-001, a JSON schema, an example envelope, and conformance tests in a draft pull request.",
+      "provenance": {
+        "source_type": "agent_message",
+        "source_ref": "conversation:current:assistant:plan"
+      },
+      "evidence_refs": []
+    },
+    {
+      "event_id": "evt-003",
+      "event_type": "artifact_modified",
+      "occurred_at": "2026-06-30T04:25:00Z",
+      "authority_class": "evidence_ref",
+      "payload": "RFC and schema files were created on the feature branch.",
+      "provenance": {
+        "source_type": "git",
+        "source_ref": "commit:d03cd1d26264a9cbc18e720339aa682289cb5f61"
+      },
+      "evidence_refs": [
+        "artifact-rfc",
+        "artifact-schema"
+      ]
+    },
+    {
+      "event_id": "evt-004",
+      "event_type": "verification_started",
+      "occurred_at": "2026-06-30T04:29:00Z",
+      "authority_class": "information",
+      "payload": "Reference conformance tests are being added but have not yet passed in CI.",
+      "provenance": {
+        "source_type": "runtime",
+        "source_ref": "local:conformance-preparation"
+      },
+      "evidence_refs": []
+    }
+  ],
+  "artifact_refs": [
+    {
+      "artifact_id": "artifact-rfc",
+      "artifact_type": "file",
+      "locator": "standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md",
+      "digest": null,
+      "relationship": "created",
+      "verification_status": "verified"
+    },
+    {
+      "artifact_id": "artifact-schema",
+      "artifact_type": "file",
+      "locator": "standards/agent-continuity/schema/continuation-envelope.schema.json",
+      "digest": null,
+      "relationship": "created",
+      "verification_status": "verified"
+    }
+  ],
+  "rejected_approaches": [
+    {
+      "approach": "Publish separate, vendor-specific proposals before defining common observable behavior.",
+      "reason": "That would duplicate the design and weaken interoperability.",
+      "status": "rejected",
+      "reopen_authority": "user"
+    }
+  ],
+  "pending_verification": [
+    {
+      "verification_id": "verify-tests",
+      "target": "Reference conformance suite",
+      "command_or_method": "python -m unittest discover -s standards/agent-continuity/conformance -p 'test_*.py' -v",
+      "status": "pending",
+      "evidence_refs": []
+    }
+  ],
+  "next_action": {
+    "description": "Add and run the reference conformance tests, then open a draft pull request.",
+    "requires_restore": true,
+    "blocked_by": [
+      "verify-tests"
+    ]
+  },
+  "restore_requirements": {
+    "required_reads": [
+      "standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md",
+      "standards/agent-continuity/examples/continuation-envelope.example.json"
+    ],
+    "required_evidence_checks": [
+      "Confirm the feature branch and referenced files exist.",
+      "Run the reference conformance suite."
+    ],
+    "fail_closed": true
+  },
+  "envelope_digest": {
+    "algorithm": "sha256",
+    "canonicalization": "json-sort-keys-utf8-v1",
+    "value": "50bba0c03dbfb1ab12f44c8d7a26890b7396d1586da907bd62ce7dd8a9bc05c6"
+  }
+}

--- a/standards/agent-continuity/examples/restore-results.example.json
+++ b/standards/agent-continuity/examples/restore-results.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1",
+  "envelope_id": "vce-example-001",
+  "completed_reads": [
+    "standards/agent-continuity/RFC-001-VERIFIABLE-CONTINUATION-ENVELOPE.md",
+    "standards/agent-continuity/examples/continuation-envelope.example.json"
+  ],
+  "evidence_checks": [
+    {
+      "check_id": "check-rfc-digest",
+      "artifact_id": "artifact-rfc",
+      "method": "digest",
+      "status": "passed",
+      "observed_digest": "sha256:c174f9d1a79023a588e9f2f5183690972849db6abdc3c6d3692610e98e1d9d84",
+      "receipt_ref": null
+    },
+    {
+      "check_id": "check-schema-digest",
+      "artifact_id": "artifact-schema",
+      "method": "digest",
+      "status": "passed",
+      "observed_digest": "sha256:dc2df1cccb9b6826d424e82ad0316568c87a20dff75fa4f4def9bad3c3f4a970",
+      "receipt_ref": null
+    }
+  ]
+}

--- a/standards/agent-continuity/schema/continuation-envelope.schema.json
+++ b/standards/agent-continuity/schema/continuation-envelope.schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/safal207/pythiaLabs/standards/agent-continuity/schema/continuation-envelope.schema.json",
+  "title": "Verifiable Continuation Envelope",
+  "description": "A bounded, vendor-neutral continuation envelope for coding-agent compaction, restart, and handoff.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "envelope_id",
+    "created_at",
+    "transition_reason",
+    "project",
+    "active_objective",
+    "authority_model",
+    "operational_tail",
+    "artifact_refs",
+    "rejected_approaches",
+    "pending_verification",
+    "next_action",
+    "restore_requirements",
+    "envelope_digest"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1"
+    },
+    "envelope_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "transition_reason": {
+      "enum": [
+        "context_compaction",
+        "session_restart",
+        "cross_session_handoff",
+        "phase_transition",
+        "manual_checkpoint"
+      ]
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project_id"],
+      "properties": {
+        "project_id": {"type": "string", "minLength": 1},
+        "repository": {"type": ["string", "null"]},
+        "workspace": {"type": ["string", "null"]},
+        "branch": {"type": ["string", "null"]},
+        "head_sha": {"type": ["string", "null"], "pattern": "^[0-9a-fA-F]{7,64}$"}
+      }
+    },
+    "active_objective": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "acceptance_criteria"],
+      "properties": {
+        "summary": {"type": "string", "minLength": 1},
+        "acceptance_criteria": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        }
+      }
+    },
+    "authority_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["precedence", "memory_default"],
+      "properties": {
+        "precedence": {
+          "type": "array",
+          "items": {
+            "enum": ["system", "developer", "user", "project_policy", "memory"]
+          },
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true
+        },
+        "memory_default": {
+          "const": "non_authoritative_memory"
+        }
+      }
+    },
+    "operational_tail": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {"$ref": "#/$defs/operationalEvent"}
+    },
+    "artifact_refs": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {"$ref": "#/$defs/artifactRef"}
+    },
+    "rejected_approaches": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["approach", "reason", "status"],
+        "properties": {
+          "approach": {"type": "string", "minLength": 1},
+          "reason": {"type": "string", "minLength": 1},
+          "status": {"const": "rejected"},
+          "reopen_authority": {
+            "enum": ["user", "developer", "project_policy"]
+          }
+        }
+      }
+    },
+    "pending_verification": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["verification_id", "target", "status"],
+        "properties": {
+          "verification_id": {"type": "string", "minLength": 1},
+          "target": {"type": "string", "minLength": 1},
+          "command_or_method": {"type": ["string", "null"]},
+          "status": {"enum": ["pending", "running", "blocked", "failed"]},
+          "evidence_refs": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        }
+      }
+    },
+    "next_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "requires_restore"],
+      "properties": {
+        "description": {"type": "string", "minLength": 1},
+        "requires_restore": {"type": "boolean"},
+        "blocked_by": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "restore_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_reads", "required_evidence_checks", "fail_closed"],
+      "properties": {
+        "required_reads": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "required_evidence_checks": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "fail_closed": {"const": true}
+      }
+    },
+    "envelope_digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "value"],
+      "properties": {
+        "algorithm": {"const": "sha256"},
+        "canonicalization": {"const": "json-sort-keys-utf8-v1"},
+        "value": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  },
+  "$defs": {
+    "authorityClass": {
+      "enum": [
+        "information",
+        "instruction",
+        "constraint",
+        "evidence_ref",
+        "non_authoritative_memory",
+        "quarantined"
+      ]
+    },
+    "operationalEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "event_type",
+        "occurred_at",
+        "authority_class",
+        "payload",
+        "provenance",
+        "evidence_refs"
+      ],
+      "properties": {
+        "event_id": {"type": "string", "minLength": 1},
+        "event_type": {
+          "enum": [
+            "user_instruction",
+            "agent_intent",
+            "tool_call",
+            "tool_result",
+            "artifact_observed",
+            "artifact_modified",
+            "decision",
+            "approach_rejected",
+            "verification_started",
+            "verification_result",
+            "blocker"
+          ]
+        },
+        "occurred_at": {"type": "string", "format": "date-time"},
+        "authority_class": {"$ref": "#/$defs/authorityClass"},
+        "payload": {"type": "string", "minLength": 1},
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_type", "source_ref"],
+          "properties": {
+            "source_type": {
+              "enum": ["user_message", "agent_message", "tool", "file", "git", "workflow", "runtime", "memory"]
+            },
+            "source_ref": {"type": "string", "minLength": 1}
+          }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_id", "artifact_type", "locator", "relationship", "verification_status"],
+      "properties": {
+        "artifact_id": {"type": "string", "minLength": 1},
+        "artifact_type": {
+          "enum": ["file", "commit", "diff", "tool_log", "test_run", "workflow_run", "runtime_receipt", "other"]
+        },
+        "locator": {"type": "string", "minLength": 1},
+        "digest": {"type": ["string", "null"]},
+        "relationship": {"enum": ["observed", "modified", "created", "deleted", "verification_target"]},
+        "verification_status": {"enum": ["unverified", "verified", "mismatched", "missing"]}
+      }
+    }
+  }
+}

--- a/standards/agent-continuity/schema/continuation-envelope.schema.json
+++ b/standards/agent-continuity/schema/continuation-envelope.schema.json
@@ -45,24 +45,59 @@
     "project": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["project_id"],
+      "required": [
+        "project_id"
+      ],
       "properties": {
-        "project_id": {"type": "string", "minLength": 1},
-        "repository": {"type": ["string", "null"]},
-        "workspace": {"type": ["string", "null"]},
-        "branch": {"type": ["string", "null"]},
-        "head_sha": {"type": ["string", "null"], "pattern": "^[0-9a-fA-F]{7,64}$"}
+        "project_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "workspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "head_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-fA-F]{40}$"
+        }
       }
     },
     "active_objective": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["summary", "acceptance_criteria"],
+      "required": [
+        "summary",
+        "acceptance_criteria"
+      ],
       "properties": {
-        "summary": {"type": "string", "minLength": 1},
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
         "acceptance_criteria": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1},
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
           "minItems": 1
         }
       }
@@ -70,19 +105,48 @@
     "authority_model": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["precedence", "memory_default"],
+      "required": [
+        "precedence",
+        "memory_default",
+        "authoritative_sources"
+      ],
       "properties": {
         "precedence": {
           "type": "array",
-          "items": {
-            "enum": ["system", "developer", "user", "project_policy", "memory"]
-          },
+          "prefixItems": [
+            {
+              "const": "system"
+            },
+            {
+              "const": "developer"
+            },
+            {
+              "const": "user"
+            },
+            {
+              "const": "project_policy"
+            },
+            {
+              "const": "memory"
+            }
+          ],
+          "items": false,
           "minItems": 5,
-          "maxItems": 5,
-          "uniqueItems": true
+          "maxItems": 5
         },
         "memory_default": {
           "const": "non_authoritative_memory"
+        },
+        "authoritative_sources": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "user_message",
+              "project_policy"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
       }
     },
@@ -90,12 +154,16 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 50,
-      "items": {"$ref": "#/$defs/operationalEvent"}
+      "items": {
+        "$ref": "#/$defs/operationalEvent"
+      }
     },
     "artifact_refs": {
       "type": "array",
       "maxItems": 100,
-      "items": {"$ref": "#/$defs/artifactRef"}
+      "items": {
+        "$ref": "#/$defs/artifactRef"
+      }
     },
     "rejected_approaches": {
       "type": "array",
@@ -103,13 +171,29 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["approach", "reason", "status"],
+        "required": [
+          "approach",
+          "reason",
+          "status"
+        ],
         "properties": {
-          "approach": {"type": "string", "minLength": 1},
-          "reason": {"type": "string", "minLength": 1},
-          "status": {"const": "rejected"},
+          "approach": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "const": "rejected"
+          },
           "reopen_authority": {
-            "enum": ["user", "developer", "project_policy"]
+            "enum": [
+              "user",
+              "developer",
+              "project_policy"
+            ]
           }
         }
       }
@@ -120,15 +204,41 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["verification_id", "target", "status"],
+        "required": [
+          "verification_id",
+          "target",
+          "status"
+        ],
         "properties": {
-          "verification_id": {"type": "string", "minLength": 1},
-          "target": {"type": "string", "minLength": 1},
-          "command_or_method": {"type": ["string", "null"]},
-          "status": {"enum": ["pending", "running", "blocked", "failed"]},
+          "verification_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1
+          },
+          "command_or_method": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "running",
+              "blocked",
+              "failed"
+            ]
+          },
           "evidence_refs": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "uniqueItems": true
           }
         }
       }
@@ -136,40 +246,76 @@
     "next_action": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["description", "requires_restore"],
+      "required": [
+        "description",
+        "requires_restore"
+      ],
       "properties": {
-        "description": {"type": "string", "minLength": 1},
-        "requires_restore": {"type": "boolean"},
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requires_restore": {
+          "type": "boolean"
+        },
         "blocked_by": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
         }
       }
     },
     "restore_requirements": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["required_reads", "required_evidence_checks", "fail_closed"],
+      "required": [
+        "required_reads",
+        "required_evidence_checks",
+        "fail_closed"
+      ],
       "properties": {
         "required_reads": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
         },
         "required_evidence_checks": {
           "type": "array",
-          "items": {"type": "string", "minLength": 1}
+          "items": {
+            "$ref": "#/$defs/evidenceCheckRequirement"
+          },
+          "uniqueItems": true
         },
-        "fail_closed": {"const": true}
+        "fail_closed": {
+          "const": true
+        }
       }
     },
     "envelope_digest": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["algorithm", "canonicalization", "value"],
+      "required": [
+        "algorithm",
+        "canonicalization",
+        "value"
+      ],
       "properties": {
-        "algorithm": {"const": "sha256"},
-        "canonicalization": {"const": "json-sort-keys-utf8-v1"},
-        "value": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        "algorithm": {
+          "const": "sha256"
+        },
+        "canonicalization": {
+          "const": "json-sort-keys-utf8-v1"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
       }
     }
   },
@@ -182,6 +328,19 @@
         "evidence_ref",
         "non_authoritative_memory",
         "quarantined"
+      ]
+    },
+    "sourceType": {
+      "enum": [
+        "user_message",
+        "project_policy",
+        "agent_message",
+        "tool",
+        "file",
+        "git",
+        "workflow",
+        "runtime",
+        "memory"
       ]
     },
     "operationalEvent": {
@@ -197,7 +356,10 @@
         "evidence_refs"
       ],
       "properties": {
-        "event_id": {"type": "string", "minLength": 1},
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
         "event_type": {
           "enum": [
             "user_instruction",
@@ -213,39 +375,147 @@
             "blocker"
           ]
         },
-        "occurred_at": {"type": "string", "format": "date-time"},
-        "authority_class": {"$ref": "#/$defs/authorityClass"},
-        "payload": {"type": "string", "minLength": 1},
+        "occurred_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "authority_class": {
+          "$ref": "#/$defs/authorityClass"
+        },
+        "payload": {
+          "type": "string",
+          "minLength": 1
+        },
         "provenance": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["source_type", "source_ref"],
+          "required": [
+            "source_type",
+            "source_ref"
+          ],
           "properties": {
             "source_type": {
-              "enum": ["user_message", "agent_message", "tool", "file", "git", "workflow", "runtime", "memory"]
+              "$ref": "#/$defs/sourceType"
             },
-            "source_ref": {"type": "string", "minLength": 1}
+            "source_ref": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "evidence_refs": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
         }
       }
     },
     "artifactRef": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["artifact_id", "artifact_type", "locator", "relationship", "verification_status"],
+      "required": [
+        "artifact_id",
+        "artifact_type",
+        "locator",
+        "digest",
+        "receipt_ref",
+        "relationship"
+      ],
       "properties": {
-        "artifact_id": {"type": "string", "minLength": 1},
-        "artifact_type": {
-          "enum": ["file", "commit", "diff", "tool_log", "test_run", "workflow_run", "runtime_receipt", "other"]
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
         },
-        "locator": {"type": "string", "minLength": 1},
-        "digest": {"type": ["string", "null"]},
-        "relationship": {"enum": ["observed", "modified", "created", "deleted", "verification_target"]},
-        "verification_status": {"enum": ["unverified", "verified", "mismatched", "missing"]}
+        "artifact_type": {
+          "enum": [
+            "file",
+            "commit",
+            "diff",
+            "tool_log",
+            "test_run",
+            "workflow_run",
+            "runtime_receipt",
+            "other"
+          ]
+        },
+        "locator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "digest": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "receipt_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "relationship": {
+          "enum": [
+            "observed",
+            "modified",
+            "created",
+            "deleted",
+            "verification_target"
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "digest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "digest"
+          ]
+        },
+        {
+          "properties": {
+            "receipt_ref": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "receipt_ref"
+          ]
+        }
+      ]
+    },
+    "evidenceCheckRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "check_id",
+        "artifact_id",
+        "method"
+      ],
+      "properties": {
+        "check_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "method": {
+          "enum": [
+            "digest",
+            "receipt",
+            "existence"
+          ]
+        }
       }
     }
   }

--- a/standards/agent-continuity/schema/restore-results.schema.json
+++ b/standards/agent-continuity/schema/restore-results.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/safal207/pythiaLabs/standards/agent-continuity/schema/restore-results.schema.json",
+  "title": "VCE Restore Results",
+  "description": "Runtime observations proving whether declared restore requirements were satisfied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "envelope_id",
+    "completed_reads",
+    "evidence_checks"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0.1"
+    },
+    "envelope_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "completed_reads": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "evidence_checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evidenceCheckResult"
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "evidenceCheckResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "check_id",
+        "artifact_id",
+        "method",
+        "status",
+        "observed_digest",
+        "receipt_ref"
+      ],
+      "properties": {
+        "check_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "method": {
+          "enum": [
+            "digest",
+            "receipt",
+            "existence"
+          ]
+        },
+        "status": {
+          "enum": [
+            "passed",
+            "pending",
+            "failed"
+          ]
+        },
+        "observed_digest": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "receipt_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a vendor-neutral specification for preserving coding-agent continuity across context compaction, session restart, and cross-session handoff.

## Included

- RFC-001: Verifiable Continuation Envelope
- JSON Schema draft 2020-12 for the envelope
- separate JSON Schema for runtime restore results
- example envelope and restore-results fixture
- canonical SHA-256 digest contract
- reference validator with schema enforcement
- 17 executable conformance tests
- GitHub Actions workflow with pinned schema validation dependency

## Core guarantees

- latest active user constraints survive restoration;
- only explicitly trusted sources may restore instruction or constraint authority;
- execution claims require independently checked digest or receipt evidence;
- existence-only checks cannot authorize execution claims;
- declared required reads and evidence checks are enforced before resume;
- unresolved `next_action.blocked_by` entries retain `REVIEW_REQUIRED`;
- rejected approaches remain rejected;
- pending verification remains pending;
- schema drift, tampering, missing evidence, digest mismatches, and incomplete restore state fail closed;
- a verified envelope becomes resumable only after all restore requirements and blockers are cleared.

## Review fixes incorporated

- added an explicit `restore_results` model instead of inferring completion from declarations;
- integrated the published JSON Schemas into the conformance path;
- replaced self-declared `verified` evidence with independent digest/receipt checks;
- added an authority-source allowlist;
- prohibited existence-only verification for execution artifacts;
- enforced `next_action.blocked_by` before `RESUMABLE`;
- fully specified `json-sort-keys-utf8-v1` canonicalization;
- detached the example from a moving PR commit SHA;
- disabled checkout credential persistence in CI.

## Governing principle

> Preserve continuity without inventing history, and restore information without silently restoring authority.

## Validation

```text
Ran 17 tests
OK
```

## Next step after review

Use this RFC as the common implementation package linked from active Codex and Claude Code discussions, then collect vendor-specific feedback without forking the core invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Agent Continuity & Authority” documentation, including the verifiable continuation envelope RFC and example envelopes/restore results.
  * Introduced JSON Schemas for continuation envelopes and VCE restore results.
  * Added a conformance workflow and test suite to validate schema compliance, digest integrity, and restore decision behavior.

* **Bug Fixes**
  * Strengthened restore gating to fail closed on invalid, incomplete, or tampered data.
  * Improved state handling to correctly produce blocked, review-required, and resumable outcomes based on evidence, digests, and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->