### PR TITLE
docs: record agent protocol market signal and verification ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,13 @@ the most important docs whether you are a new contributor, reviewer, or grantmak
 
 ---
 
+## Market Signals and Architecture Decisions
+
+- [Vint Cerf: Formal Protocols for AI Agents](market_signals/VINT_CERF_AGENT_PROTOCOLS.md) — records the reported industry signal, its verification status, relevance to PythiaLabs, product implications, and explicit non-endorsement boundary.
+- [ADR-001: Critical Agent Interactions Must Be Machine-Verifiable](adr/ADR-001-machine-verifiable-agent-interactions.md) — proposes a versioned action contract, deterministic decision flow, conformance target, trade-offs, and non-goals.
+
+---
+
 ## Demos and Expected Outputs
 
 - [Paid Review Demo Reviewer Checklist](paid_review_demo_reviewer_checklist.md) — concise review steps for running `make demo`, checking expected decisions, verifying evidence, and inspecting the artifact bundle.

--- a/docs/adr/ADR-001-machine-verifiable-agent-interactions.md
+++ b/docs/adr/ADR-001-machine-verifiable-agent-interactions.md
@@ -1,0 +1,106 @@
+# ADR-001: Critical Agent Interactions Must Be Machine-Verifiable
+
+- **Status:** Proposed
+- **Date:** 2026-07-01
+- **Decision owners:** PythiaLabs maintainers
+- **Related market signal:** [`../market_signals/VINT_CERF_AGENT_PROTOCOLS.md`](../market_signals/VINT_CERF_AGENT_PROTOCOLS.md)
+
+## Context
+
+AI agents increasingly propose or perform actions with external side effects: infrastructure changes, financial operations, governance decisions, code modifications, messages, and tool calls.
+
+Natural-language instructions and model-generated explanations are not reliable execution contracts. They can be ambiguous, incomplete, stale, or inconsistent across agents and frameworks. A reviewer also cannot safely infer authorization, evidence freshness, or recovery readiness from prose alone.
+
+PythiaLabs therefore needs a stable architectural rule that applies across its action gates, demos, protocol experiments, and framework adapters.
+
+## Decision
+
+Every critical agent interaction evaluated by PythiaLabs must be representable as a versioned, machine-verifiable action contract.
+
+At minimum, the contract should be able to express:
+
+- protocol or schema version;
+- action identifier;
+- actor and agent identity;
+- requested capability and operation;
+- target resource and environment;
+- authorization or delegation context;
+- required preconditions;
+- evidence references, provenance, and freshness;
+- expected state transition;
+- idempotency or replay-protection data;
+- recovery or rollback declaration;
+- deterministic decision outcome;
+- stable stop reasons;
+- generated audit-artifact references.
+
+Free-form natural language may accompany the contract, but it must not replace the fields required to make the critical decision.
+
+## Decision flow
+
+```text
+Proposed action
+    -> schema validation
+    -> identity and capability checks
+    -> authorization checks
+    -> precondition and environment checks
+    -> evidence validation
+    -> recovery-context checks
+    -> ALLOW / BLOCK / ESCALATE
+    -> replayable audit artifact
+```
+
+## Consequences
+
+### Positive
+
+- Decisions can be reproduced without trusting an agent's narrative.
+- Different framework adapters can converge on one semantic contract.
+- Stop reasons remain stable enough for testing and audit.
+- Stale, missing, or mismatched evidence can fail closed.
+- Idempotency and replay protection can become explicit rather than implicit.
+- Reviewers can inspect artifacts independently of terminal output.
+
+### Costs and trade-offs
+
+- Schema evolution and compatibility rules must be maintained.
+- Integrations need translation layers from framework-native tool calls.
+- Some actions will require domain-specific extensions.
+- Strict validation may reject underspecified actions that a human would understand.
+- A machine-verifiable contract does not by itself provide production security, trustworthy identity, regulatory compliance, or correct policy design.
+
+## Initial conformance target
+
+A first conformance suite should verify that:
+
+1. unknown schema versions are rejected;
+2. required identity and action fields are present;
+3. malformed authorization context is rejected;
+4. evidence is bound to the intended action;
+5. stale evidence is rejected where freshness is required;
+6. duplicate action identifiers are detected where replay protection applies;
+7. unreachable or undeclared state transitions are rejected;
+8. `ALLOW`, `BLOCK`, and `ESCALATE` produce stable reason codes;
+9. the emitted artifact can be independently verified;
+10. adapters do not silently discard required fields.
+
+## Non-goals
+
+This ADR does not claim that PythiaLabs currently provides:
+
+- a universal inter-agent standard;
+- production-grade identity or cryptography;
+- cloud, wallet, or banking enforcement;
+- regulatory certification;
+- safe autonomous execution without human governance;
+- compatibility with every agent framework.
+
+## Follow-up work
+
+- Define a minimal `ActionEnvelopeV1` schema.
+- Define stable decision and stop-reason registries.
+- Add conformance fixtures for valid, invalid, stale, replayed, and mismatched actions.
+- Map the current showcases to the envelope fields.
+- Document extension points for domain-specific evidence.
+- Add one framework adapter that preserves the full contract.
+- Keep public claims aligned with [`../NON_CLAIMS.md`](../NON_CLAIMS.md).

--- a/docs/market_signals/VINT_CERF_AGENT_PROTOCOLS.md
+++ b/docs/market_signals/VINT_CERF_AGENT_PROTOCOLS.md
@@ -1,0 +1,92 @@
+# Market Signal: Formal Protocols for AI Agents
+
+**Recorded:** 2026-07-01  
+**Status:** External market signal, not an endorsement of PythiaLabs  
+**Verification status:** The retirement and conference remarks are based on secondary reporting. At the time this note was recorded, no official Google announcement was located. Treat the employment detail as reported rather than primary-source-confirmed.
+
+## Signal
+
+Secondary reporting attributed two related points to Vint Cerf, a co-designer of TCP/IP and Google's long-time Chief Internet Evangelist:
+
+1. he was expected to leave Google after roughly two decades at the company; and
+2. the growth of autonomous AI agents would push the technology industry back toward formal, standardized protocols for machine-to-machine interaction.
+
+The second point is the strategically relevant signal for PythiaLabs.
+
+## Why it matters
+
+Natural-language instructions are useful for expressing intent, but they are not a sufficient safety boundary for high-risk autonomous actions. Cross-agent execution needs machine-checkable semantics for at least:
+
+- actor and agent identity;
+- declared capability and requested action;
+- authorization and delegation scope;
+- preconditions and environment constraints;
+- evidence freshness and provenance;
+- deterministic decision outcomes;
+- retries, idempotency, and replay protection;
+- failure handling, escalation, and recovery;
+- reviewer-facing audit artifacts.
+
+Without those properties, two agents may appear to agree while still disagreeing about authority, timing, scope, evidence, or the meaning of completion.
+
+## Relevance to PythiaLabs
+
+PythiaLabs is already exploring a compatible layer: deterministic evidence gates for high-risk agentic actions before tools are called.
+
+The current project direction maps to the reported protocol need as follows:
+
+| Protocol concern | PythiaLabs direction |
+|---|---|
+| Proposed machine action | Structured action input and strict shape validation |
+| Authorization | Decision-time permission and temporal authorization checks |
+| Preconditions | Deterministic gate-specific safety checks |
+| Evidence | Replayable traces, evidence records, digests, and verification |
+| Outcome | Stable `ALLOW`, `BLOCK`, or `ESCALATE` decisions |
+| Failure semantics | Stable stop reasons rather than free-form explanations |
+| Auditability | Reviewer-facing artifacts and reproducible local demos |
+| Recovery context | Explicit recovery and rollback context in action evaluation |
+
+This does **not** mean that Vint Cerf endorsed PythiaLabs, that PythiaLabs is an internet standard, or that the current MVP implements a production inter-agent protocol.
+
+## Strategic interpretation
+
+The opportunity is not only to build more capable agents. It is also to build the verification and trust layer through which agents can safely propose, authorize, execute, review, and recover actions across organizational and technical boundaries.
+
+A concise positioning statement is:
+
+> Vint Cerf reportedly identified the need for formal protocols between AI agents. PythiaLabs explores the deterministic verification and evidence-gate layer that such protocols would require for high-risk actions.
+
+## Product implications
+
+This signal supports prioritizing a small, testable protocol surface rather than a broad claim of becoming "TCP/IP for agents."
+
+Near-term protocol artifacts should include:
+
+1. a versioned action envelope;
+2. explicit identity and capability fields;
+3. authorization and delegation semantics;
+4. evidence references with freshness and provenance;
+5. deterministic decision and stop-reason codes;
+6. idempotency and replay-protection fields;
+7. recovery and rollback declarations;
+8. a conformance test suite;
+9. framework adapters that preserve the same semantics;
+10. clear non-claims around production security, compliance, and standardization.
+
+## Evidence threshold for future updates
+
+Promote this note from an external market signal to a confirmed industry statement only when at least one primary source is available, such as:
+
+- a recording or transcript of the Open Frontier remarks;
+- a publication or post from Vint Cerf;
+- an official Google statement;
+- conference material containing the attributed comments.
+
+Until then, preserve the caveat above in public-facing use.
+
+## References
+
+- TechCrunch, *The father of the internet is finally retiring*, 2026-06-30: https://techcrunch.com/2026/06/30/the-father-of-the-internet-is-finally-retiring/
+- PythiaLabs project positioning and scope: [`../../README.md`](../../README.md)
+- PythiaLabs non-claims: [`../NON_CLAIMS.md`](../NON_CLAIMS.md)
+- Design principles: [`../design_principles.md`](../design_principles.md)


### PR DESCRIPTION
## Summary

Records the reported Vint Cerf agent-protocol signal and converts it into a bounded PythiaLabs architecture decision.

## Changes

- adds `docs/market_signals/VINT_CERF_AGENT_PROTOCOLS.md`;
- records source-verification status and the non-endorsement boundary;
- maps the signal to PythiaLabs' existing evidence-gate direction;
- adds `ADR-001` requiring critical agent interactions to be representable as versioned, machine-verifiable contracts;
- defines initial conformance targets, trade-offs, non-goals, and follow-up work;
- indexes both documents in `docs/README.md`.

## Guardrails

This PR deliberately does **not** claim that:

- Vint Cerf endorsed PythiaLabs;
- the retirement report is primary-source-confirmed;
- PythiaLabs is an internet standard;
- the current MVP is a production enforcement, security, or compliance system;
- the project is already a universal protocol for agents.

## Verification

Docs-only comparison against `main`:

- 3 commits ahead;
- 3 changed files;
- 205 additions, 0 deletions;
- no runtime code changed.

## Follow-up

Tracks implementation roadmap in #211.

Closes no issue: ADR status remains **Proposed** until reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new market-signal article covering attributed comments on formal protocols for AI agents, with links, references, and guidance on how to interpret the signal.
  - Expanded the documentation index with a new “Market Signals and Architecture Decisions” section.
  - Added a new architecture decision record describing a machine-verifiable contract for critical agent interactions, including clearer decision flow, auditability, and validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->